### PR TITLE
fix: Infinity loop in force ejection

### DIFF
--- a/src/services/exit_order_iterator.py
+++ b/src/services/exit_order_iterator.py
@@ -340,7 +340,7 @@ class ValidatorExitIterator:
         result: list[tuple[NodeOperatorGlobalIndex, LidoValidator]] = []
 
         # Extra validators limited by VEBO report
-        while self.index != self.max_validators_to_exit:
+        while self.index < self.max_validators_to_exit:
             for no_stats in sorted(self.node_operators_stats.values(), key=self.no_remaining_forced_predicate):
                 if self._no_force_predicate(no_stats) == 0:
                     # The current and all subsequent NOs in the list has no forced validators to exit. Cycle done
@@ -356,6 +356,8 @@ class ValidatorExitIterator:
                     self.index += 1
                     result.append((gid, self._eject_validator(gid)))
                     break
+            else:
+                break
 
         return result
 

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -434,6 +434,61 @@ def test_get_remaining_forced_validators(iterator):
     assert len(vals) == 1
 
 
+@pytest.mark.unit
+def test_get_remaining_forced_validators_all_predictable(iterator):
+    iterator.max_validators_to_exit = 10
+    iterator.index = 5
+    sm = StakingModuleFactory.build(id=1)
+
+    iterator.node_operators_stats = {
+        (1, 1): NodeOperatorStatsFactory.build(
+            predictable_validators=10,
+            force_exit_to=9,
+            node_operator=NodeOperatorFactory.build(id=1, staking_module=sm),
+        ),
+        (1, 2): NodeOperatorStatsFactory.build(
+            predictable_validators=10,
+            force_exit_to=9,
+            node_operator=NodeOperatorFactory.build(id=2, staking_module=sm),
+        ),
+    }
+
+    iterator.exitable_validators = {
+        (1, 1): [],
+        (1, 2): [],
+    }
+
+    vals = iterator.get_remaining_forced_validators()
+
+    assert len(vals) == 0
+
+
+def test_get_remaining_forced_validators_no_node_operators(iterator):
+    iterator.node_operators_stats = {}
+    vals = iterator.get_remaining_forced_validators()
+    assert len(vals) == 0
+
+
+def test_get_remaining_forced_validators_no_more_place_in_report(iterator):
+    iterator.max_validators_to_exit = 10
+    iterator.index = 10
+
+    iterator.node_operators_stats = {
+        (1, 1): NodeOperatorStatsFactory.build(
+            predictable_validators=10,
+            force_exit_to=5,
+            node_operator=NodeOperatorFactory.build(id=1, staking_module=StakingModuleFactory.build(id=1)),
+        ),
+    }
+
+    iterator.exitable_validators = {
+        (1, 1): [LidoValidatorFactory.build(index=5)],
+    }
+
+    vals = iterator.get_remaining_forced_validators()
+    assert len(vals) == 0
+
+
 def test_lowest_validators_index_predicate(iterator):
     iterator.node_operators_stats = {
         (1, 1): NodeOperatorStatsFactory.build(


### PR DESCRIPTION
In case when all NO have forced limit flag and don't have exitable validators to eject, force_eject method gets into inf loop