### PR TITLE
Fix incorrect clear cache func name

### DIFF
--- a/src/utils/cache.py
+++ b/src/utils/cache.py
@@ -13,12 +13,12 @@ def global_lru_cache(*args, **kwargs):
             global_cache[func] = cached_func
             return result
 
-        def clear_cache():
+        def cache_clear():
             cached_func.cache_clear()
             if func in global_cache:
                 del global_cache[func]
 
-        wrapper.clear_cache = clear_cache
+        wrapper.cache_clear = cache_clear
         wrapper.cache_info = cached_func.cache_info
         return wrapper
 


### PR DESCRIPTION
The only use of `cache_clear` is to make `global_lru_cache` similar to generic `lru_cache`. There was a typo, but it seems a real problem wasn't:
- a real way to clear cache in our code is calling `clear_global_cache` which clears global cache itself
- another way to be sure that we clear links, is using a weakref
