### PR TITLE
Allow bumper to fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,7 @@ WORKDIR /app
 COPY requirements.txt ./
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
 
-COPY assets ./assets
-COPY app ./
-
-ENTRYPOINT ["python3", "-u", "oracle.py"]
-
 # Set metadata
-
 ARG VERSION
 ARG COMMIT_DATETIME
 ARG BUILD_DATETIME
@@ -32,4 +26,16 @@ LABEL TAGS="$TAGS"
 LABEL BRANCH="$BRANCH"
 LABEL COMMIT_MESSAGE="$COMMIT_MESSAGE"
 LABEL COMMIT_HASH="$COMMIT_HASH"
-COPY ./version.json /version.json
+
+ENV VERSION=${VERSION}
+ENV COMMIT_DATETIME=${COMMIT_DATETIME}
+ENV BUILD_DATETIME=${BUILD_DATETIME}
+ENV TAGS=${TAGS}
+ENV BRANCH=${BRANCH}
+ENV COMMIT_MESSAGE=${COMMIT_MESSAGE}
+ENV COMMIT_HASH=${COMMIT_HASH}
+
+COPY assets ./assets
+COPY app ./
+
+ENTRYPOINT ["python3", "-u", "oracle.py"]

--- a/app/oracle.py
+++ b/app/oracle.py
@@ -18,19 +18,13 @@ from log import init_log
 init_log()
 logger = logging.getLogger(__name__)
 
-VERSION_JSON_PATH = os.environ.get('VERSION_JSON_PATH', '/version.json')
-if os.path.exists(VERSION_JSON_PATH):
-    with open(VERSION_JSON_PATH) as version_file:
-        version_info = json.load(version_file)
-    logging.info('version: %s' % version_info.get('version'))
-    logging.info('commit_message: %s' % version_info.get('commit_message'))
-    logging.info('commit_hash: %s' % version_info.get('commit_hash'))
-    logging.info('commit_datetime: %s' % version_info.get('commit_datetime'))
-    logging.info('build_datetime: %s' % version_info.get('build_datetime'))
-    logging.info('tags: %s' % version_info.get('tags'))
-    logging.info('branch: %s' % version_info.get('branch'))
-else:
-    logging.info('version json file does not exist')
+meta_envs = ['VERSION', 'COMMIT_MESSAGE', 'COMMIT_HASH', 'COMMIT_DATETIME', 'BUILD_DATETIME', 'TAGS', 'BRANCH']
+
+for env in meta_envs:
+    value = 'Not set'
+    if env in os.environ and os.environ[env] != '':
+        value = os.environ[env]
+    logging.info(f'{env.lower()}: {value}')
 
 envs = [
     'ETH1_NODE',

--- a/build.sh
+++ b/build.sh
@@ -1,35 +1,37 @@
 #!/bin/bash
-set -e +u
+set +u
 set -o pipefail
 
 IMG="lidofinance/oracle:latest"
 export DOCKER_CONFIG=$HOME/.lidofinance
 
 #### Version info ####
-if ! python ./helpers/get_git_info.py > ./version.json; then
-  echo "python script error"
-  exit 1
+META_INFO=$(python ./helpers/get_git_info.py 2>&1)
+
+if [[ $? != 0 ]]
+then
+    echo "python script error"
+    META_INFO=""
+else
+    #### Show info ####
+    echo "version: $(echo ${META_INFO} | jq --raw-output .version)"
+    echo "commit hash: $(echo ${META_INFO}| jq --raw-output .commit_hash)"
+    echo "commit message: $(echo ${META_INFO} | jq --raw-output .commit_message)"
+    echo "commit datetime: $(echo ${META_INFO}| jq --raw-output .commit_datetime)"
+    echo "build datetime: $(echo ${META_INFO}| jq --raw-output .build_datetime)"
+    echo "tags: $(echo ${META_INFO} | jq --raw-output .tags)"
+    echo "branch: $(echo ${META_INFO} | jq --raw-output .branch)"
 fi
-
-#### Show info ####
-
-echo "version: $(cat ./version.json | jq --raw-output .version)"
-echo "commit hash: $(cat ./version.json | jq --raw-output .commit_hash)"
-echo "commit message: $(cat ./version.json | jq --raw-output .commit_message)"
-echo "commit datetime: $(cat ./version.json | jq --raw-output .commit_datetime)"
-echo "build datetime: $(cat ./version.json | jq --raw-output .build_datetime)"
-echo "tags: $(cat ./version.json | jq --raw-output .tags)"
-echo "branch: $(cat ./version.json | jq --raw-output .branch)"
 
 echo "Building oracle Docker image..."
 docker build \
-  --build-arg VERSION="$(cat ./version.json | jq --raw-output .version)" \
-  --build-arg COMMIT_MESSAGE="$(cat ./version.json | jq --raw-output .commit_message)" \
-  --build-arg COMMIT_HASH="$(cat ./version.json | jq --raw-output .commit_hash)" \
-  --build-arg COMMIT_DATETIME="$(cat ./version.json | jq --raw-output .commit_datetime)" \
-  --build-arg BUILD_DATETIME="$(cat ./version.json | jq --raw-output .build_datetime)" \
-  --build-arg TAGS="$(cat ./version.json | jq --raw-output .tags)" \
-  --build-arg BRANCH="$(cat ./version.json | jq --raw-output .branch)" \
+  --build-arg VERSION="$(echo ${META_INFO} | jq --raw-output .version)" \
+  --build-arg COMMIT_MESSAGE="$(echo ${META_INFO} | jq --raw-output .commit_message)" \
+  --build-arg COMMIT_HASH="$(echo ${META_INFO} | jq --raw-output .commit_hash)" \
+  --build-arg COMMIT_DATETIME="$(echo ${META_INFO} | jq --raw-output .commit_datetime)" \
+  --build-arg BUILD_DATETIME="$(echo ${META_INFO} | jq --raw-output .build_datetime)" \
+  --build-arg TAGS="$(echo ${META_INFO} | jq --raw-output .tags)" \
+  --build-arg BRANCH="$(echo ${META_INFO} | jq --raw-output .branch)" \
   -t $IMG \
   .
 echo "The image \"${IMG}\" was built"

--- a/tests/test_get_semver_tag.py
+++ b/tests/test_get_semver_tag.py
@@ -1,6 +1,6 @@
 import pytest
 
-from helpers.get_git_info import get_semver_tag, TooMuchSemVerTags
+from helpers.get_git_info import get_semver_tag
 
 
 def test_empty():
@@ -69,7 +69,7 @@ v0.1.2-release
 
 
 def test_several_semver_tags():
-    with pytest.raises(TooMuchSemVerTags):
+    with pytest.raises(ValueError):
         get_semver_tag("""aaa
 some-tag
 v0.1.2-release


### PR DESCRIPTION
* Allow python get_git_info.py to fail
* get_git_info.py now work on python 3.6 and git <2.22
* Unify time format in commit_datetime and build_datetime
* Remove version.json
* Update tests

https://github.com/lidofinance/lido-oracle/issues/78