### PR TITLE
Removing filtration by earliest exit epoch in a prediction of earliest slashed epoch in bunker mode

### DIFF
--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -177,7 +177,7 @@ class SafeBorder(Web3Converter):
         Returns the earliest slashed epoch for the given validators rounded to the frame
         """
         last_finalized_request_id_epoch = self.get_epoch_by_slot(self._get_last_finalized_withdrawal_request_slot())
-        earliest_activation_epoch = min((v.validator.activation_epoch for v in validators), default=0)
+        earliest_activation_epoch = min((v.validator.activation_epoch for v in validators))
         # Since we are looking for the safe border epoch, we can start from the last finalized withdrawal request epoch
         # or the earliest activation epoch among the given validators for optimization
         start_epoch = max(last_finalized_request_id_epoch, earliest_activation_epoch)

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -97,7 +97,8 @@ class SafeBorder(Web3Converter):
         latest_allowable_epoch = bunker_start_or_last_successful_report_epoch - self.finalization_default_shift
 
         max_negative_rebase = self.w3.lido_contracts.oracle_daemon_config.finalization_max_negative_rebase_epoch_shift(
-            self.blockstamp.block_hash)
+            self.blockstamp.block_hash,
+        )
         earliest_allowable_epoch = self.get_epoch_by_slot(self.blockstamp.ref_slot) - max_negative_rebase
 
         return EpochNumber(max(earliest_allowable_epoch, latest_allowable_epoch))

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -183,7 +183,7 @@ class SafeBorder(Web3Converter):
 
         # We can stop searching for the slashed epoch when we reach the reference epoch
         # or the max possible earliest slashed epoch for the given validators
-        withdrawable_epoch = min(v.validator.withdrawable_epoch for v in validators)
+        withdrawable_epoch = min(get_validators_withdrawable_epochs(validators))
         max_possible_earliest_slashed_epoch = EpochNumber(withdrawable_epoch - EPOCHS_PER_SLASHINGS_VECTOR)
         end_epoch = min(self.blockstamp.ref_epoch, max_possible_earliest_slashed_epoch)
 
@@ -276,3 +276,7 @@ def filter_validators_by_exit_epoch(validators: Iterable[Validator], exit_epoch:
 
 def get_validators_pubkeys(validators: Iterable[Validator]) -> list[HexStr]:
     return [HexStr(v.validator.pubkey) for v in validators]
+
+
+def get_validators_withdrawable_epochs(validators: Iterable[Validator]) -> list[EpochNumber]:
+    return [v.validator.withdrawable_epoch for v in validators]

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -178,7 +178,7 @@ class SafeBorder(Web3Converter):
         last_finalized_request_id_epoch = self.get_epoch_by_slot(self._get_last_finalized_withdrawal_request_slot())
         # Since we are looking for the safe border epoch, we can start from the last finalized withdrawal request epoch
         # or the earliest activation epoch among the given validators for optimization
-        earliest_activation_epoch = min((v.validator.activation_epoch for v in validators), default=0)
+        earliest_activation_epoch = self._get_validators_earliest_activation_epoch(validators)
         start_epoch = max(last_finalized_request_id_epoch, earliest_activation_epoch)
 
         # We can stop searching for the slashed epoch when we reach the reference epoch
@@ -205,6 +205,16 @@ class SafeBorder(Web3Converter):
         slot_number = self.get_frame_first_slot(start_frame)
         epoch_number = self.get_epoch_by_slot(slot_number)
         return epoch_number
+
+    def _get_validators_earliest_activation_epoch(self, validators: list[Validator]) -> EpochNumber:
+        if len(validators) == 0:
+            return EpochNumber(0)
+
+        sorted_validators = sorted(
+            validators,
+            key=lambda validator: validator.validator.activation_epoch
+        )
+        return sorted_validators[0].validator.activation_epoch
 
     def _slashings_in_frame(self, frame: FrameNumber, slashed_pubkeys: set[str]) -> bool:
         """

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -1,4 +1,5 @@
 import math
+import sys
 from typing import Iterable
 
 from eth_typing import HexStr
@@ -148,7 +149,7 @@ class SafeBorder(Web3Converter):
             if not predicted_epoch:
                 return self._find_earliest_slashed_epoch_rounded_to_frame(validators_slashed_non_withdrawable)
 
-            earliest_predicted_epoch = min(earliest_predicted_epoch or float("inf"), predicted_epoch)
+            earliest_predicted_epoch = min(earliest_predicted_epoch or EpochNumber(sys.maxsize), predicted_epoch)
 
         return earliest_predicted_epoch
 

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -1,5 +1,4 @@
 import math
-import sys
 from typing import Iterable
 
 from eth_typing import HexStr
@@ -150,7 +149,8 @@ class SafeBorder(Web3Converter):
             if not predicted_epoch:
                 return self._find_earliest_slashed_epoch_rounded_to_frame(validators_slashed_non_withdrawable)
 
-            earliest_predicted_epoch = min(earliest_predicted_epoch or EpochNumber(sys.maxsize), predicted_epoch)
+            if not earliest_predicted_epoch or earliest_predicted_epoch > predicted_epoch:
+                earliest_predicted_epoch = predicted_epoch
 
         return earliest_predicted_epoch
 
@@ -177,9 +177,9 @@ class SafeBorder(Web3Converter):
         Returns the earliest slashed epoch for the given validators rounded to the frame
         """
         last_finalized_request_id_epoch = self.get_epoch_by_slot(self._get_last_finalized_withdrawal_request_slot())
+        earliest_activation_epoch = min((v.validator.activation_epoch for v in validators), default=0)
         # Since we are looking for the safe border epoch, we can start from the last finalized withdrawal request epoch
         # or the earliest activation epoch among the given validators for optimization
-        earliest_activation_epoch = min((v.validator.activation_epoch for v in validators), default=0)
         start_epoch = max(last_finalized_request_id_epoch, earliest_activation_epoch)
 
         # We can stop searching for the slashed epoch when we reach the reference epoch

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -178,12 +178,12 @@ class SafeBorder(Web3Converter):
         last_finalized_request_id_epoch = self.get_epoch_by_slot(self._get_last_finalized_withdrawal_request_slot())
         # Since we are looking for the safe border epoch, we can start from the last finalized withdrawal request epoch
         # or the earliest activation epoch among the given validators for optimization
-        earliest_activation_slot = self._get_validators_earliest_activation_epoch(validators)
-        start_epoch = max(last_finalized_request_id_epoch, earliest_activation_slot)
+        earliest_activation_epoch = min([v.validator.activation_epoch for v in validators], default=0)
+        start_epoch = max(last_finalized_request_id_epoch, earliest_activation_epoch)
 
         # We can stop searching for the slashed epoch when we reach the reference epoch
         # or the max possible earliest slashed epoch for the given validators
-        withdrawable_epoch = min(get_validators_withdrawable_epochs(validators))
+        withdrawable_epoch = min([v.validator.withdrawable_epoch for v in validators])
         max_possible_earliest_slashed_epoch = EpochNumber(withdrawable_epoch - EPOCHS_PER_SLASHINGS_VECTOR)
         end_epoch = min(self.blockstamp.ref_epoch, max_possible_earliest_slashed_epoch)
 
@@ -220,16 +220,6 @@ class SafeBorder(Web3Converter):
         )
 
         return len(slashed_validators) > 0
-
-    def _get_validators_earliest_activation_epoch(self, validators: list[Validator]) -> EpochNumber:
-        if len(validators) == 0:
-            return EpochNumber(0)
-
-        sorted_validators = sorted(
-            validators,
-            key=lambda validator: validator.validator.activation_epoch
-        )
-        return sorted_validators[0].validator.activation_epoch
 
     def _get_bunker_mode_start_timestamp(self) -> int | None:
         start_timestamp = self.w3.lido_contracts.withdrawal_queue_nft.bunker_mode_since_timestamp(self.blockstamp.block_hash)
@@ -276,7 +266,3 @@ def filter_validators_by_exit_epoch(validators: Iterable[Validator], exit_epoch:
 
 def get_validators_pubkeys(validators: Iterable[Validator]) -> list[HexStr]:
     return [HexStr(v.validator.pubkey) for v in validators]
-
-
-def get_validators_withdrawable_epochs(validators: Iterable[Validator]) -> list[EpochNumber]:
-    return [v.validator.withdrawable_epoch for v in validators]

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -175,18 +175,16 @@ class SafeBorder(Web3Converter):
         """
         Returns the earliest slashed epoch for the given validators rounded to the frame
         """
-        withdrawable_epoch = min(get_validators_withdrawable_epochs(validators))
         last_finalized_request_id_epoch = self.get_epoch_by_slot(self._get_last_finalized_withdrawal_request_slot())
-
-        earliest_activation_slot = self._get_validators_earliest_activation_epoch(validators)
-        max_possible_earliest_slashed_epoch = EpochNumber(withdrawable_epoch - EPOCHS_PER_SLASHINGS_VECTOR)
-
         # Since we are looking for the safe border epoch, we can start from the last finalized withdrawal request epoch
         # or the earliest activation epoch among the given validators for optimization
+        earliest_activation_slot = self._get_validators_earliest_activation_epoch(validators)
         start_epoch = max(last_finalized_request_id_epoch, earliest_activation_slot)
 
         # We can stop searching for the slashed epoch when we reach the reference epoch
         # or the max possible earliest slashed epoch for the given validators
+        withdrawable_epoch = min(get_validators_withdrawable_epochs(validators))
+        max_possible_earliest_slashed_epoch = EpochNumber(withdrawable_epoch - EPOCHS_PER_SLASHINGS_VECTOR)
         end_epoch = min(self.blockstamp.ref_epoch, max_possible_earliest_slashed_epoch)
 
         start_frame = self.get_frame_by_epoch(start_epoch)

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -178,12 +178,12 @@ class SafeBorder(Web3Converter):
         last_finalized_request_id_epoch = self.get_epoch_by_slot(self._get_last_finalized_withdrawal_request_slot())
         # Since we are looking for the safe border epoch, we can start from the last finalized withdrawal request epoch
         # or the earliest activation epoch among the given validators for optimization
-        earliest_activation_epoch = min([v.validator.activation_epoch for v in validators], default=0)
+        earliest_activation_epoch = min((v.validator.activation_epoch for v in validators), default=0)
         start_epoch = max(last_finalized_request_id_epoch, earliest_activation_epoch)
 
         # We can stop searching for the slashed epoch when we reach the reference epoch
         # or the max possible earliest slashed epoch for the given validators
-        withdrawable_epoch = min([v.validator.withdrawable_epoch for v in validators])
+        withdrawable_epoch = min(v.validator.withdrawable_epoch for v in validators)
         max_possible_earliest_slashed_epoch = EpochNumber(withdrawable_epoch - EPOCHS_PER_SLASHINGS_VECTOR)
         end_epoch = min(self.blockstamp.ref_epoch, max_possible_earliest_slashed_epoch)
 

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -187,8 +187,8 @@ class SafeBorder(Web3Converter):
         max_possible_earliest_slashed_epoch = EpochNumber(withdrawable_epoch - EPOCHS_PER_SLASHINGS_VECTOR)
         end_epoch = min(self.blockstamp.ref_epoch, max_possible_earliest_slashed_epoch)
 
-        start_frame = self.get_frame_by_epoch(start_epoch)
-        end_frame = self.get_frame_by_epoch(end_epoch)
+        start_frame = self.get_frame_by_epoch(EpochNumber(start_epoch))
+        end_frame = self.get_frame_by_epoch(EpochNumber(end_epoch))
 
         slashed_pubkeys = set(v.validator.pubkey for v in validators)
 

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -11,10 +11,10 @@ from tests.factory.blockstamp import ReferenceBlockStampFactory
 from tests.factory.configs import OracleReportLimitsFactory
 from tests.factory.no_registry import ValidatorFactory, ValidatorStateFactory
 
-FAR_FUTURE_EPOCH = 2 ** 64 - 1
-MIN_VALIDATOR_WITHDRAWABILITY_DELAY = 2 ** 8
-EPOCHS_PER_SLASHINGS_VECTOR = 2 ** 13
-SLOTS_PER_EPOCH = 2 ** 5
+FAR_FUTURE_EPOCH = 2**64 - 1
+MIN_VALIDATOR_WITHDRAWABILITY_DELAY = 2**8
+EPOCHS_PER_SLASHINGS_VECTOR = 2**13
+SLOTS_PER_EPOCH = 2**5
 SLOT_TIME = 12
 
 
@@ -247,7 +247,7 @@ def test_get_earliest_slashed_epoch_slashing_after_exit(safe_border, past_blocks
             slashed=True,
             exit_epoch=exit_epoch,
             withdrawable_epoch=non_withdrawable_epoch,
-            activation_epoch=exit_epoch - EPOCHS_PER_SLASHINGS_VECTOR - 25
+            activation_epoch=exit_epoch - EPOCHS_PER_SLASHINGS_VECTOR - 25,
         )
     )
 
@@ -256,7 +256,7 @@ def test_get_earliest_slashed_epoch_slashing_after_exit(safe_border, past_blocks
             slashed=True,
             exit_epoch=exit_epoch + 1,
             withdrawable_epoch=non_withdrawable_epoch + 25,
-            activation_epoch=exit_epoch - EPOCHS_PER_SLASHINGS_VECTOR - 20
+            activation_epoch=exit_epoch - EPOCHS_PER_SLASHINGS_VECTOR - 20,
         )
     )
     safe_border._slashings_in_frame = Mock(side_effect=lambda frame, slashed_pubkeys: frame >= 74)

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -256,13 +256,13 @@ def test_get_earliest_slashed_epoch_slashing_after_exit(safe_border, past_blocks
             slashed=True,
             exit_epoch=exit_epoch + 1,
             withdrawable_epoch=non_withdrawable_epoch + 25,
-            activation_epoch=exit_epoch - EPOCHS_PER_SLASHINGS_VECTOR - 20,
+            activation_epoch=exit_epoch - EPOCHS_PER_SLASHINGS_VECTOR - 300,
         )
     )
-    safe_border._slashings_in_frame = Mock(side_effect=lambda frame, slashed_pubkeys: frame >= 74)
+    safe_border._slashings_in_frame = Mock(side_effect=lambda frame, slashed_pubkeys: frame >= 45)
     safe_border.w3.lido_validators.get_lido_validators = Mock(return_value=[validator1, validator2])
     earliest_slashed_epoch = safe_border._get_earliest_slashed_epoch_among_incomplete_slashings()
-    assert earliest_slashed_epoch == 740
+    assert earliest_slashed_epoch == 450
 
 
 def test_get_bunker_start_or_last_successful_report_epoch_no_bunker_start(safe_border, past_blockstamp):

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -1,11 +1,12 @@
-import pytest
 from dataclasses import dataclass
-
 from unittest.mock import Mock
+
+import pytest
+
+from src.modules.submodules.consensus import ChainConfig, FrameConfig
+from src.providers.consensus.types import ValidatorState
 from src.services.safe_border import SafeBorder
 from src.web3py.extensions.lido_validators import Validator
-from src.providers.consensus.types import ValidatorState
-from src.modules.submodules.consensus import ChainConfig, FrameConfig
 from tests.factory.blockstamp import ReferenceBlockStampFactory
 from tests.factory.configs import OracleReportLimitsFactory
 from tests.factory.no_registry import ValidatorFactory, ValidatorStateFactory
@@ -75,16 +76,6 @@ def test_calc_validator_slashed_epoch_from_state_undetectable(safe_border):
     validator = create_validator_stub(exit_epoch, withdrawable_epoch)
 
     assert safe_border._predict_earliest_slashed_epoch(validator) is None
-
-
-def test_filter_validators_with_earliest_exit_epoch(safe_border):
-    validators = [
-        create_validator_stub(100, 105),
-        create_validator_stub(102, 107),
-        create_validator_stub(103, 108),
-    ]
-
-    assert safe_border._filter_validators_with_earliest_exit_epoch(validators) == [validators[0]]
 
 
 def test_get_negative_rebase_border_epoch(safe_border, past_blockstamp):

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -241,13 +241,9 @@ def test_get_earliest_slashed_epoch_slashing_after_exit(safe_border, past_blocks
         exit_epoch + 1, non_withdrawable_epoch + 15, True
     )
     safe_border.w3.lido_validators.get_lido_validators = Mock(return_value=[validator1])
-    safe_border._find_earliest_slashed_epoch_rounded_to_frame = Mock(return_value=1331)
-
     earliest_slashed_epoch1 = safe_border._get_earliest_slashed_epoch_among_incomplete_slashings()
 
     safe_border.w3.lido_validators.get_lido_validators = Mock(return_value=[validator1, validator2])
-    safe_border._find_earliest_slashed_epoch_rounded_to_frame = Mock(return_value=1331)
-
     earliest_slashed_epoch2 = safe_border._get_earliest_slashed_epoch_among_incomplete_slashings()
     assert earliest_slashed_epoch2 < earliest_slashed_epoch1
 

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -214,6 +214,8 @@ def test_get_earliest_slashed_epoch_among_incomplete_slashings_at_least_one_unpr
 
 
 ###
+# Test should ensure that there is no filtering applied to the inputs of _find_earliest_slashed_epoch_rounded_to_frame.
+# Previously under some conditions we could trap into situation printed below, because of the exit_epoch filtering.
 # validator 1:
 # --|-------------|-------|-----|------------->
 #   initiate      slashed exit  withdrawable
@@ -230,7 +232,7 @@ def test_get_earliest_slashed_epoch_among_incomplete_slashings_at_least_one_unpr
 #     safe
 #     border
 ###
-def test_get_earliest_slashed_epoch_slashing_after_exit(safe_border, past_blockstamp, lido_validators):
+def test_get_earliest_slashed_epcoh_if_exiting_validator_slashed(safe_border, past_blockstamp, lido_validators):
     # in binary search:
     # start frame = 73
     # end frame = 101


### PR DESCRIPTION
# What

In the bunker mode we doesn't want to filter by earliest exit epoch.

