### PR TITLE
Replace consensus version calls

### DIFF
--- a/src/modules/accounting/accounting.py
+++ b/src/modules/accounting/accounting.py
@@ -167,7 +167,7 @@ class Accounting(BaseModule, ConsensusModule):
 
     # ---------------------------------------- Build report ----------------------------------------
     def _calculate_report(self, blockstamp: ReferenceBlockStamp):
-        consensus_version = self.report_contract.get_consensus_version(blockstamp.block_hash)
+        consensus_version = self.get_consensus_version(blockstamp)
         logger.info({'msg': 'Building the report', 'consensus_version': consensus_version})
         rebase_part = self._calculate_rebase_report(blockstamp)
         modules_part = self._get_newly_exited_validators_by_modules(blockstamp)

--- a/src/modules/csm/csm.py
+++ b/src/modules/csm/csm.py
@@ -112,7 +112,7 @@ class CSOracle(BaseModule, ConsensusModule):
         if not distributed and not shares:
             logger.info({"msg": "No shares distributed in the current frame"})
             return ReportData(
-                self.report_contract.get_consensus_version(blockstamp.block_hash),
+                self.get_consensus_version(blockstamp),
                 blockstamp.ref_slot,
                 tree_root=prev_root,
                 tree_cid=prev_cid or "",
@@ -131,7 +131,7 @@ class CSOracle(BaseModule, ConsensusModule):
         tree_cid = self.publish_tree(tree)
 
         return ReportData(
-            self.report_contract.get_consensus_version(blockstamp.block_hash),
+            self.get_consensus_version(blockstamp),
             blockstamp.ref_slot,
             tree_root=tree.root,
             tree_cid=tree_cid,

--- a/src/modules/ejector/ejector.py
+++ b/src/modules/ejector/ejector.py
@@ -104,7 +104,7 @@ class Ejector(BaseModule, ConsensusModule):
         data, data_format = encode_data(validators)
 
         report_data = ReportData(
-            self.report_contract.get_consensus_version(blockstamp.block_hash),
+            self.get_consensus_version(blockstamp),
             blockstamp.ref_slot,
             len(validators),
             data_format,

--- a/src/modules/submodules/consensus.py
+++ b/src/modules/submodules/consensus.py
@@ -296,7 +296,7 @@ class ConsensusModule(ABC):
                 logger.info({'msg': 'Consensus reached with provided hash.'})
                 return None
 
-        consensus_version = self.report_contract.get_consensus_version(blockstamp.block_hash)
+        consensus_version = self.get_consensus_version(blockstamp)
 
         logger.info({'msg': f'Send report hash. Consensus version: [{consensus_version}]'})
         self._send_report_hash(blockstamp, report_hash, consensus_version)

--- a/tests/modules/submodules/consensus/test_consensus.py
+++ b/tests/modules/submodules/consensus/test_consensus.py
@@ -209,7 +209,7 @@ def test_incompatible_contract_version(consensus):
     bs = ReferenceBlockStampFactory.build()
 
     consensus.report_contract.get_contract_version = Mock(return_value=2)
-    consensus.report_contract.get_consensus_version = Mock(return_value=2)
+    consensus.report_contract.get_consensus_version = Mock(return_value=1)
 
     with pytest.raises(IncompatibleOracleVersion):
         consensus._check_contract_versions(bs)

--- a/tests/modules/submodules/consensus/test_consensus.py
+++ b/tests/modules/submodules/consensus/test_consensus.py
@@ -209,7 +209,7 @@ def test_incompatible_contract_version(consensus):
     bs = ReferenceBlockStampFactory.build()
 
     consensus.report_contract.get_contract_version = Mock(return_value=2)
-    consensus.report_contract.get_consensus_version = Mock(return_value=1)
+    consensus.report_contract.get_consensus_version = Mock(return_value=2)
 
     with pytest.raises(IncompatibleOracleVersion):
         consensus._check_contract_versions(bs)


### PR DESCRIPTION
# What

get rid of self.report_contract.get_consensus_version()

# Things to consider

I can't replace it in:
```python
    def _check_contract_versions(self, blockstamp: ReferenceBlockStamp):
        """
        Check if Oracle can process report on reference blockstamp.
        """
        self._check_compatability(blockstamp.block_hash)
        self._check_compatability('latest')

    def _check_compatability(self, block_tag: BlockIdentifier):
        contract_version = self.report_contract.get_contract_version(block_tag)
        consensus_version = self.report_contract.get_consensus_version(block_tag)

        compatibility = (contract_version, consensus_version) in self.COMPATIBLE_ONCHAIN_VERSIONS

        if not compatibility:
            raise IncompatibleOracleVersion(
                f'Incompatible Oracle version. Block tag: {repr(block_tag)}. '
                f'Expected (Contract, Consensus) versions: {', '.join(repr(v) for v in self.COMPATIBLE_ONCHAIN_VERSIONS)}, '
                f'Got ({contract_version}, {consensus_version})'
            )
```