### PR TITLE
Introduce dual-stage get_current_metrics() #102

### DIFF
--- a/app/metrics.py
+++ b/app/metrics.py
@@ -62,33 +62,38 @@ def get_previous_metrics(w3, pool, oracle, beacon_spec, from_block=0):
     return result
 
 
-def get_current_metrics(w3, beacon, pool, oracle, registry, beacon_spec):
-    epochs_per_frame = beacon_spec[0]
+def get_current_metrics(w3, beacon, pool, oracle, registry, beacon_spec, partial_metrics=None):
+    """If the result of previous get_current_metrics call isn't given
+    create and return partial metric.mSince it doesn't get keys from
+    registry and doesn't retrieve beacon state, it's much faster."""
+    if not partial_metrics:
+        epochs_per_frame = beacon_spec[0]
+        partial_metrics = PoolMetrics()
+        # Get the the epoch that is both finalized and reportable
+        current_frame = oracle.functions.getCurrentFrame().call()
+        potentially_reportable_epoch = current_frame[0]
+        logging.info(f'Potentially reportable epoch: {potentially_reportable_epoch} (from ETH1 contract)')
+        finalized_epoch_beacon = beacon.get_finalized_epoch()
+        logging.info(f'Last finalized epoch: {finalized_epoch_beacon} (from Beacon)')
+        partial_metrics.epoch = min(potentially_reportable_epoch,
+                        (finalized_epoch_beacon // epochs_per_frame) * epochs_per_frame)
+        partial_metrics.timestamp = get_timestamp_by_epoch(beacon_spec, partial_metrics.epoch)
+        partial_metrics.depositedValidators = pool.functions.getBeaconStat().call()[0]
+        partial_metrics.bufferedBalance = pool.functions.getBufferedEther().call()
+        return partial_metrics
+    
+    """If partial result provided, the oracle fetches all the required states from ETH1 and ETH2"""
     slots_per_epoch = beacon_spec[1]
-    result = PoolMetrics()
-    # Get the the epoch that is both finalized and reportable
-    current_frame = oracle.functions.getCurrentFrame().call()
-    potentially_reportable_epoch = current_frame[0]
-    logging.info(f'Potentially reportable epoch: {potentially_reportable_epoch} (from ETH1 contract)')
-    finalized_epoch_beacon = beacon.get_finalized_epoch()
-    logging.info(f'Last finalized epoch: {finalized_epoch_beacon} (from Beacon)')
-    result.epoch = min(potentially_reportable_epoch,
-                       (finalized_epoch_beacon // epochs_per_frame) * epochs_per_frame)
-    slot = result.epoch * slots_per_epoch
-    logging.info(f'Reportable state: epoch:{result.epoch} slot:{slot}')
-
+    slot = partial_metrics.epoch * slots_per_epoch
+    logging.info(f'Reportable state: epoch:{partial_metrics.epoch} slot:{slot}')
     validators_keys = get_validators_keys(registry)
     logging.info(f'Total validator keys in registry: {len(validators_keys)}')
-
-    result.timestamp = get_timestamp_by_epoch(beacon_spec, result.epoch)
-    result.beaconBalance, result.beaconValidators, result.activeValidatorBalance = beacon.get_balances(
-        slot, validators_keys)
-    result.depositedValidators = pool.functions.getBeaconStat().call()[0]
-    result.bufferedBalance = pool.functions.getBufferedEther().call()
-    logging.info(f'Lido validators\' sum. balance on Beacon: {result.beaconBalance} wei or {result.beaconBalance/1e18} ETH')
-    logging.info(f'Lido validators visible on Beacon: {result.beaconValidators}')
-    return result
-
+    full_metrics = partial_metrics
+    full_metrics.beaconBalance, full_metrics.beaconValidators, full_metrics.activeValidatorBalance = beacon.get_balances(
+        slot, validators_keys)    
+    logging.info(f'Lido validators\' sum. balance on Beacon: {full_metrics.beaconBalance} wei or {full_metrics.beaconBalance/1e18} ETH')
+    logging.info(f'Lido validators visible on Beacon: {full_metrics.beaconValidators}')
+    return full_metrics
 
 def compare_pool_metrics(previous, current):
     """Describes the economics of metrics change.


### PR DESCRIPTION
The first call of get_current_metrics(...) returns just partial result
by default. Validators keys and balances get fetched only if
the function called with the result of the previous call (partial).

It's a fast workaround to have 'stages' without complex FSM logic.

closes #102 