### PR TITLE
Write informative one-line warning instead of traceback #44

### DIFF
--- a/app/oracle.py
+++ b/app/oracle.py
@@ -213,13 +213,17 @@ while True:
                 logging.info(f'Tx data: {tx.__repr__()}')
                 if prompt('Should we sent this TX? [y/n]: ', ''):
                     sign_and_send_tx(tx)
-        except:
-            logging.error('Unexpected exception. ')
-            traceback.print_exc()
-            if run_as_daemon:
-                logging.info(f'Sleep {await_time_in_sec} s.')
-                time.sleep(await_time_in_sec)
-                continue
+        except Exception as exc:
+            if isinstance(exc, ValueError) and 'execution reverted: EPOCH_IS_TOO_OLD' in str(exc):
+                # e.g. {
+                #   'code': 3,
+                #   'message':
+                #   'execution reverted: EPOCH_IS_TOO_OLD',
+                #   'data': '0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001045504f43485f49535f544f4f5f4f4c4400000000000000000000000000000000'
+                # }
+                logging.warning(f'execution reverted: EPOCH_IS_TOO_OLD')
+            else:
+                logging.exception(f'Unexpected exception. {type(exc)}')
     else:
         logging.info('The tx hasn\'t been actually sent to the oracle contract! We are in DRY RUN mode')
         logging.info('Provide MEMBER_PRIV_KEY to be able to transact')


### PR DESCRIPTION
Write informative one-line warning instead of traceback.
Increase SLEEP in production to 3600sec.