### PR TITLE
Fix inconsistent implementation

### DIFF
--- a/src/modules/accounting/accounting.py
+++ b/src/modules/accounting/accounting.py
@@ -62,13 +62,13 @@ class Accounting(BaseModule, ConsensusModule):
     def execute_module(self, last_finalized_blockstamp: BlockStamp) -> ModuleExecuteDelay:
         report_blockstamp = self.get_blockstamp_for_report(last_finalized_blockstamp)
 
-        if report_blockstamp:
-            self.process_report(report_blockstamp)
-            # Third phase of report. Specific for accounting.
-            self.process_extra_data(report_blockstamp)
-            return ModuleExecuteDelay.NEXT_SLOT
+        if not report_blockstamp:
+            return ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
 
-        return ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
+        self.process_report(report_blockstamp)
+        # Third phase of report. Specific for accounting.
+        self.process_extra_data(report_blockstamp)
+        return ModuleExecuteDelay.NEXT_SLOT
 
     def process_extra_data(self, blockstamp: ReferenceBlockStamp):
         latest_blockstamp = self._get_latest_blockstamp()

--- a/src/modules/ejector/ejector.py
+++ b/src/modules/ejector/ejector.py
@@ -75,6 +75,7 @@ class Ejector(BaseModule, ConsensusModule):
 
     def execute_module(self, last_finalized_blockstamp: BlockStamp) -> ModuleExecuteDelay:
         report_blockstamp = self.get_blockstamp_for_report(last_finalized_blockstamp)
+
         if not report_blockstamp:
             return ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
 


### PR DESCRIPTION
Implement accounting `def execute_module` same as in ejector `def execute_module`