### PR TITLE
fix: Prysm specific error text

### DIFF
--- a/src/providers/consensus/client.py
+++ b/src/providers/consensus/client.py
@@ -181,7 +181,7 @@ class ConsensusClient(HTTPProvider):
 
             raise error
 
-    PRYSM_STATE_NOT_FOUND_ERROR = 'State not found: state not found in the last'
+    PRYSM_STATE_NOT_FOUND_ERROR = 'State not found'
 
     def __raise_on_prysm_error(self, errors: list[Exception]) -> Exception | None:
         """


### PR DESCRIPTION
Due to the new error text
```
Response from eth/v1/beacon/states/0x448ed6cac5963b47566ee7fac30f649e09ac87da3d34e2613d7f224352e735ea/validators [404] with text: \"{\"message\":\"State not found\",\"code\":404}\" returned.\n"}
```