### PR TITLE
Some oracle variables should be fetched on a latest slot

### DIFF
--- a/fixtures/tests/modules/accounting/test_withdrawal_integration.py/test_happy_path.json
+++ b/fixtures/tests/modules/accounting/test_withdrawal_integration.py/test_happy_path.json
@@ -6,7 +6,7 @@
         "to": "0x8D49f1b4AF30598679D4D37Be4B094da1b459b82",
         "data": "0xa3a3fd5d"
       },
-      "0x8ee61584b9d3e010c55f1fa77a803051f5f783385ec75b4e3fc71e199a86184d"
+      "latest"
     ],
     "response": {
       "jsonrpc": "2.0",
@@ -195,7 +195,7 @@
         "to": "0x4c1F6cA213abdbc19b27f2562d7b1A645A019bD9",
         "data": "0x29fd065d"
       },
-      "0x8ee61584b9d3e010c55f1fa77a803051f5f783385ec75b4e3fc71e199a86184d"
+      "latest"
     ],
     "response": {
       "jsonrpc": "2.0",

--- a/src/modules/accounting/accounting.py
+++ b/src/modules/accounting/accounting.py
@@ -326,7 +326,7 @@ class Accounting(BaseModule, ConsensusModule):
         logger.info({'msg': 'Calculate stuck validators.', 'value': stuck_validators})
         exited_validators = self.lido_validator_state_service.get_lido_newly_exited_validators(blockstamp)
         logger.info({'msg': 'Calculate exited validators.', 'value': exited_validators})
-        orl = self.w3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits(blockstamp.block_hash)
+        orl = self.w3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits()
 
         if consensus_version == 1:
             return ExtraDataService.collect(
@@ -350,7 +350,7 @@ class Accounting(BaseModule, ConsensusModule):
         logger.info({'msg': 'Calculate stuck validators.', 'value': stuck_validators})
         exited_validators = self.lido_validator_state_service.get_lido_newly_exited_validators(blockstamp)
         logger.info({'msg': 'Calculate exited validators.', 'value': exited_validators})
-        orl = self.w3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits(blockstamp.block_hash)
+        orl = self.w3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits()
         return stuck_validators, exited_validators, orl
 
     def _calculate_report_v1(self, blockstamp: ReferenceBlockStamp) -> ReportData:

--- a/src/services/exit_order/iterator.py
+++ b/src/services/exit_order/iterator.py
@@ -54,9 +54,8 @@ class ExitOrderIterator:
         eois = ExitOrderIteratorStateService(self.w3, self.blockstamp)
 
         self.left_queue_count = 0
-        self.max_validators_to_exit = eois.w3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits(
-            self.blockstamp.block_hash,
-        ).max_validator_exit_requests_per_report
+        self.max_validators_to_exit = (eois.w3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits()
+                                       .max_validator_exit_requests_per_report)
         self.operator_network_penetration_threshold = eois.get_operator_network_penetration_threshold(self.blockstamp)
 
         # Prepare list of exitable validators, which will be sorted by exit order predicates

--- a/src/services/exit_order_v2/iterator.py
+++ b/src/services/exit_order_v2/iterator.py
@@ -149,9 +149,8 @@ class ValidatorExitIteratorV2:
                 self.node_operators_stats[gid].soft_exit_to = self.node_operators_stats[gid].node_operator.target_validators_count
 
     def _load_blockchain_state(self):
-        self.max_validators_to_exit = self.w3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits(
-            self.blockstamp.block_hash,
-        ).max_validator_exit_requests_per_report
+        self.max_validators_to_exit = (self.w3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits()
+                                       .max_validator_exit_requests_per_report)
 
         self.no_penetration_threshold = self.w3.lido_contracts.oracle_daemon_config.node_operator_network_penetration_threshold_bp(
             block_identifier=self.blockstamp.block_hash,

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -57,7 +57,7 @@ class SafeBorder(Web3Converter):
         self._retrieve_constants()
 
     def _retrieve_constants(self):
-        limits_list = self.w3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits(self.blockstamp.block_hash)
+        limits_list = self.w3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits()
 
         self.finalization_default_shift = math.ceil(
             limits_list.request_timestamp_margin / (self.chain_config.slots_per_epoch * self.chain_config.seconds_per_slot)

--- a/src/services/withdrawal.py
+++ b/src/services/withdrawal.py
@@ -82,7 +82,7 @@ class Withdrawal:
         available_eth: int,
         until_timestamp: int
     ) -> list[int]:
-        max_length = self.w3.lido_contracts.withdrawal_queue_nft.max_batches_length(self.blockstamp.block_hash)
+        max_length = self.w3.lido_contracts.withdrawal_queue_nft.max_batches_length()
 
         state = BatchState(
             remaining_eth_budget=available_eth,

--- a/tests/modules/accounting/test_withdrawal_integration.py
+++ b/tests/modules/accounting/test_withdrawal_integration.py
@@ -1,8 +1,8 @@
 import pytest
 
+from src.constants import SHARE_RATE_PRECISION_E27
 from src.modules.submodules.types import FrameConfig, ChainConfig
 from src.services.withdrawal import Withdrawal
-from src.constants import SHARE_RATE_PRECISION_E27
 from tests.conftest import get_blockstamp_by_state
 
 


### PR DESCRIPTION
# What

Some of the variables should be fetched on a latest slot instead of the referenced one

# Why

It affects relevance of the calculations

# How

Changed fetching this variables by putting `latest` to the `eth_call`