### PR TITLE
Reproducability validation [SRE-2530]

### DIFF
--- a/.github/workflows/reproducability.yml
+++ b/.github/workflows/reproducability.yml
@@ -1,0 +1,111 @@
+---
+name: Test Docker image reproducibility
+
+"on":
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build1:
+    runs-on: ubuntu-latest
+    outputs:
+      sha256: ${{ steps.hash.outputs.sha256 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v6.15.0
+        with:
+          push: false
+          load: true
+          outputs: type=docker,dest=image.tar,rewrite-timestamp=true
+          provenance: false
+        env:
+          SOURCE_DATE_EPOCH: 0
+
+      - name: Compute SHA256
+        id: hash
+        run: echo "sha256=$(sha256sum image.tar | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Report image hash
+        run: |
+          echo "Hash from the second image build: ${{ steps.hash.outputs.sha256 }}"
+
+  build2:
+    runs-on: ubuntu-latest
+    outputs:
+      sha256: ${{ steps.hash.outputs.sha256 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          push: false
+          load: true
+          outputs: type=docker,dest=image.tar,rewrite-timestamp=true
+          provenance: false
+        env:
+          SOURCE_DATE_EPOCH: 0
+
+      - name: Compute SHA256
+        id: hash
+        run: echo "sha256=$(sha256sum image.tar | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Report image hash
+        run: |
+          echo "Hash from the second image build: ${{ steps.hash.outputs.sha256 }}"
+
+  reproducibility:
+    runs-on: ubuntu-latest
+    needs:
+      - build1
+      - build2
+    steps:
+      - name: Fail if empty
+        if: ${{ needs.build1.outputs.sha256 == '' }}
+        run: |
+          echo needs.build1.outputs.sha256 is ${{ needs.build1.outputs.sha256 }}
+          exit 1
+      - name: Report image Hash
+        run: |
+          echo "Hash from the first image build: ${{ needs.build1.outputs.sha256 }}"
+          echo "Hash from the second image build: ${{ needs.build2.outputs.sha256 }}"
+
+      - name: Check if match
+        if: ${{ needs.build1.outputs.sha256 != needs.build2.outputs.sha256 }}
+        run: |
+          echo ${{ needs.build1.outputs.sha256 }} != ${{ needs.build2.outputs.sha256 }}
+          exit 1


### PR DESCRIPTION
This code validates that we can (re)build the same tar file for a given commit twice. It won't check for high-level things (like properly pinned dependencies), but it checks if there are no stray non-deterministic files in the image (caches, timestamps, etc).

Won't work without https://github.com/lidofinance/lido-oracle/pull/663

Example of working workflow is here:  https://github.com/tdhq-org/lido-oracle/actions/runs/14155927778
Example of failed workflow (when image is not reproducible) is here: https://github.com/tdhq-org/lido-oracle/actions/runs/14158190103