### PR TITLE
Tweak prometheus buckets

### DIFF
--- a/src/metrics/prometheus/basic.py
+++ b/src/metrics/prometheus/basic.py
@@ -1,6 +1,7 @@
 from enum import Enum
 
 from prometheus_client import Gauge, Histogram, Counter, Info
+from prometheus_client.utils import INF
 
 from src.variables import PROMETHEUS_PREFIX
 
@@ -54,13 +55,17 @@ FUNCTIONS_DURATION = Histogram(
     'Duration of oracle daemon tasks',
     ['name', 'status'],
     namespace=PROMETHEUS_PREFIX,
+    buckets=(.1, .5, 1.0, 2.5, 5.0, 7.5, 10.0, 20.0, 30.0, 60.0, 120.0, 180.0, 240.0, 300.0, 600.0, INF),
 )
+
+requests_buckets = (.01, .05, .1, .25, .5, .75, 1.0, 2.5, 5.0, 7.5, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 120.0, INF)
 
 EL_REQUESTS_DURATION = Histogram(
     'el_requests_duration',
     'Duration of requests to EL RPC',
     ['endpoint', 'call_method', 'call_to', 'code', 'domain'],
     namespace=PROMETHEUS_PREFIX,
+    buckets=requests_buckets,
 )
 
 CL_REQUESTS_DURATION = Histogram(
@@ -68,6 +73,7 @@ CL_REQUESTS_DURATION = Histogram(
     'Duration of requests to CL API',
     ['endpoint', 'code', 'domain'],
     namespace=PROMETHEUS_PREFIX,
+    buckets=requests_buckets,
 )
 
 KEYS_API_REQUESTS_DURATION = Histogram(
@@ -75,6 +81,7 @@ KEYS_API_REQUESTS_DURATION = Histogram(
     'Duration of requests to Keys API',
     ['endpoint', 'code', 'domain'],
     namespace=PROMETHEUS_PREFIX,
+    buckets=requests_buckets,
 )
 
 KEYS_API_LATEST_BLOCKNUMBER = Gauge(


### PR DESCRIPTION
Some functions work more than 5 minutes, so we don't see accurate prometheus histogram, so we increased buckets for requests and functions.