### PR TITLE
Fix wrong exit validators count

### DIFF
--- a/src/modules/ejector/ejector.py
+++ b/src/modules/ejector/ejector.py
@@ -250,10 +250,11 @@ class Ejector(BaseModule, ConsensusModule):
         """
         max_exit_epoch_number, latest_to_exit_validators_count = self._get_latest_exit_epoch(blockstamp)
 
-        max_exit_epoch_number = max(
-            max_exit_epoch_number,
-            self.compute_activation_exit_epoch(blockstamp),
-        )
+        activation_exit_epoch = self.compute_activation_exit_epoch(blockstamp)
+
+        if activation_exit_epoch > max_exit_epoch_number:
+            max_exit_epoch_number = activation_exit_epoch
+            latest_to_exit_validators_count = 0
 
         EJECTOR_MAX_EXIT_EPOCH.set(max_exit_epoch_number)
 

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -195,7 +195,10 @@ def test_get_predicted_withdrawable_epoch(ejector: Ejector) -> None:
     ejector._get_churn_limit = Mock(return_value=2)
     ref_blockstamp = ReferenceBlockStampFactory.build(ref_epoch=3546)
     result = ejector._get_predicted_withdrawable_epoch(ref_blockstamp, 2)
-    assert result == 3824, "Unexpected predicted withdrawable epoch"
+    assert result == 3808, "Unexpected predicted withdrawable epoch"
+
+    result = ejector._get_predicted_withdrawable_epoch(ref_blockstamp, 4)
+    assert result == 3809, "Unexpected predicted withdrawable epoch"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
In the function _get_predicted_withdrawable_epoch in the file ejector.py the
maximum value of exit_epoch among validators ( max_exit_epoch_number ) can be less
than blockstamp.ref_epoch + 1 + MAX_SEED_LOOKAHEAD (according to
compute_activation_exit_epoch function). This can happen when all validators have
reached their exit_epochs and none of the validators have initiated an exit yet.
In this case max_exit_epoch_number sets to blockstamp.ref_epoch + 1 +
MAX_SEED_LOOKAHEAD , but at the same time latest_to_exit_validators_count is left
untouched with a non-zero value It leads to the reduction of the capacity of the exit queue.