### PR TITLE
Use from_key instead of privateKeyToAccount #67

### DIFF
--- a/app/oracle.py
+++ b/app/oracle.py
@@ -72,7 +72,7 @@ if dry_run:
     logging.info('MEMBER_PRIV_KEY not provided, running in read-only (DRY RUN) mode')
 else:
     logging.info('MEMBER_PRIV_KEY provided, running in transactable (PRODUCTION) mode')
-    account = w3.eth.account.privateKeyToAccount(member_privkey)
+    account = w3.eth.account.from_key(member_privkey)
     logging.info(f'Member account: {account.address}')
 
 # Get Pool contract


### PR DESCRIPTION
Switch privateKeyToAccount method to from_key https://github.com/lidofinance/lido-oracle/issues/67
Mute curl connect failure messages in tests https://github.com/lidofinance/lido-oracle/issues/68