### PR TITLE
Feature/orc 363 fix tests for vaults

### DIFF
--- a/tests/modules/accounting/test_withdrawal_integration.py
+++ b/tests/modules/accounting/test_withdrawal_integration.py
@@ -26,6 +26,8 @@ def subject(web3, past_blockstamp, chain_config, frame_config, contracts, keys_a
     return Withdrawal(web3, past_blockstamp, chain_config, frame_config)
 
 
+@pytest.mark.mainnet
+@pytest.mark.integration
 def test_happy_path(subject, past_blockstamp):
     withdrawal_vault_balance = subject.w3.lido_contracts.get_withdrawal_balance(past_blockstamp)
     el_rewards_vault_balance = subject.w3.lido_contracts.get_el_vault_balance(past_blockstamp)

--- a/tests/modules/accounting/test_withdrawal_unit.py
+++ b/tests/modules/accounting/test_withdrawal_unit.py
@@ -35,8 +35,10 @@ def subject(web3, past_blockstamp, chain_config, frame_config, contracts, keys_a
 @pytest.mark.unit
 def test_returns_empty_batch_if_there_is_no_requests(subject: Withdrawal):
     subject._has_unfinalized_requests = Mock(return_value=False)
+    subject.w3.lido_contracts.withdrawal_queue_nft.is_paused = Mock(return_value=False)
     result = subject.get_finalization_batches(True, 100, 0, 0)
 
+    subject.w3.lido_contracts.withdrawal_queue_nft.is_paused.assert_called_once_with(subject.blockstamp.block_hash)
     assert result == []
 
 
@@ -45,6 +47,7 @@ def test_returns_empty_batch_if_paused(subject: Withdrawal):
     subject.w3.lido_contracts.withdrawal_queue_nft.is_paused = Mock(return_value=True)
     result = subject.get_finalization_batches(True, 100, 0, 0)
 
+    subject.w3.lido_contracts.withdrawal_queue_nft.is_paused.assert_called_once_with(subject.blockstamp.block_hash)
     assert result == []
 
 
@@ -52,11 +55,15 @@ def test_returns_empty_batch_if_paused(subject: Withdrawal):
 def test_returns_batch_if_there_are_finalizable_requests(subject: Withdrawal):
     subject._has_unfinalized_requests = Mock(return_value=True)
     subject._get_available_eth = Mock(return_value=100)
+    subject.w3.lido_contracts.withdrawal_queue_nft.is_paused = Mock(return_value=False)
 
     subject.safe_border_service.get_safe_border_epoch = Mock(return_value=0)
     subject._calculate_finalization_batches = Mock(return_value=[1, 2, 3])
 
-    assert subject.get_finalization_batches(True, 100, 0, 0) == [1, 2, 3]
+    result = subject.get_finalization_batches(True, 100, 0, 0)
+
+    subject.w3.lido_contracts.withdrawal_queue_nft.is_paused.assert_called_once_with(subject.blockstamp.block_hash)
+    assert result == [1, 2, 3]
 
 
 @pytest.mark.unit
@@ -67,6 +74,7 @@ def test_no_available_eth_to_cover_wc(subject: Withdrawal):
 
     result = subject.get_finalization_batches(False, 100, 0, 0)
 
+    subject.w3.lido_contracts.withdrawal_queue_nft.is_paused.assert_called_once_with(subject.blockstamp.block_hash)
     assert result == []
 
 

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -101,6 +101,7 @@ def test_ejector_execute_module_on_pause(ejector: Ejector, blockstamp: BlockStam
 @pytest.mark.unit
 def test_ejector_build_report(ejector: Ejector, ref_blockstamp: ReferenceBlockStamp) -> None:
     ejector.get_validators_to_eject = Mock(return_value=[])
+    ejector.w3.lido_contracts.get_ejector_last_processing_ref_slot = Mock(return_value=ref_blockstamp)
     result = ejector.build_report(ref_blockstamp)
     _, ref_slot, _, _, data = result
     assert ref_slot == ref_blockstamp.ref_slot, "Unexpected blockstamp.ref_slot"
@@ -108,6 +109,7 @@ def test_ejector_build_report(ejector: Ejector, ref_blockstamp: ReferenceBlockSt
 
     ejector.build_report(ref_blockstamp)
     ejector.get_validators_to_eject.assert_called_once_with(ref_blockstamp)
+    ejector.w3.lido_contracts.get_ejector_last_processing_ref_slot.assert_called_once()
 
 
 class SimpleIterator:
@@ -197,7 +199,8 @@ class TestGetValidatorsToEject:
             assert result == [validators[0], *validators[2:]], "Unexpected validators to eject"
 
 
-@pytest.mark.unit
+@pytest.mark.mainnet
+@pytest.mark.possible_integration
 @pytest.mark.usefixtures("contracts")
 def test_get_unfinalized_steth(ejector: Ejector, blockstamp: BlockStamp) -> None:
     result = ejector.w3.lido_contracts.withdrawal_queue_nft.unfinalized_steth(blockstamp.block_hash)
@@ -565,7 +568,8 @@ class TestChurnLimit:
             ejector.w3.cc.get_validators.assert_called_once_with(ref_blockstamp)
 
 
-@pytest.mark.unit
+@pytest.mark.mainnet
+@pytest.mark.possible_integration
 def test_get_processing_state(ejector: Ejector, blockstamp: BlockStamp) -> None:
     result = ejector.w3.lido_contracts.validators_exit_bus_oracle.get_processing_state(blockstamp.block_hash)
     assert isinstance(result, EjectorProcessingState), "Unexpected processing state response"


### PR DESCRIPTION
## Description
feat/vaults-pectra tested locally on the Sepolia testnet. There are differences between the Sepolia chain state and the mainnet used in our tests (e.g., our tests rely on hardcoded blocks and contract addresses from the mainnet). As a result, a number of tests are blocking local testing on sepolia because the --update-responses flag rewrites mock files based on Sepolia, leading to errors. In this PR:
1. Such tests were identified.
2. Some tests were rewritten to use pure mocks where possible, so they no longer depend on the chain.
3. Some tests were marked with @pytest.mark.possible_integration and @pytest.mark.mainnet if they cannot be run without the mainnet chain, allowing these tests to be skipped when --update-responses is used.

How to run tests?
`poetry run pytest tests --update-responses -m "not mainnet"`

## Related Issue/Task
- Related task: ORC-363
- Epic: feat/vaults-pectra

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
Tests at CI doesnt use --update-responses flag, so there is a proof:
<img width="1267" alt="Снимок экрана 2025-04-10 в 18 14 21" src="https://github.com/user-attachments/assets/39476cf0-4cec-49a4-9d51-6e32514a07c9" />

- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [ ] New tests added (if applicable)
