### PR TITLE
[CSM] feat: reset main cycle timeout

### DIFF
--- a/src/modules/csm/csm.py
+++ b/src/modules/csm/csm.py
@@ -210,7 +210,8 @@ class CSOracle(BaseModule, ConsensusModule):
                 logger.info({"msg": "Checkpoints were prepared for an outdated epochs range, stop processing"})
                 raise ValueError("Outdated checkpoint")
             processor.exec(checkpoint)
-
+            # Reset BaseOracle cycle timeout to avoid timeout errors during long checkpoints processing
+            self._reset_cycle_timeout()
         return self.state.is_fulfilled
 
     def make_rewards_tree(self, shares: dict[NodeOperatorId, Shares]) -> RewardsTree:

--- a/src/modules/submodules/oracle_module.py
+++ b/src/modules/submodules/oracle_module.py
@@ -1,4 +1,5 @@
 import logging
+import signal
 import time
 import traceback
 from abc import abstractmethod, ABC
@@ -111,6 +112,12 @@ class BaseModule(ABC):
             logger.error({'msg': 'IPFS provider error.', 'error': str(error)})
         except ValueError as error:
             logger.error({'msg': 'Unexpected error.', 'error': str(error)})
+
+    @staticmethod
+    def _reset_cycle_timeout():
+        """Reset the timeout timer for the current cycle."""
+        logger.info({'msg': f'Reset running cycle timeout to {variables.MAX_CYCLE_LIFETIME_IN_SECONDS} seconds'})
+        signal.setitimer(signal.ITIMER_REAL, variables.MAX_CYCLE_LIFETIME_IN_SECONDS)
 
     @staticmethod
     def _sleep_cycle():


### PR DESCRIPTION
Currently, oracle instance can be interrupted by general Timeout in valid collecting case.

Fix can be checked by this Proof-of-Concept:
```python
import signal
import time
from timeout_decorator import timeout


@timeout(5)
def long_running_task():
    print("Start...")
    for i in range(10):
        print(f"Iter {i}")
        time.sleep(4)
        reset_timeout(5)
    print("Finished")


def reset_timeout(new_timeout):
    signal.setitimer(signal.ITIMER_REAL, new_timeout)
    print(f"Reset timeout to {new_timeout} seconds")


long_running_task()
```