### PR TITLE
Feature/orc 108 vebo remove weight predicate

### DIFF
--- a/src/modules/ejector/ejector.py
+++ b/src/modules/ejector/ejector.py
@@ -122,7 +122,6 @@ class Ejector(BaseModule, ConsensusModule):
         chain_config = self.get_chain_config(blockstamp)
         validators_iterator = iter(ValidatorExitIterator(
             w3=self.w3,
-            consensus_version=self.get_consensus_version(blockstamp),
             blockstamp=blockstamp,
             seconds_per_slot=chain_config.seconds_per_slot
         ))

--- a/src/providers/execution/contracts/oracle_daemon_config.py
+++ b/src/providers/execution/contracts/oracle_daemon_config.py
@@ -42,10 +42,6 @@ class OracleDaemonConfigContract(ContractInterface):
         return self._get('REBASE_CHECK_DISTANT_EPOCH_DISTANCE', block_identifier)
 
     @lru_cache(maxsize=1)
-    def node_operator_network_penetration_threshold_bp(self, block_identifier: BlockIdentifier = 'latest') -> int:
-        return self._get('NODE_OPERATOR_NETWORK_PENETRATION_THRESHOLD_BP', block_identifier)
-
-    @lru_cache(maxsize=1)
     def prediction_duration_in_slots(self, block_identifier: BlockIdentifier = 'latest') -> int:
         return self._get('PREDICTION_DURATION_IN_SLOTS', block_identifier)
 

--- a/src/services/exit_order_iterator.py
+++ b/src/services/exit_order_iterator.py
@@ -63,12 +63,10 @@ class ValidatorExitIterator:
     def __init__(
         self,
         w3: Web3,
-        consensus_version: int,
         blockstamp: ReferenceBlockStamp,
         seconds_per_slot: int,
     ):
         self.w3 = w3
-        self.consensus_version = consensus_version
         self.blockstamp = blockstamp
         self.seconds_per_slot = seconds_per_slot
 

--- a/src/services/exit_order_iterator.py
+++ b/src/services/exit_order_iterator.py
@@ -57,7 +57,6 @@ class ValidatorExitIterator:
     exitable_validators: dict[NodeOperatorGlobalIndex, list[LidoValidator]] = {}
 
     max_validators_to_exit: int = 0
-    no_penetration_threshold: float = 0
 
     eth_validators_effective_balance: Gwei = Gwei(0)
 
@@ -160,10 +159,7 @@ class ValidatorExitIterator:
             self.blockstamp.block_hash,
         ).max_validator_exit_requests_per_report
 
-        self.no_penetration_threshold = self.w3.lido_contracts.oracle_daemon_config.node_operator_network_penetration_threshold_bp(
-            block_identifier=self.blockstamp.block_hash,
-        ) / TOTAL_BASIS_POINTS
-
+        self.eth_validators_count = ilen(v for v in self.w3.cc.get_validators(self.blockstamp) if not is_on_exit(v))
         self.eth_validators_effective_balance = self._calculate_effective_balance_non_exiting_validators(self.w3.cc.get_validators(self.blockstamp))
 
     @staticmethod
@@ -225,11 +221,6 @@ class ValidatorExitIterator:
             - self._no_force_predicate(node_operator),
             - self._no_soft_predicate(node_operator),
             - self._max_share_rate_coefficient_predicate(node_operator),
-            - self._stake_weight_coefficient_predicate(
-                node_operator,
-                self.eth_validators_effective_balance,
-                self.no_penetration_threshold,
-            ),
             - node_operator.predictable_validators,
             self._lowest_validator_index_predicate(node_operator),
         )
@@ -263,19 +254,6 @@ class ValidatorExitIterator:
 
         max_validators_count = int(max_share_rate * self.total_lido_validators)
         return max(node_operator.module_stats.predictable_validators - max_validators_count, 0)
-
-    @staticmethod
-    def _stake_weight_coefficient_predicate(
-        node_operator: NodeOperatorStats,
-        total_effective_balance: Gwei,
-        no_penetration: float,
-    ) -> int:
-        """
-        The higher coefficient the higher priority to eject validator
-        """
-        if total_effective_balance * no_penetration < node_operator.predictable_effective_balance:
-            return node_operator.total_age
-        return 0
 
     def _lowest_validator_index_predicate(self, node_operator: NodeOperatorStats) -> int:
         validators = self.exitable_validators[(

--- a/tests/integration/contracts/test_oracle_daemon_config.py
+++ b/tests/integration/contracts/test_oracle_daemon_config.py
@@ -26,11 +26,6 @@ def test_oracle_daemon_config_contract(oracle_daemon_config_contract, caplog):
                 lambda response: check_value_type(response, int),
             ),
             (
-                'node_operator_network_penetration_threshold_bp',
-                None,
-                lambda response: check_value_type(response, int) and response < TOTAL_BASIS_POINTS,
-            ),
-            (
                 'prediction_duration_in_slots',
                 None,
                 lambda response: check_value_type(response, int),

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -282,34 +282,6 @@ def test_max_share_rate_coefficient_predicate(iterator):
 
 
 @pytest.mark.unit
-def test_stake_weight_coefficient_predicate(iterator):
-    nos = [
-        NodeOperatorStatsFactory.build(
-            predictable_validators=900,
-            predictable_effective_balance=900 * 32 * 10**9,
-            total_age=3000,
-        ),
-        NodeOperatorStatsFactory.build(
-            predictable_validators=1010,
-            predictable_effective_balance=1010 * 32 * 10**9,
-            total_age=2000,
-        ),
-        NodeOperatorStatsFactory.build(
-            predictable_validators=2010,
-            predictable_effective_balance=2010 * 32 * 10**9,
-            total_age=1000,
-        ),
-    ]
-
-    sorted_nos = sorted(
-        nos,
-        key=lambda x: -iterator._stake_weight_coefficient_predicate(x, 10000 * 32 * 10**9, 0.1),
-    )
-
-    assert [nos[1], nos[2], nos[0]] == sorted_nos
-
-
-@pytest.mark.unit
 def test_get_remaining_forced_validators(iterator):
     iterator.max_validators_to_exit = 10
     iterator.index = 5

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -27,7 +27,6 @@ class NodeOperatorStatsFactory(Web3DataclassFactory[NodeOperatorStats]):
 def iterator(web3, contracts, lido_validators):
     return ValidatorExitIterator(
         web3,
-        2,
         ReferenceBlockStampFactory.build(),
         12,
     )
@@ -190,6 +189,10 @@ def test_no_predicate(iterator):
         ),
     )
 
+    result = iterator._no_predicate(node_operator_1)
+
+    assert result == (-50, -75, -185, -100, 10)
+
     node_operator_2 = NodeOperatorStatsFactory.build(
         predictable_validators=2000,
         predictable_effective_balance=Gwei(100 * 32 * 10**9),
@@ -204,10 +207,10 @@ def test_no_predicate(iterator):
     )
 
     result = iterator._no_predicate(node_operator_2)
-    assert result == (-1950, -1975, -185, 0, -2000, 20)
+    assert result == (-1950, -1975, -185, -2000, 20)
 
     result = iterator._no_predicate(node_operator_1)
-    assert result == (-50, -75, -185, -1000, -100, 10)
+    assert result == (-50, -75, -185, -100, 10)
 
 
 @pytest.mark.unit

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -149,7 +149,6 @@ def test_eject_validator(iterator):
     assert iterator.node_operators_stats[(1, 1)].total_age < prev_total_age
 
     iterator.max_validators_to_exit = 3
-    iterator.eth_validators_effective_balance = Gwei(1000 * 32 * 10**9)
     iterator._load_blockchain_state = Mock()
 
     validators_to_eject = list(iterator)
@@ -167,7 +166,6 @@ def test_eject_validator(iterator):
 
 @pytest.mark.unit
 def test_no_predicate(iterator):
-    iterator.eth_validators_effective_balance = Gwei(1000 * 32 * 10**9)
     iterator.total_lido_validators = 1000
     iterator.no_penetration_threshold = 0.1
 
@@ -188,10 +186,6 @@ def test_no_predicate(iterator):
             staking_module=StakingModuleFactory.build(priority_exit_share_threshold=0.15 * 1000),
         ),
     )
-
-    result = iterator._no_predicate(node_operator_1)
-
-    assert result == (-50, -75, -185, -100, 10)
 
     node_operator_2 = NodeOperatorStatsFactory.build(
         predictable_validators=2000,

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -150,7 +150,6 @@ def test_eject_validator(iterator):
     assert iterator.node_operators_stats[(1, 1)].total_age < prev_total_age
 
     iterator.max_validators_to_exit = 3
-    iterator.no_penetration_threshold = 0.1
     iterator.eth_validators_effective_balance = Gwei(1000 * 32 * 10**9)
     iterator._load_blockchain_state = Mock()
 


### PR DESCRIPTION
## Description
1. Removed _stake_weight_coefficient_predicate 

Contracts:
1. NODE_OPERATOR_NETWORK_PENETRATION_THRESHOLD_BP can be removed from map https://github.com/lidofinance/core/blob/9a5a20a2044bcf904603a08ac4eee367b7f2dc2e/contracts/0.8.9/OracleDaemonConfig.sol#L13-L13

## Related Issue/Task
- Related task: ORC-108
- Epic: oracle-v7

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [ ] New tests added (if applicable)
