### PR TITLE
[PoC] Very ugly fixes to achieve reproducible builds of Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+Dockerfile
+RECORD
 __pycache__
 *.pyc
 *.pyo


### PR DESCRIPTION
## Changes

- clearing log files generated while an image is being build
- clearing LD auxilary cache
- disabled generation pyc for pip
- deleting generated pyc after poetry execution
- deleting RECORD files from python packages (content is randomized for some reason?)
- introduced CFLAGS to make repeatable build of shared library from lru-dict (sub-dep of web3)

## Docker tricks

Just an example of how to build:

```
SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) docker buildx build --no-cache --output type=docker,name=lidofinance/lido-oracle,push=false,rewrite-timestamp=true .
```
Variable SOURCE_DATE_EPOCH uses a timestamp from the latest git commit, which is later used as reference point later to rewrite timestamps inside of image layers.

### BuildKit

Also you need BuildKit >= 0.13, because versions up to 0.12 are buggy. I've used this:

```
$ docker buildx inspect | grep -i buildkit
Name:          buildkit-container
Name:                  buildkit-container0
BuildKit daemon flags: --allow-insecure-entitlement=network.host
BuildKit version:      v0.20.1
 org.mobyproject.buildkit.worker.executor:         oci
 org.mobyproject.buildkit.worker.hostname:         e299ecd707a9
 org.mobyproject.buildkit.worker.network:          host
 org.mobyproject.buildkit.worker.oci.process-mode: sandbox
 org.mobyproject.buildkit.worker.selinux.enabled:  false
 org.mobyproject.buildkit.worker.snapshotter:      overlayfs
```

PS: Don't use this PR, it's very ugly and just PoC ¯\_(ツ)_/¯

## Related docs
* https://reproducible-builds.org/docs/source-date-epoch/
* https://docs.docker.com/build/ci/github-actions/reproducible-builds/
