### PR TITLE
fix: staking reward v2 backward compatibility

### DIFF
--- a/src/providers/execution/contracts/staking_router.py
+++ b/src/providers/execution/contracts/staking_router.py
@@ -99,7 +99,7 @@ class StakingRouterContractV2(StakingRouterContract):
             logger.warning({'msg': 'Use StakingRouterV1.json abi (old one) to parse the response.'})
             staking_router = self.w3.eth.contract(
                 address=self.address,
-                abi=self.load_abi(super().abi_path),
+                abi=self.load_abi(StakingRouterContractV1.abi_path),
                 decode_tuples=True,
             )
             response = staking_router.functions.getStakingModules().call(block_identifier=block_identifier)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,7 +11,7 @@ from src.providers.execution.contracts.lido import LidoContract
 from src.providers.execution.contracts.lido_locator import LidoLocatorContract
 from src.providers.execution.contracts.oracle_daemon_config import OracleDaemonConfigContract
 from src.providers.execution.contracts.oracle_report_sanity_checker import OracleReportSanityCheckerContract
-from src.providers.execution.contracts.staking_router import StakingRouterContractV1
+from src.providers.execution.contracts.staking_router import StakingRouterContractV1, StakingRouterContractV2
 from src.providers.execution.contracts.withdrawal_queue_nft import WithdrawalQueueNftContract
 
 
@@ -70,6 +70,15 @@ def staking_router_contract(web3_provider_integration, lido_locator_contract) ->
     return get_contract(
         web3_provider_integration,
         StakingRouterContractV1,
+        lido_locator_contract.staking_router(),
+    )
+
+
+@pytest.fixture
+def staking_router_contract_v2(web3_provider_integration, lido_locator_contract) -> StakingRouterContractV2:
+    return get_contract(
+        web3_provider_integration,
+        StakingRouterContractV2,
         lido_locator_contract.staking_router(),
     )
 

--- a/tests/integration/contracts/test_staking_router.py
+++ b/tests/integration/contracts/test_staking_router.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 
 from src.web3py.extensions.lido_validators import StakingModule, NodeOperator
@@ -25,3 +27,36 @@ def test_staking_router(staking_router_contract, caplog):
         ],
         caplog,
     )
+
+
+@pytest.mark.integration
+def test_staking_router_v2(staking_router_contract_v2, caplog):
+    check_contract(
+        staking_router_contract_v2,
+        [
+            (
+                'get_all_node_operator_digests',
+                (StakingModuleFactory.build(id=1),),
+                lambda response: check_value_type(response, list)
+                and map(lambda sm: check_value_type(sm, NodeOperator), response),
+            ),
+        ],
+        caplog,
+    )
+
+
+@pytest.mark.integration
+def test_backward_compitability_staking_router_v2(staking_router_contract_v2, caplog):
+    caplog.set_level(logging.DEBUG)
+
+    # Block with old staking router
+    staking_modules = staking_router_contract_v2.get_staking_modules(20929216)
+
+    assert "{'msg': 'Use StakingRouterV1.json abi (old one) to parse the response.'}" in caplog.messages
+
+    log_with_call = list(filter(lambda log: 'Call ' in log or 'Build ' in log, caplog.messages))
+
+    assert 'Call `getContractVersion()`' in log_with_call[0]
+    assert 'Call `getStakingModules()`' in log_with_call[1]
+
+    assert len(staking_modules)


### PR DESCRIPTION
If all cases are True, the Oracle will fall:
- Voting passed and enacted. Contract changed version.
- Current reportable reference slot points to the block before enact transaction.
- Contract is still reportable.

Correct Oracle behavior:
Oracle can correctly build report, but can't submit it, because contracnt and consensus version on ref slot differ from current onchain versions.

Current:
Oracle throws exception