### PR TITLE
Fix: Python11 image does not have wget by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends -qq \
     gcc=4:12.2.0-3 \
     libffi-dev=3.4.4-1 \
     g++=4:12.2.0-3 \
+    curl=7.88.1-10+deb12u5 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
@@ -43,7 +44,7 @@ EXPOSE $PROMETHEUS_PORT
 USER www-data
 
 HEALTHCHECK --interval=10s --timeout=3s \
-    CMD wget --no-verbose --tries=1 --spider http://localhost:$HEALTHCHECK_SERVER_PORT/healthcheck || exit 1
+    CMD curl -f http://localhost:$HEALTHCHECK_SERVER_PORT/healthcheck || exit 1
 
 WORKDIR /app/
 


### PR DESCRIPTION
replace `wget` with `culr`