### PR TITLE
Fix flaky test

### DIFF
--- a/tests/factory/no_registry.py
+++ b/tests/factory/no_registry.py
@@ -1,5 +1,6 @@
 import random
 from itertools import count
+from typing import Any
 
 from faker import Faker
 from pydantic_factories import Use
@@ -9,7 +10,6 @@ from src.providers.consensus.types import Validator, ValidatorState
 from src.providers.keys.types import LidoKey
 from tests.factory.web3_factory import Web3Factory
 from src.web3py.extensions.lido_validators import StakingModule, LidoValidator, NodeOperator
-
 
 faker = Faker()
 
@@ -46,6 +46,12 @@ class LidoValidatorFactory(Web3Factory):
 
     index: str = Use(lambda x: str(next(x)), count(1))
     balance: str = Use(lambda x: str(x), random.randrange(1, 10**9))
+
+    @classmethod
+    def build_with_activation_epoch_bound(cls, max_value: int, **kwargs: Any):
+        return cls.build(
+            validator=ValidatorStateFactory.build(activation_epoch=str(faker.pyint(max_value=max_value - 1))), **kwargs
+        )
 
 
 class NodeOperatorFactory(Web3Factory):

--- a/tests/modules/ejector/test_iterator_v2.py
+++ b/tests/modules/ejector/test_iterator_v2.py
@@ -131,7 +131,7 @@ def test_eject_validator(iterator):
     )
 
     def generate_validator_state_with_activation_epoch_bound():
-        return ValidatorStateFactory.build(activation_epoch=faker.pyint(max_value=iterator.blockstamp.ref_epoch - 1))
+        return ValidatorStateFactory.build(activation_epoch=str(faker.pyint(max_value=iterator.blockstamp.ref_epoch - 1)))
 
     iterator.w3.lido_validators.get_lido_validators_by_node_operators = Mock(
         return_value={

--- a/tests/modules/ejector/test_iterator_v2.py
+++ b/tests/modules/ejector/test_iterator_v2.py
@@ -130,26 +130,21 @@ def test_eject_validator(iterator):
         ]
     )
 
-    def generate_validator_state_with_activation_epoch_bound():
-        return ValidatorStateFactory.build(
-            activation_epoch=str(faker.pyint(max_value=iterator.blockstamp.ref_epoch - 1))
-        )
-
     iterator.w3.lido_validators.get_lido_validators_by_node_operators = Mock(
         return_value={
             (1, 1): [
-                LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
-                LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
-                LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
+                LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch),
+                LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch),
+                LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch),
             ],
             (1, 2): [
-                LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
-                LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
+                LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch),
+                LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch),
             ],
             (2, 1): [
-                LidoValidatorFactory.build(index='8', validator=generate_validator_state_with_activation_epoch_bound()),
-                LidoValidatorFactory.build(index='7', validator=generate_validator_state_with_activation_epoch_bound()),
-                LidoValidatorFactory.build(index='6', validator=generate_validator_state_with_activation_epoch_bound()),
+                LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch, index='8'),
+                LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch, index='7'),
+                LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch, index='6'),
             ],
         }
     )

--- a/tests/modules/ejector/test_iterator_v2.py
+++ b/tests/modules/ejector/test_iterator_v2.py
@@ -7,7 +7,12 @@ from faker import Faker
 from src.services.exit_order_v2.iterator import ValidatorExitIteratorV2, NodeOperatorStats, StakingModuleStats
 from src.web3py.extensions.lido_validators import NodeOperatorLimitMode
 from tests.factory.blockstamp import ReferenceBlockStampFactory
-from tests.factory.no_registry import NodeOperatorFactory, StakingModuleFactory, LidoValidatorFactory, ValidatorStateFactory
+from tests.factory.no_registry import (
+    NodeOperatorFactory,
+    StakingModuleFactory,
+    LidoValidatorFactory,
+    ValidatorStateFactory,
+)
 from tests.factory.web3_factory import Web3Factory
 
 faker = Faker()
@@ -130,11 +135,15 @@ def test_eject_validator(iterator):
 
     iterator.w3.lido_validators.get_lido_validators_by_node_operators = Mock(
         return_value={
-            (1, 1): [LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
-                     LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
-                     LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound())],
-            (1, 2): [LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
-                     LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound())],
+            (1, 1): [
+                LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
+                LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
+                LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
+            ],
+            (1, 2): [
+                LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
+                LidoValidatorFactory.build(validator=generate_validator_state_with_activation_epoch_bound()),
+            ],
             (2, 1): [
                 LidoValidatorFactory.build(index='8', validator=generate_validator_state_with_activation_epoch_bound()),
                 LidoValidatorFactory.build(index='7', validator=generate_validator_state_with_activation_epoch_bound()),
@@ -254,19 +263,19 @@ def test_no_force_and_soft_predicate(iterator):
 
     # Last two elements have same weight
     assert [
-               nos[0].node_operator.id,
-               nos[3].node_operator.id,
-           ] == [
-                    no.node_operator.id for no in sorted_nos
-                ][:2]
+        nos[0].node_operator.id,
+        nos[3].node_operator.id,
+    ] == [
+        no.node_operator.id for no in sorted_nos
+    ][:2]
 
     sorted_nos = sorted(nos, key=lambda x: -iterator._no_soft_predicate(x))
     assert [
-               nos[2].node_operator.id,
-               nos[1].node_operator.id,
-           ] == [
-                    no.node_operator.id for no in sorted_nos
-                ][:2]
+        nos[2].node_operator.id,
+        nos[1].node_operator.id,
+    ] == [
+        no.node_operator.id for no in sorted_nos
+    ][:2]
 
 
 @pytest.mark.unit

--- a/tests/modules/ejector/test_iterator_v2.py
+++ b/tests/modules/ejector/test_iterator_v2.py
@@ -78,7 +78,8 @@ def test_calculate_validators_age(iterator, monkeypatch):
     assert age == 20
 
 
-def test_eject_validator(iterator):
+@pytest.mark.parametrize('execution_number', range(7))
+def test_eject_validator(execution_number, iterator):
     sk_1 = StakingModuleFactory.build(
         id=1,
         priority_exit_share_threshold=1 * 10000,
@@ -95,12 +96,14 @@ def test_eject_validator(iterator):
     )
 
     no_1 = NodeOperatorFactory.build(
+        id=1,
         staking_module=sk_1,
         total_deposited_validators=3,
         target_validators_count=1,
         is_target_limit_active=NodeOperatorLimitMode.FORCE,
     )
     no_2 = NodeOperatorFactory.build(
+        id=2,
         staking_module=sk_1,
         total_deposited_validators=2,
         is_target_limit_active=NodeOperatorLimitMode.SOFT,
@@ -162,7 +165,7 @@ def test_eject_validator(iterator):
     assert iterator.total_lido_validators == 6
     assert iterator.module_stats[1].predictable_validators == 4
     assert iterator.node_operators_stats[(1, 1)].predictable_validators == 2
-    assert iterator.node_operators_stats[(1, 1)].total_age < prev_total_age
+    assert iterator.node_operators_stats[(1, 1)].total_age <= prev_total_age
 
     iterator.max_validators_to_exit = 3
     iterator.no_penetration_threshold = 0.1
@@ -243,19 +246,19 @@ def test_no_force_and_soft_predicate(iterator):
 
     # Last two elements have same weight
     assert [
-        nos[0].node_operator.id,
-        nos[3].node_operator.id,
-    ] == [
-        no.node_operator.id for no in sorted_nos
-    ][:2]
+               nos[0].node_operator.id,
+               nos[3].node_operator.id,
+           ] == [
+                    no.node_operator.id for no in sorted_nos
+                ][:2]
 
     sorted_nos = sorted(nos, key=lambda x: -iterator._no_soft_predicate(x))
     assert [
-        nos[2].node_operator.id,
-        nos[1].node_operator.id,
-    ] == [
-        no.node_operator.id for no in sorted_nos
-    ][:2]
+               nos[2].node_operator.id,
+               nos[1].node_operator.id,
+           ] == [
+                    no.node_operator.id for no in sorted_nos
+                ][:2]
 
 
 @pytest.mark.unit

--- a/tests/modules/ejector/test_iterator_v2.py
+++ b/tests/modules/ejector/test_iterator_v2.py
@@ -131,7 +131,9 @@ def test_eject_validator(iterator):
     )
 
     def generate_validator_state_with_activation_epoch_bound():
-        return ValidatorStateFactory.build(activation_epoch=str(faker.pyint(max_value=iterator.blockstamp.ref_epoch - 1)))
+        return ValidatorStateFactory.build(
+            activation_epoch=str(faker.pyint(max_value=iterator.blockstamp.ref_epoch - 1))
+        )
 
     iterator.w3.lido_validators.get_lido_validators_by_node_operators = Mock(
         return_value={

--- a/tests/modules/ejector/test_iterator_v2.py
+++ b/tests/modules/ejector/test_iterator_v2.py
@@ -246,19 +246,19 @@ def test_no_force_and_soft_predicate(iterator):
 
     # Last two elements have same weight
     assert [
-               nos[0].node_operator.id,
-               nos[3].node_operator.id,
-           ] == [
-                    no.node_operator.id for no in sorted_nos
-                ][:2]
+        nos[0].node_operator.id,
+        nos[3].node_operator.id,
+    ] == [
+        no.node_operator.id for no in sorted_nos
+    ][:2]
 
     sorted_nos = sorted(nos, key=lambda x: -iterator._no_soft_predicate(x))
     assert [
-               nos[2].node_operator.id,
-               nos[1].node_operator.id,
-           ] == [
-                    no.node_operator.id for no in sorted_nos
-                ][:2]
+        nos[2].node_operator.id,
+        nos[1].node_operator.id,
+    ] == [
+        no.node_operator.id for no in sorted_nos
+    ][:2]
 
 
 @pytest.mark.unit

--- a/tests/modules/ejector/test_iterator_v2.py
+++ b/tests/modules/ejector/test_iterator_v2.py
@@ -2,7 +2,6 @@ from types import MethodType
 from unittest.mock import Mock
 
 import pytest
-from faker import Faker
 
 from src.services.exit_order_v2.iterator import ValidatorExitIteratorV2, NodeOperatorStats, StakingModuleStats
 from src.web3py.extensions.lido_validators import NodeOperatorLimitMode
@@ -11,11 +10,8 @@ from tests.factory.no_registry import (
     NodeOperatorFactory,
     StakingModuleFactory,
     LidoValidatorFactory,
-    ValidatorStateFactory,
 )
 from tests.factory.web3_factory import Web3Factory
-
-faker = Faker()
 
 
 class ModuleStatsFactory(Web3Factory):


### PR DESCRIPTION
The test `test_eject_validator` is flaky, because of the nature of fake data generation. Since [substraction](https://github.com/lidofinance/lido-oracle/blob/13366d54e2d35796f619fc9f448aab1bef7b5f7b/src/services/exit_order_v2/iterator.py#L212) can result in no changes, see [get_validator_age](https://github.com/lidofinance/lido-oracle/blob/13366d54e2d35796f619fc9f448aab1bef7b5f7b/src/utils/validator_state.py#L36) <= should be enough