### PR TITLE
[Part 2] Feature/orc 370 tests improvement 2 remove json mocks and update responses

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,12 +31,15 @@ jobs:
           poetry install --no-interaction --with=dev
 
       - name: Test with pytest
+        timeout-minutes: 60
         run: poetry run pytest --cov=src tests
         env:
           EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}
           CONSENSUS_CLIENT_URI: ${{ secrets.CONSENSUS_CLIENT_URI }}
           KEYS_API_URI: ${{ secrets.KEYS_API_URI }}
+          TESTNET_EXECUTION_CLIENT_URI: ${{ secrets.TESTNET_EXECUTION_CLIENT_URI }}
           TESTNET_CONSENSUS_CLIENT_URI: ${{ secrets.TESTNET_CONSENSUS_CLIENT_URI }}
+          TESTNET_KAPI_URI: ${{ secrets.TESTNET_KAPI_URI }}
           CSM_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F"
 
   linters:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,10 +12,6 @@ In case if you need to test something with using specific responses, you can moc
 
 To run tests with a coverage report, run `pytest --cov=src tests` in the root directory of the repository.
 
-## TODOS
-
-- [ ] run tests marked with possible_integration as a part of integration tests with a real providers
-
 ## Env variables
 
 | Name                        | Description                                | Required | Example value           |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -14,6 +14,8 @@ To run tests with a coverage report, run `pytest --cov=src tests` in the root di
 
 ## Env variables
 
-| Name                        | Description                                | Required | Example value           |
-|-----------------------------|--------------------------------------------|----------|-------------------------|
-| `TESTNET_CONSENSUS_CLIENT_URI` | URI of the Consensus client node for tests | False    | `http://localhost:8545` |
+| Name                           | Description                                                                 | Required | Example value           |
+|--------------------------------|-----------------------------------------------------------------------------|----------|-------------------------|
+| `TESTNET_CONSENSUS_CLIENT_URI` | URI of the consensus client node for tests marked with @pytest.mark.testnet | False    | `http://localhost:8545` |
+| `TESTNET_EXECUTION_CLIENT_URI` | URI of the execution client node for tests marked with @pytest.mark.testnet | False    | `http://localhost:8545` |
+| `TESTNET_KAPI_URI`             | URI of the keys api node for tests marked with @pytest.mark.testnet         | False    | `http://localhost:8545` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ build-backend = "poetry.core.masonry.api"
 markers = [
     "unit: tests with using mocks and don't make external requests",
     "integration: tests with using providers",
-    "possible_integration: tests with using providers, but can be run using mocks",
     "e2e: complex tests with using providers and real Ethereum network",
     "fork: tests with using forked Ethereum network",
     "mainnet: tests that depends on mainnet",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ markers = [
     "mainnet: tests that depends on mainnet",
     "testnet: tests that depends on testnet",
 ]
-addopts = "-s -vv"
+addopts = "-s -vv --strict-markers"
 
 [tool.coverage.run]
 branch = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,11 @@
 import os
 import socket
-from dataclasses import dataclass
 from typing import Final, Generator
 from unittest.mock import Mock, patch
 
 import pytest
 from eth_tester import EthereumTester
 from eth_tester.backends.mock import MockBackend
-from eth_typing import ChecksumAddress
-from hexbytes import HexBytes
 from web3 import EthereumTesterProvider
 
 from src import variables
@@ -90,7 +87,7 @@ def configure_mainnet_tests(request, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def configure_testnet_tests(request, monkeypatch):
-    if request.node.get_closest_marker('testnet'):
+    if request.node.get_closest_marker(TESTNET_MARKER):
         if not all(x[0] for x in [TESTNET_CONSENSUS_CLIENT_URI, TESTNET_EXECUTION_CLIENT_URI, TESTNET_KAPI_URI]):
             pytest.fail(
                 'TESTNET_CONSENSUS_CLIENT_URI, TESTNET_EXECUTION_CLIENT_URI and TESTNET_KAPI_URI '
@@ -179,9 +176,3 @@ def web3_integration() -> Generator[Web3, None, None]:
     )
 
     yield w3
-
-
-@dataclass
-class Account:
-    address: ChecksumAddress
-    _private_key: HexBytes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,12 +123,6 @@ def web3_integration() -> Generator[Web3, None, None]:
 
 
 @pytest.fixture()
-def keys_api_client(request, web3):
-    # TODO: Deprecated, will be removed in next PR
-    pass
-
-
-@pytest.fixture()
 def csm(web3):
     # TODO: Deprecated, will be removed in next PR
     pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,12 +130,6 @@ def contracts(web3, monkeypatch):
 
 
 @pytest.fixture()
-def tx_utils(web3):
-    # TODO: Deprecated, will be removed in next PR
-    pass
-
-
-@pytest.fixture()
 def lido_validators(web3):
     # TODO: Deprecated, will be removed in next PR
     pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -80,6 +80,8 @@ def configure_testnet_tests(request, monkeypatch):
                 'must be set in order to run tests on testnet.'
             )
 
+        # Works only if module fully imported, e.g.
+        # "from src import variables" not "from src.variables import <ENV>"
         monkeypatch.setattr(variables, 'CONSENSUS_CLIENT_URI', TESTNET_CONSENSUS_CLIENT_URI)
         monkeypatch.setattr(variables, 'EXECUTION_CLIENT_URI', TESTNET_EXECUTION_CLIENT_URI)
         monkeypatch.setattr(variables, 'KEYS_API_URI', TESTNET_KAPI_URI)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,12 +129,6 @@ def contracts(web3, monkeypatch):
     monkeypatch.setattr(variables, 'CSM_MODULE_ADDRESS', '0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F')
 
 
-@pytest.fixture()
-def lido_validators(web3):
-    # TODO: Deprecated, will be removed in next PR
-    pass
-
-
 def get_blockstamp_by_state(w3, state_id) -> ReferenceBlockStamp:
     root = w3.cc.get_block_root(state_id).root
     slot_details = w3.cc.get_block_details(root)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,30 +44,19 @@ def check_test_marks_compatibility(request):
     all_test_markers = {x.name for x in request.node.iter_markers()}
 
     if not all_test_markers:
-        pytest.fail(
-            'Test must be marked.'
-        )
+        pytest.fail('Test must be marked.')
 
-    elif (
-        UNIT_MARKER in all_test_markers and
-        {MAINNET_MARKER, TESTNET_MARKER, INTEGRATION_MARKER} & all_test_markers
-    ):
-        pytest.fail(
-            'Test can not be both unit and integration at the same time.'
-        )
+    elif UNIT_MARKER in all_test_markers and {MAINNET_MARKER, TESTNET_MARKER, INTEGRATION_MARKER} & all_test_markers:
+        pytest.fail('Test can not be both unit and integration at the same time.')
 
-    elif (
-        {MAINNET_MARKER, TESTNET_MARKER} & all_test_markers and
-        INTEGRATION_MARKER not in all_test_markers
-    ):
-        pytest.fail(
-            'Test can not be run on mainnet or testnet without integration marker.'
-        )
+    elif {MAINNET_MARKER, TESTNET_MARKER} & all_test_markers and INTEGRATION_MARKER not in all_test_markers:
+        pytest.fail('Test can not be run on mainnet or testnet without integration marker.')
 
 
 @pytest.fixture(autouse=True)
 def configure_unit_tests(request):
     if request.node.get_closest_marker(UNIT_MARKER):
+
         def blocked_connect(*args, **kwargs):
             msg = (
                 'Network access deprecated in unit test! '

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,12 +123,6 @@ def web3_integration() -> Generator[Web3, None, None]:
 
 
 @pytest.fixture()
-def consensus_client(request, web3):
-    # TODO: Deprecated, will be removed in next PR
-    pass
-
-
-@pytest.fixture()
 def keys_api_client(request, web3):
     # TODO: Deprecated, will be removed in next PR
     pass

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,12 +123,6 @@ def web3_integration() -> Generator[Web3, None, None]:
 
 
 @pytest.fixture()
-def csm(web3):
-    # TODO: Deprecated, will be removed in next PR
-    pass
-
-
-@pytest.fixture()
 def contracts(web3, monkeypatch):
     # TODO: Will be applied for mainnet tests only in next PR
     monkeypatch.setattr(variables, 'LIDO_LOCATOR_ADDRESS', '0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb')

--- a/tests/execution/base_interface_test.py
+++ b/tests/execution/base_interface_test.py
@@ -1,4 +1,5 @@
 import unittest
+import pytest
 from unittest.mock import patch, MagicMock, mock_open
 
 from web3 import Web3
@@ -7,6 +8,7 @@ from web3.types import BlockIdentifier
 from src.providers.execution.base_interface import ContractInterface
 
 
+@pytest.mark.unit
 class TestContractInterface(unittest.TestCase):
     def setUp(self):
         # Set up a mock Web3 instance

--- a/tests/integration/contracts/test_lido.py
+++ b/tests/integration/contracts/test_lido.py
@@ -15,17 +15,17 @@ def test_lido_contract_call(lido_contract, accounting_oracle_contract, burner_co
             (
                 'handle_oracle_report',
                 (
-                    1744632011,  # timestamp
+                    1746275159,  # timestamp
                     86400,
                     389746,
-                    9303747261167584000000000,
-                    1337759360109000000000,
-                    119464421677104745350,
+                    9190764598468942000000000,
+                    13771995248000000000,
+                    478072602914417566,
                     0,
                     accounting_oracle_contract.address,
-                    20390705,
+                    11620928,
                     # Call depends on contract state
-                    '0xfbd1037bb43913198d5c8415a1d059afde09bf0dc56e250f5ff2bd2410c16dd2',
+                    '0xffa34bcc5a08c92272a62e591f7afb9cb839134aa08c091ae0c95682fba35da9',
                 ),
                 lambda response: check_value_type(response, LidoReportRebase),
             ),

--- a/tests/metrics/test_healthcheck_server.py
+++ b/tests/metrics/test_healthcheck_server.py
@@ -1,5 +1,7 @@
 # pylint: disable=protected-access
 import unittest
+import pytest
+
 from datetime import datetime, timedelta
 from http import HTTPStatus
 from io import BytesIO
@@ -13,6 +15,7 @@ from src.metrics.healthcheck_server import pulse, PulseRequestHandler
 from src import variables
 
 
+@pytest.mark.unit
 class TestPulseFunction(unittest.TestCase):
 
     @responses.activate
@@ -56,6 +59,7 @@ def _create_mock_request_handler(path):
     return handler
 
 
+@pytest.mark.unit
 class TestPulseRequestHandler(unittest.TestCase):
     def setUp(self):
         # Reset _last_pulse to current time before each test

--- a/tests/metrics/test_healthcheck_server.py
+++ b/tests/metrics/test_healthcheck_server.py
@@ -10,7 +10,7 @@ import responses
 
 import src.metrics.healthcheck_server
 from src.metrics.healthcheck_server import pulse, PulseRequestHandler
-from src.variables import MAX_CYCLE_LIFETIME_IN_SECONDS
+from src import variables
 
 
 class TestPulseFunction(unittest.TestCase):
@@ -74,7 +74,7 @@ class TestPulseRequestHandler(unittest.TestCase):
         """Test that the handler responds with 503 when the last pulse is outdated."""
         # Set the last pulse to an outdated time
         src.metrics.healthcheck_server._last_pulse = datetime.now() - timedelta(
-            seconds=MAX_CYCLE_LIFETIME_IN_SECONDS + 1
+            seconds=variables.MAX_CYCLE_LIFETIME_IN_SECONDS + 1
         )
 
         handler = _create_mock_request_handler('/smth/')

--- a/tests/metrics/test_logging.py
+++ b/tests/metrics/test_logging.py
@@ -154,6 +154,7 @@ def test_convert_bytes_to_hex(input_data, expected_output):
     assert convert_bytes_to_hex(input_data) == expected_output
 
 
+@pytest.mark.unit
 def test_convert_bytes_to_hex_generator():
     gen = byte_generator()
     converted_gen = convert_bytes_to_hex(gen)

--- a/tests/modules/accounting/bunker/conftest.py
+++ b/tests/modules/accounting/bunker/conftest.py
@@ -243,7 +243,7 @@ def mock_get_validators(web3):
 
 
 @pytest.fixture
-def bunker(web3, lido_validators) -> BunkerService:
+def bunker(web3) -> BunkerService:
     """Minimal initialized bunker service"""
     service = BunkerService(web3)
     return service
@@ -255,7 +255,7 @@ def blockstamp():
 
 
 @pytest.fixture
-def abnormal_case(web3, lido_validators, contracts, mock_get_validators, blockstamp) -> AbnormalClRebase:
+def abnormal_case(web3, contracts, mock_get_validators, blockstamp) -> AbnormalClRebase:
     c_conf = ChainConfig(
         slots_per_epoch=1,
         seconds_per_slot=12,

--- a/tests/modules/accounting/bunker/conftest.py
+++ b/tests/modules/accounting/bunker/conftest.py
@@ -134,7 +134,7 @@ def mock_get_eth_distributed_events(abnormal_case):
 
 
 @pytest.fixture
-def mock_get_withdrawal_vault_balance(abnormal_case, contracts):
+def mock_get_withdrawal_vault_balance(abnormal_case):
     def _get_withdrawal_vault_balance(blockstamp: BlockStamp):
         balance = {
             0: 15 * 10**18,
@@ -255,7 +255,7 @@ def blockstamp():
 
 
 @pytest.fixture
-def abnormal_case(web3, contracts, mock_get_validators, blockstamp) -> AbnormalClRebase:
+def abnormal_case(web3, mock_get_validators, blockstamp) -> AbnormalClRebase:
     c_conf = ChainConfig(
         slots_per_epoch=1,
         seconds_per_slot=12,

--- a/tests/modules/accounting/bunker/test_bunker.py
+++ b/tests/modules/accounting/bunker/test_bunker.py
@@ -19,7 +19,6 @@ from tests.modules.accounting.bunker.conftest import simple_ref_blockstamp
 class TestIsBunkerMode:
     @pytest.mark.unit
     @pytest.mark.usefixtures(
-        "contracts",
         "mock_get_config",
         "mock_get_state",
     )
@@ -42,7 +41,6 @@ class TestIsBunkerMode:
 
     @pytest.mark.unit
     @pytest.mark.usefixtures(
-        "contracts",
         "mock_get_config",
         "mock_get_state",
     )
@@ -70,7 +68,6 @@ class TestIsBunkerMode:
 
     @pytest.mark.unit
     @pytest.mark.usefixtures(
-        "contracts",
         "mock_get_config",
         "mock_get_state",
     )
@@ -98,7 +95,6 @@ class TestIsBunkerMode:
 
     @pytest.mark.unit
     @pytest.mark.usefixtures(
-        "contracts",
         "mock_get_config",
         "mock_get_state",
     )
@@ -127,7 +123,6 @@ class TestIsBunkerMode:
 
     @pytest.mark.unit
     @pytest.mark.usefixtures(
-        "contracts",
         "mock_get_config",
         "mock_get_state",
         "mock_total_supply",
@@ -214,7 +209,6 @@ class TestIsBunkerMode:
 )
 def test_get_cl_rebase_for_frame(
     bunker,
-    contracts,
     simulated_post_total_pooled_ether,
     expected_rebase,
 ):

--- a/tests/modules/accounting/bunker/test_bunker_midterm_penalty.py
+++ b/tests/modules/accounting/bunker/test_bunker_midterm_penalty.py
@@ -396,6 +396,7 @@ def test_get_validator_midterm_penalty(
     assert result == expected_penalty
 
 
+@pytest.mark.unit
 def test_cut_slashings_basic():
     slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
     midterm_penalty_epoch = 20
@@ -410,6 +411,7 @@ def test_cut_slashings_basic():
     assert result == expected, f"Expected {expected}, but got {result}"
 
 
+@pytest.mark.unit
 def test_cut_slashings_incorrect_length():
     invalid_length = EPOCHS_PER_SLASHINGS_VECTOR - 1
     slashings = [Gwei(i) for i in range(invalid_length)]
@@ -418,6 +420,7 @@ def test_cut_slashings_incorrect_length():
         MidtermSlashingPenalty._cut_slashings(slashings, 10, 20)
 
 
+@pytest.mark.unit
 def test_cut_slashings_no_obsolete_indexes():
     slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
     midterm_penalty_epoch = 5
@@ -428,6 +431,7 @@ def test_cut_slashings_no_obsolete_indexes():
     assert result == slashings, f"Expected {slashings}, but got {result}"
 
 
+@pytest.mark.unit
 def test_cut_slashings_all_removed():
     slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
     report_ref_epoch = 1

--- a/tests/modules/accounting/test_accounting_module.py
+++ b/tests/modules/accounting/test_accounting_module.py
@@ -190,6 +190,7 @@ def test_get_slots_elapsed_from_last_report(accounting: Accounting):
     assert slots_elapsed == 100 - 70
 
 
+@pytest.mark.unit
 class TestAccountingReportingAllowed:
     def test_env_toggle(self, accounting: Accounting, monkeypatch: pytest.MonkeyPatch, ref_bs: ReferenceBlockStamp):
         accounting._is_bunker = Mock(return_value=True)
@@ -255,6 +256,7 @@ class TestAccountingProcessExtraData:
         submit_extra_data_mock.assert_called_once_with(ref_bs)
 
 
+@pytest.mark.unit
 class TestAccountingSubmitExtraData:
     def test_submit_extra_data_non_empty(
         self,
@@ -274,7 +276,6 @@ class TestAccountingSubmitExtraData:
         accounting.report_contract.submit_report_extra_data_list.assert_called_once_with(extra_data)
         accounting.get_extra_data.assert_called_once_with(ref_bs)
 
-    @pytest.mark.unit
     def test_submit_extra_data_empty(
         self,
         accounting: Accounting,
@@ -493,6 +494,7 @@ def test_is_bunker(
     accounting.bunker_service.is_bunker_mode.assert_not_called()
 
 
+@pytest.mark.unit
 def test_accounting_get_processing_state_no_yet_init_epoch(accounting: Accounting):
     bs = ReferenceBlockStampFactory.build()
 
@@ -509,6 +511,7 @@ def test_accounting_get_processing_state_no_yet_init_epoch(accounting: Accountin
     assert processing_state.main_data_hash == ZERO_HASH
 
 
+@pytest.mark.unit
 def test_accounting_get_processing_state(accounting: Accounting):
     bs = ReferenceBlockStampFactory.build()
     accounting_processing_state = AccountingProcessingStateFactory.build()

--- a/tests/modules/accounting/test_accounting_module.py
+++ b/tests/modules/accounting/test_accounting_module.py
@@ -29,7 +29,7 @@ def silence_logger() -> None:
 
 
 @pytest.fixture
-def accounting(web3, contracts):
+def accounting(web3):
     yield Accounting(web3)
 
 

--- a/tests/modules/accounting/test_safe_border_integration.py
+++ b/tests/modules/accounting/test_safe_border_integration.py
@@ -37,7 +37,7 @@ def subject(
     return SafeBorder(web3, past_blockstamp, ChainConfigFactory.build(), FrameConfigFactory.build())
 
 
-@pytest.mark.possible_integration
+@pytest.mark.unit
 def test_happy_path(subject, past_blockstamp: ReferenceBlockStamp):
     is_bunker_mode = False
 
@@ -46,7 +46,7 @@ def test_happy_path(subject, past_blockstamp: ReferenceBlockStamp):
     )
 
 
-@pytest.mark.possible_integration
+@pytest.mark.unit
 def test_bunker_mode_negative_rebase(subject, past_blockstamp: ReferenceBlockStamp):
     is_bunker_mode = True
 
@@ -58,7 +58,7 @@ def test_bunker_mode_negative_rebase(subject, past_blockstamp: ReferenceBlockSta
     )
 
 
-@pytest.mark.possible_integration
+@pytest.mark.unit
 def test_bunker_mode_associated_slashing_predicted(
     subject: SafeBorder, past_blockstamp: ReferenceBlockStamp, finalization_max_negative_rebase_epoch_shift: int
 ):
@@ -85,7 +85,7 @@ def test_bunker_mode_associated_slashing_predicted(
     )
 
 
-@pytest.mark.possible_integration
+@pytest.mark.unit
 def test_bunker_mode_associated_slashing_unpredicted(
     subject: SafeBorder, past_blockstamp: ReferenceBlockStamp, finalization_max_negative_rebase_epoch_shift: int
 ):

--- a/tests/modules/accounting/test_safe_border_integration.py
+++ b/tests/modules/accounting/test_safe_border_integration.py
@@ -26,7 +26,6 @@ def subject(
     web3,
     contracts,
     keys_api_client,
-    consensus_client,
     lido_validators,
     finalization_max_negative_rebase_epoch_shift,
 ):

--- a/tests/modules/accounting/test_safe_border_integration.py
+++ b/tests/modules/accounting/test_safe_border_integration.py
@@ -24,7 +24,6 @@ def finalization_max_negative_rebase_epoch_shift():
 def subject(
     past_blockstamp,
     web3,
-    contracts,
     finalization_max_negative_rebase_epoch_shift,
 ):
     web3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits = Mock(

--- a/tests/modules/accounting/test_safe_border_integration.py
+++ b/tests/modules/accounting/test_safe_border_integration.py
@@ -25,7 +25,6 @@ def subject(
     past_blockstamp,
     web3,
     contracts,
-    keys_api_client,
     lido_validators,
     finalization_max_negative_rebase_epoch_shift,
 ):

--- a/tests/modules/accounting/test_safe_border_integration.py
+++ b/tests/modules/accounting/test_safe_border_integration.py
@@ -25,7 +25,6 @@ def subject(
     past_blockstamp,
     web3,
     contracts,
-    lido_validators,
     finalization_max_negative_rebase_epoch_shift,
 ):
     web3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits = Mock(

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -45,7 +45,6 @@ def safe_border(
     past_blockstamp,
     web3,
     contracts,
-    lido_validators,
 ):
     web3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits = Mock(
         return_value=OracleReportLimitsFactory.build()
@@ -133,9 +132,7 @@ def test_get_earliest_slashed_epoch_among_incomplete_slashings_no_slashed_valida
     assert safe_border._get_earliest_slashed_epoch_among_incomplete_slashings() is None
 
 
-def test_get_earliest_slashed_epoch_among_incomplete_slashings_withdrawable_validators(
-    safe_border, past_blockstamp, lido_validators
-):
+def test_get_earliest_slashed_epoch_among_incomplete_slashings_withdrawable_validators(safe_border, past_blockstamp):
     withdrawable_epoch = past_blockstamp.ref_epoch - 10
     validators = [create_validator_stub(100, withdrawable_epoch, True)]
     safe_border.w3.lido_validators.get_lido_validators = Mock(return_value=validators)
@@ -143,9 +140,7 @@ def test_get_earliest_slashed_epoch_among_incomplete_slashings_withdrawable_vali
     assert safe_border._get_earliest_slashed_epoch_among_incomplete_slashings() is None
 
 
-def test_get_earliest_slashed_epoch_among_incomplete_slashings_unable_to_predict(
-    safe_border, past_blockstamp, lido_validators
-):
+def test_get_earliest_slashed_epoch_among_incomplete_slashings_unable_to_predict(safe_border, past_blockstamp):
     non_withdrawable_epoch = past_blockstamp.ref_epoch + 10
     validators = [
         create_validator_stub(
@@ -158,9 +153,7 @@ def test_get_earliest_slashed_epoch_among_incomplete_slashings_unable_to_predict
     assert safe_border._get_earliest_slashed_epoch_among_incomplete_slashings() == 1331
 
 
-def test_get_earliest_slashed_epoch_among_incomplete_slashings_all_withdrawable(
-    safe_border, past_blockstamp, lido_validators
-):
+def test_get_earliest_slashed_epoch_among_incomplete_slashings_all_withdrawable(safe_border, past_blockstamp):
     validators = [
         create_validator_stub(
             past_blockstamp.ref_epoch - MIN_VALIDATOR_WITHDRAWABILITY_DELAY, past_blockstamp.ref_epoch - 1, True
@@ -174,7 +167,7 @@ def test_get_earliest_slashed_epoch_among_incomplete_slashings_all_withdrawable(
     assert safe_border._get_earliest_slashed_epoch_among_incomplete_slashings() is None
 
 
-def test_get_earliest_slashed_epoch_among_incomplete_slashings_predicted(safe_border, past_blockstamp, lido_validators):
+def test_get_earliest_slashed_epoch_among_incomplete_slashings_predicted(safe_border, past_blockstamp):
     non_withdrawable_epoch = past_blockstamp.ref_epoch + 10
     validators = [
         create_validator_stub(
@@ -194,7 +187,6 @@ def test_get_earliest_slashed_epoch_among_incomplete_slashings_predicted(safe_bo
 def test_get_earliest_slashed_epoch_among_incomplete_slashings_at_least_one_unpredictable_epoch(
     safe_border,
     past_blockstamp,
-    lido_validators,
 ):
     non_withdrawable_epoch = past_blockstamp.ref_epoch + 10
     validators = [
@@ -230,7 +222,7 @@ def test_get_earliest_slashed_epoch_among_incomplete_slashings_at_least_one_unpr
 #     safe
 #     border
 ###
-def test_get_earliest_slashed_epcoh_if_exiting_validator_slashed(safe_border, past_blockstamp, lido_validators):
+def test_get_earliest_slashed_epcoh_if_exiting_validator_slashed(safe_border, past_blockstamp):
     # in binary search:
     # start frame = 73
     # end frame = 101

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -45,7 +45,6 @@ def safe_border(
     past_blockstamp,
     web3,
     contracts,
-    keys_api_client,
     lido_validators,
 ):
     web3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits = Mock(

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -44,7 +44,6 @@ def safe_border(
     frame_config,
     past_blockstamp,
     web3,
-    contracts,
 ):
     web3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits = Mock(
         return_value=OracleReportLimitsFactory.build()

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -46,7 +46,6 @@ def safe_border(
     web3,
     contracts,
     keys_api_client,
-    consensus_client,
     lido_validators,
 ):
     web3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits = Mock(

--- a/tests/modules/accounting/test_validator_state.py
+++ b/tests/modules/accounting/test_validator_state.py
@@ -125,7 +125,7 @@ def lido_validators(web3):
 
 
 @pytest.fixture
-def validator_state(web3, contracts, lido_validators):
+def validator_state(web3, lido_validators):
     service = LidoValidatorStateService(web3)
     service.w3.lido_contracts.validators_exit_bus_oracle.get_last_requested_validator_indices = Mock(
         return_value=[3, 8]

--- a/tests/modules/accounting/test_validator_state.py
+++ b/tests/modules/accounting/test_validator_state.py
@@ -125,7 +125,7 @@ def lido_validators(web3):
 
 
 @pytest.fixture
-def validator_state(web3, contracts, consensus_client, lido_validators):
+def validator_state(web3, contracts, lido_validators):
     service = LidoValidatorStateService(web3)
     service.w3.lido_contracts.validators_exit_bus_oracle.get_last_requested_validator_indices = Mock(
         return_value=[3, 8]

--- a/tests/modules/accounting/test_withdrawal_integration.py
+++ b/tests/modules/accounting/test_withdrawal_integration.py
@@ -22,9 +22,7 @@ def past_blockstamp(web3_integration):
 
 
 @pytest.fixture
-def subject(
-    web3_integration, past_blockstamp, chain_config, frame_config, contracts, keys_api_client
-):
+def subject(web3_integration, past_blockstamp, chain_config, frame_config, contracts):
     return Withdrawal(web3_integration, past_blockstamp, chain_config, frame_config)
 
 

--- a/tests/modules/accounting/test_withdrawal_integration.py
+++ b/tests/modules/accounting/test_withdrawal_integration.py
@@ -17,13 +17,13 @@ def frame_config():
 
 
 @pytest.fixture
-def past_blockstamp(web3_integration, consensus_client):
+def past_blockstamp(web3_integration):
     return get_blockstamp_by_state(web3_integration, 'finalized')
 
 
 @pytest.fixture
 def subject(
-    web3_integration, past_blockstamp, chain_config, frame_config, contracts, keys_api_client, consensus_client
+    web3_integration, past_blockstamp, chain_config, frame_config, contracts, keys_api_client
 ):
     return Withdrawal(web3_integration, past_blockstamp, chain_config, frame_config)
 

--- a/tests/modules/accounting/test_withdrawal_unit.py
+++ b/tests/modules/accounting/test_withdrawal_unit.py
@@ -25,7 +25,7 @@ def past_blockstamp(web3):
 
 
 @pytest.fixture
-def subject(web3, past_blockstamp, chain_config, frame_config, contracts):
+def subject(web3, past_blockstamp, chain_config, frame_config):
     web3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits = Mock(
         return_value=OracleReportLimitsFactory.build()
     )

--- a/tests/modules/accounting/test_withdrawal_unit.py
+++ b/tests/modules/accounting/test_withdrawal_unit.py
@@ -25,7 +25,7 @@ def past_blockstamp(web3):
 
 
 @pytest.fixture
-def subject(web3, past_blockstamp, chain_config, frame_config, contracts, keys_api_client):
+def subject(web3, past_blockstamp, chain_config, frame_config, contracts):
     web3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits = Mock(
         return_value=OracleReportLimitsFactory.build()
     )

--- a/tests/modules/accounting/test_withdrawal_unit.py
+++ b/tests/modules/accounting/test_withdrawal_unit.py
@@ -20,12 +20,12 @@ def frame_config():
 
 
 @pytest.fixture
-def past_blockstamp(web3, consensus_client):
+def past_blockstamp(web3):
     return ReferenceBlockStampFactory.build()
 
 
 @pytest.fixture
-def subject(web3, past_blockstamp, chain_config, frame_config, contracts, keys_api_client, consensus_client):
+def subject(web3, past_blockstamp, chain_config, frame_config, contracts, keys_api_client):
     web3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits = Mock(
         return_value=OracleReportLimitsFactory.build()
     )

--- a/tests/modules/csm/test_checkpoint.py
+++ b/tests/modules/csm/test_checkpoint.py
@@ -54,11 +54,13 @@ def converter(frame_config: FrameConfig, chain_config: ChainConfig) -> Web3Conve
     return Web3Converter(chain_config, frame_config)
 
 
+@pytest.mark.unit
 def test_checkpoints_iterator_min_epoch_is_not_reached(converter):
     with pytest.raises(MinStepIsNotReached):
         FrameCheckpointsIterator(converter, 100, 600, 109)
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "l_epoch,r_epoch,finalized_epoch,expected_checkpoints",
     [
@@ -135,6 +137,7 @@ def mock_get_state_block_roots_with_duplicates(consensus_client):
     consensus_client.get_state_block_roots = Mock(side_effect=_get_state_block_roots)
 
 
+@pytest.mark.unit
 def test_checkpoints_processor_get_block_roots(consensus_client, mock_get_state_block_roots, converter: Web3Converter):
     state = ...
     finalized_blockstamp = ...
@@ -148,6 +151,7 @@ def test_checkpoints_processor_get_block_roots(consensus_client, mock_get_state_
     assert len([r for r in roots if r is not None]) == 8192
 
 
+@pytest.mark.unit
 def test_checkpoints_processor_get_block_roots_with_duplicates(
     consensus_client, mock_get_state_block_roots_with_duplicates, converter: Web3Converter
 ):
@@ -170,6 +174,7 @@ def mock_get_config_spec(consensus_client):
     consensus_client.get_config_spec = Mock(return_value=bc_spec)
 
 
+@pytest.mark.unit
 def test_checkpoints_processor_select_block_roots(
     consensus_client, mock_get_state_block_roots, mock_get_config_spec, converter: Web3Converter
 ):
@@ -187,6 +192,7 @@ def test_checkpoints_processor_select_block_roots(
     assert selected == [f'0x{r}' for r in range(320, 384)]
 
 
+@pytest.mark.unit
 def test_checkpoints_processor_select_block_roots_out_of_range(
     consensus_client, mock_get_state_block_roots, mock_get_config_spec, converter: Web3Converter
 ):
@@ -221,6 +227,7 @@ def mock_get_attestation_committees(consensus_client):
     consensus_client.get_attestation_committees = Mock(side_effect=_get_attestation_committees)
 
 
+@pytest.mark.unit
 def test_checkpoints_processor_prepare_committees(mock_get_attestation_committees, consensus_client, converter):
     state = ...
     finalized_blockstamp = ...
@@ -243,6 +250,7 @@ def test_checkpoints_processor_prepare_committees(mock_get_attestation_committee
             assert validator.included is False
 
 
+@pytest.mark.unit
 def test_checkpoints_processor_process_attestations(mock_get_attestation_committees, consensus_client, converter):
     state = ...
     finalized_blockstamp = ...
@@ -274,6 +282,7 @@ def test_checkpoints_processor_process_attestations(mock_get_attestation_committ
                 assert validator.included is False
 
 
+@pytest.mark.unit
 def test_checkpoints_processor_process_attestations_undefined_committee(
     mock_get_attestation_committees, consensus_client, converter
 ):
@@ -313,6 +322,7 @@ def mock_get_block_attestations(consensus_client, faker: Faker):
     consensus_client.get_block_attestations = Mock(side_effect=_get_block_attestations)
 
 
+@pytest.mark.unit
 def test_checkpoints_processor_check_duty(
     mock_get_state_block_roots,
     mock_get_attestation_committees,
@@ -338,6 +348,7 @@ def test_checkpoints_processor_check_duty(
     assert len(state.data) == 2048 * 32
 
 
+@pytest.mark.unit
 def test_checkpoints_processor_process(
     mock_get_state_block_roots,
     mock_get_attestation_committees,
@@ -363,6 +374,7 @@ def test_checkpoints_processor_process(
     assert len(state.data) == 2048 * 32
 
 
+@pytest.mark.unit
 def test_checkpoints_processor_exec(
     mock_get_state_block_roots,
     mock_get_attestation_committees,

--- a/tests/modules/csm/test_csm_module.py
+++ b/tests/modules/csm/test_csm_module.py
@@ -31,7 +31,7 @@ def mock_load_state(monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.fixture()
-def module(web3, csm: CSM):
+def module(web3):
     yield CSOracle(web3)
 
 
@@ -41,7 +41,7 @@ def test_init(module: CSOracle):
 
 
 @pytest.mark.unit
-def test_stuck_operators(module: CSOracle, csm: CSM):
+def test_stuck_operators(module: CSOracle):
     module.module = Mock()  # type: ignore
     module.module_id = StakingModuleId(1)
     module.w3.cc = Mock()

--- a/tests/modules/csm/test_log.py
+++ b/tests/modules/csm/test_log.py
@@ -22,11 +22,13 @@ def log(ref_blockstamp: ReferenceBlockStamp, frame: tuple[EpochNumber, EpochNumb
     return FramePerfLog(ref_blockstamp, frame)
 
 
+@pytest.mark.unit
 def test_fields_access(log: FramePerfLog):
     log.operators[NodeOperatorId(42)].validators["100500"].slashed = True
     log.operators[NodeOperatorId(17)].stuck = True
 
 
+@pytest.mark.unit
 def test_log_encode(log: FramePerfLog):
     # Fill in dynamic fields to make sure we have data in it to be encoded.
     log.operators[NodeOperatorId(42)].validators["41337"].perf = AttestationsAccumulator(220, 119)

--- a/tests/modules/csm/test_state.py
+++ b/tests/modules/csm/test_state.py
@@ -18,11 +18,13 @@ def mock_state_file(state_file_path: Path):
     State.file = Mock(return_value=state_file_path)
 
 
+@pytest.mark.unit
 def test_attestation_aggregate_perf():
     aggr = AttestationsAccumulator(included=333, assigned=777)
     assert aggr.perf == pytest.approx(0.4285, abs=1e-4)
 
 
+@pytest.mark.unit
 def test_state_avg_perf():
     state = State()
 
@@ -47,6 +49,7 @@ def test_state_avg_perf():
     assert state.get_network_aggr().perf == 0.5
 
 
+@pytest.mark.unit
 def test_state_frame():
     state = State()
 
@@ -62,6 +65,7 @@ def test_state_frame():
         state.frame
 
 
+@pytest.mark.unit
 def test_state_attestations():
     state = State(
         {
@@ -76,6 +80,7 @@ def test_state_attestations():
     assert network_aggr.included == 500
 
 
+@pytest.mark.unit
 def test_state_load():
     orig = State(
         {
@@ -89,6 +94,7 @@ def test_state_load():
     assert copy.data == orig.data
 
 
+@pytest.mark.unit
 def test_state_clear():
     state = State(
         {
@@ -105,6 +111,7 @@ def test_state_clear():
     assert not state.data
 
 
+@pytest.mark.unit
 def test_state_add_processed_epoch():
     state = State()
     state.add_processed_epoch(EpochNumber(42))
@@ -112,6 +119,7 @@ def test_state_add_processed_epoch():
     assert state._processed_epochs == {EpochNumber(42), EpochNumber(17)}
 
 
+@pytest.mark.unit
 def test_state_inc():
     state = State(
         {
@@ -137,10 +145,12 @@ def test_state_inc():
     )
 
 
+@pytest.mark.unit
 def test_state_file_is_path():
     assert isinstance(State.file(), Path)
 
 
+@pytest.mark.unit
 class TestStateTransition:
     """Tests for State's transition for different l_epoch, r_epoch values"""
 

--- a/tests/modules/csm/test_tree.py
+++ b/tests/modules/csm/test_tree.py
@@ -17,20 +17,24 @@ def tree():
     )
 
 
+@pytest.mark.unit
 def test_non_null_root(tree: Tree):
     assert tree.root
 
 
+@pytest.mark.unit
 def test_encode_decode(tree: Tree):
     decoded = Tree.decode(tree.encode())
     assert decoded.root == tree.root
 
 
+@pytest.mark.unit
 def test_decode_plain_tree_dump(tree: Tree):
     decoded = Tree.decode(TreeJSONEncoder().encode(tree.tree.dump()).encode())
     assert decoded.root == tree.root
 
 
+@pytest.mark.unit
 def test_dump_compatibility(tree: Tree):
     loaded = StandardMerkleTree.load(tree.dump())
     assert loaded.root == tree.root

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -422,6 +422,7 @@ def test_get_total_balance(ejector: Ejector, blockstamp: BlockStamp) -> None:
     ejector.w3.lido_contracts.lido.get_buffered_ether.assert_called_once_with(blockstamp.block_hash)
 
 
+@pytest.mark.unit
 class TestChurnLimit:
     """_get_churn_limit tests"""
 
@@ -435,14 +436,12 @@ class TestChurnLimit:
             )
             yield
 
-    @pytest.mark.unit
     def test_get_churn_limit_no_validators(self, ejector: Ejector, ref_blockstamp: ReferenceBlockStamp) -> None:
         ejector.w3.cc.get_validators = Mock(return_value=[])
         result = ejector._get_churn_limit(ref_blockstamp)
         assert result == constants.MIN_PER_EPOCH_CHURN_LIMIT, "Unexpected churn limit"
         ejector.w3.cc.get_validators.assert_called_once_with(ref_blockstamp)
 
-    @pytest.mark.unit
     def test_get_churn_limit_validators_less_than_min_churn(
         self,
         ejector: Ejector,
@@ -455,7 +454,6 @@ class TestChurnLimit:
             assert result == 4, "Unexpected churn limit"
             ejector.w3.cc.get_validators.assert_called_once_with(ref_blockstamp)
 
-    @pytest.mark.unit
     def test_get_churn_limit_basic(
         self,
         ejector: Ejector,
@@ -488,6 +486,7 @@ def test_get_latest_exit_epoch(ejector: Ejector, blockstamp: BlockStamp) -> None
     assert max_epoch == 42, "Unexpected max epoch"
 
 
+@pytest.mark.unit
 def test_ejector_get_processing_state_no_yet_init_epoch(ejector: Ejector):
     bs = ReferenceBlockStampFactory.build()
 
@@ -503,6 +502,7 @@ def test_ejector_get_processing_state_no_yet_init_epoch(ejector: Ejector):
     assert processing_state.data_submitted == False
 
 
+@pytest.mark.unit
 def test_ejector_get_processing_state(ejector: Ejector):
     bs = ReferenceBlockStampFactory.build()
     accounting_processing_state = EjectorProcessingStateFactory.build()

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -59,7 +59,7 @@ def ref_blockstamp() -> ReferenceBlockStamp:
 
 
 @pytest.fixture()
-def ejector(web3: Web3, contracts: LidoContracts) -> Ejector:
+def ejector(web3: Web3) -> Ejector:
     web3.lido_contracts.validators_exit_bus_oracle.get_consensus_version = Mock(return_value=1)
     return Ejector(web3)
 

--- a/tests/modules/ejector/test_prediction.py
+++ b/tests/modules/ejector/test_prediction.py
@@ -238,7 +238,7 @@ def token_rebased_logs(tr_hashes):
 
 
 @pytest.mark.unit
-def test_get_rewards_no_matching_events(web3, contracts):
+def test_get_rewards_no_matching_events(web3):
     bp = ReferenceBlockStampFactory.build(
         block_number=BlockNumber(14),
         block_timestamp=1675441520,
@@ -264,7 +264,7 @@ def test_get_rewards_no_matching_events(web3, contracts):
 
 
 @pytest.mark.unit
-def test_get_rewards_prediction(web3, contracts, monkeypatch: pytest.MonkeyPatch):
+def test_get_rewards_prediction(web3, monkeypatch: pytest.MonkeyPatch):
     bp = ReferenceBlockStampFactory.build(
         block_number=BlockNumber(14),
         block_timestamp=1675441520,

--- a/tests/modules/ejector/test_sweep.py
+++ b/tests/modules/ejector/test_sweep.py
@@ -86,6 +86,7 @@ def test_get_validators_withdrawals(fake_beacon_state_view):
     assert result[0].amount == 10, f"Expected amount 1 for validator 2, got {result[0].amount}"
 
 
+@pytest.mark.unit
 def test_only_validators_withdrawals():
     """Test when there are only validators eligible for withdrawals."""
 
@@ -100,6 +101,7 @@ def test_only_validators_withdrawals():
     assert result == 2
 
 
+@pytest.mark.unit
 def test_combined_withdrawals():
     """Test when there are both partial and full withdrawals."""
 

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -24,7 +24,7 @@ class NodeOperatorStatsFactory(Web3DataclassFactory[NodeOperatorStats]):
 
 
 @pytest.fixture
-def iterator(web3, contracts, lido_validators):
+def iterator(web3, contracts):
     return ValidatorExitIterator(
         web3,
         ReferenceBlockStampFactory.build(),

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -24,7 +24,7 @@ class NodeOperatorStatsFactory(Web3DataclassFactory[NodeOperatorStats]):
 
 
 @pytest.fixture
-def iterator(web3, contracts):
+def iterator(web3):
     return ValidatorExitIterator(
         web3,
         ReferenceBlockStampFactory.build(),

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -48,6 +48,7 @@ def test_get_filter_non_exitable_validators(iterator):
     assert filt(LidoValidatorFactory.build(index="1"))
 
 
+@pytest.mark.unit
 def test_calculate_validators_age(iterator, monkeypatch):
     monkeypatch.setattr('src.services.exit_order_iterator.get_validator_age', lambda x, _: 1)
     iterator.blockstamp = ReferenceBlockStampFactory.build()
@@ -55,6 +56,7 @@ def test_calculate_validators_age(iterator, monkeypatch):
     assert age == 20
 
 
+@pytest.mark.unit
 def test_eject_validator(iterator):
     sk_1 = StakingModuleFactory.build(
         id=1,
@@ -403,12 +405,14 @@ def test_get_remaining_forced_validators_all_predictable(iterator):
     assert len(vals) == 0
 
 
+@pytest.mark.unit
 def test_get_remaining_forced_validators_no_node_operators(iterator):
     iterator.node_operators_stats = {}
     vals = iterator.get_remaining_forced_validators()
     assert len(vals) == 0
 
 
+@pytest.mark.unit
 def test_get_remaining_forced_validators_no_more_place_in_report(iterator):
     iterator.max_validators_to_exit = 10
     iterator.index = 10
@@ -429,6 +433,7 @@ def test_get_remaining_forced_validators_no_more_place_in_report(iterator):
     assert len(vals) == 0
 
 
+@pytest.mark.unit
 def test_lowest_validators_index_predicate(iterator):
     iterator.node_operators_stats = {
         (1, 1): NodeOperatorStatsFactory.build(

--- a/tests/modules/submodules/consensus/conftest.py
+++ b/tests/modules/submodules/consensus/conftest.py
@@ -26,5 +26,5 @@ class SimpleConsensusModule(ConsensusModule):
 
 
 @pytest.fixture()
-def consensus(web3, contracts):
+def consensus(web3):
     return SimpleConsensusModule(web3)

--- a/tests/modules/submodules/consensus/conftest.py
+++ b/tests/modules/submodules/consensus/conftest.py
@@ -26,5 +26,5 @@ class SimpleConsensusModule(ConsensusModule):
 
 
 @pytest.fixture()
-def consensus(web3, consensus_client, contracts):
+def consensus(web3, contracts):
     return SimpleConsensusModule(web3)

--- a/tests/modules/submodules/consensus/test_consensus.py
+++ b/tests/modules/submodules/consensus/test_consensus.py
@@ -359,6 +359,7 @@ def test_no_report_contract(web3, impl: type[ConsensusModule]):
         impl(web3)
 
 
+@pytest.mark.unit
 def test_check_contract_config(consensus: ConsensusModule, monkeypatch: pytest.MonkeyPatch):
     consensus.w3.cc.get_block_root = Mock(return_value=Mock(root=""))
     consensus.w3.cc.get_block_details = Mock()
@@ -387,6 +388,7 @@ def test_check_contract_config(consensus: ConsensusModule, monkeypatch: pytest.M
             consensus.check_contract_configs()
 
 
+@pytest.mark.unit
 def test_get_web3_converter(consensus):
     blockstamp = BlockStampFactory.build()
 

--- a/tests/modules/submodules/consensus/test_consensus.py
+++ b/tests/modules/submodules/consensus/test_consensus.py
@@ -1,7 +1,10 @@
 from typing import cast
+from dataclasses import dataclass
 from unittest.mock import Mock
 
 import pytest
+from eth_typing import ChecksumAddress
+from hexbytes import HexBytes
 from web3.exceptions import ContractCustomError
 
 from src import variables
@@ -11,7 +14,7 @@ from src.modules.submodules.exceptions import IncompatibleOracleVersion, Contrac
 from src.modules.submodules.types import ChainConfig
 from src.providers.consensus.types import BeaconSpecResponse
 from src.types import BlockStamp, ReferenceBlockStamp
-from tests.conftest import Account
+
 from tests.factory.blockstamp import ReferenceBlockStampFactory, BlockStampFactory
 from tests.factory.configs import (
     BeaconSpecResponseFactory,
@@ -20,6 +23,12 @@ from tests.factory.configs import (
     BlockDetailsResponseFactory,
 )
 from tests.factory.member_info import MemberInfoFactory
+
+
+@dataclass
+class Account:
+    address: ChecksumAddress
+    _private_key: HexBytes
 
 
 @pytest.fixture()

--- a/tests/modules/submodules/consensus/test_consensus.py
+++ b/tests/modules/submodules/consensus/test_consensus.py
@@ -11,7 +11,7 @@ from src.modules.submodules.exceptions import IncompatibleOracleVersion, Contrac
 from src.modules.submodules.types import ChainConfig
 from src.providers.consensus.types import BeaconSpecResponse
 from src.types import BlockStamp, ReferenceBlockStamp
-from tests.conftest import get_blockstamp_by_state, Account
+from tests.conftest import Account
 from tests.factory.blockstamp import ReferenceBlockStampFactory, BlockStampFactory
 from tests.factory.configs import (
     BeaconSpecResponseFactory,

--- a/tests/modules/submodules/consensus/test_reports.py
+++ b/tests/modules/submodules/consensus/test_reports.py
@@ -1,15 +1,23 @@
 from unittest.mock import Mock
 
 import pytest
+from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
+from dataclasses import dataclass
 
 from src import variables
 from src.modules.accounting.accounting import Accounting
 from src.modules.accounting.types import ReportData
 from src.modules.submodules.types import ChainConfig, FrameConfig, ZERO_HASH
-from tests.conftest import Account
+
 from tests.factory.blockstamp import ReferenceBlockStampFactory
 from tests.factory.member_info import MemberInfoFactory
+
+
+@dataclass
+class Account:
+    address: ChecksumAddress
+    _private_key: HexBytes
 
 
 @pytest.fixture()

--- a/tests/modules/submodules/consensus/test_reports.py
+++ b/tests/modules/submodules/consensus/test_reports.py
@@ -36,7 +36,7 @@ def mock_latest_data(consensus):
 
 # ----- Process report main ----------
 @pytest.mark.unit
-def test_process_report_main(consensus, tx_utils, caplog):
+def test_process_report_main(consensus, caplog):
     consensus.w3.lido_contracts.accounting_oracle.get_consensus_version = Mock(return_value=2)
     consensus.w3.lido_contracts.accounting_oracle.get_contract_version = Mock(return_value=2)
     blockstamp = ReferenceBlockStampFactory.build()
@@ -67,7 +67,7 @@ def test_hash_calculations(consensus):
 
 # ------ Process report hash -----------
 @pytest.mark.unit
-def test_report_hash(web3, consensus, tx_utils, set_report_account):
+def test_report_hash(web3, consensus, set_report_account):
     consensus.w3.lido_contracts.accounting_oracle.get_consensus_version = Mock(return_value=1)
     blockstamp = ReferenceBlockStampFactory.build()
     consensus._get_latest_blockstamp = Mock(return_value=blockstamp)
@@ -169,7 +169,7 @@ def test_process_report_data_main_data_submitted(consensus, caplog, mock_latest_
 
 
 @pytest.mark.unit
-def test_process_report_data_main_sleep_until_data_submitted(consensus, caplog, tx_utils, mock_latest_data):
+def test_process_report_data_main_sleep_until_data_submitted(consensus, caplog, mock_latest_data):
     consensus.w3.lido_contracts.accounting_oracle.get_consensus_version = Mock(
         return_value=Accounting.COMPATIBLE_CONSENSUS_VERSION
     )
@@ -222,7 +222,7 @@ def test_process_report_data_sleep_ends(consensus, caplog, mock_latest_data):
 
 
 @pytest.mark.unit
-def test_process_report_submit_report(consensus, tx_utils, caplog, mock_latest_data):
+def test_process_report_submit_report(consensus, caplog, mock_latest_data):
     consensus.w3.lido_contracts.accounting_oracle.get_consensus_version = Mock(
         return_value=Accounting.COMPATIBLE_CONSENSUS_VERSION
     )

--- a/tests/modules/submodules/test_oracle_module.py
+++ b/tests/modules/submodules/test_oracle_module.py
@@ -38,7 +38,7 @@ def set_default_sleep(monkeypatch):
 
 
 @pytest.fixture()
-def oracle(web3, consensus_client):
+def oracle(web3):
     return SimpleOracle(web3)
 
 

--- a/tests/modules/submodules/test_oracle_module.py
+++ b/tests/modules/submodules/test_oracle_module.py
@@ -61,7 +61,7 @@ def test_receive_last_finalized_slot(oracle):
 
 @pytest.mark.unit
 @responses.activate
-def test_cycle_handler_run_once_per_slot(oracle, contracts, web3):
+def test_cycle_handler_run_once_per_slot(oracle, web3):
     web3.lido_contracts.has_contract_address_changed = Mock()
     oracle._receive_last_finalized_slot = Mock(return_value=ReferenceBlockStampFactory.build(slot_number=1))
     responses.get('http://localhost:8000/pulse/', status=HTTPStatus.OK)

--- a/tests/providers/consensus/test_consensus_client.py
+++ b/tests/providers/consensus/test_consensus_client.py
@@ -8,15 +8,15 @@ from src.providers.consensus.client import ConsensusClient
 from src.providers.consensus.types import Validator
 from src.types import SlotNumber
 from src.utils.blockstamp import build_blockstamp
-from src.variables import CONSENSUS_CLIENT_URI
+from src import variables
 from tests.factory.blockstamp import BlockStampFactory
 
 
 @pytest.fixture
 def consensus_client(request):
     params = getattr(request, 'param', {})
-    rpc_endpoint = params.get('endpoint', CONSENSUS_CLIENT_URI)
-    return ConsensusClient(rpc_endpoint, 5 * 60, 5, 5)
+    rpc_endpoint = params.get('endpoint', variables.CONSENSUS_CLIENT_URI)
+    return ConsensusClient(rpc_endpoint, 10, 3, 3)
 
 
 @pytest.mark.integration

--- a/tests/providers/consensus/test_consensus_client.py
+++ b/tests/providers/consensus/test_consensus_client.py
@@ -9,7 +9,6 @@ from src.providers.consensus.types import Validator
 from src.types import SlotNumber
 from src.utils.blockstamp import build_blockstamp
 from src.variables import CONSENSUS_CLIENT_URI
-from tests.conftest import TESTNET_CONSENSUS_CLIENT_URI
 from tests.factory.blockstamp import BlockStampFactory
 
 
@@ -21,6 +20,7 @@ def consensus_client(request):
 
 
 @pytest.mark.integration
+@pytest.mark.testnet
 def test_get_block_root(consensus_client: ConsensusClient):
     block_root = consensus_client.get_block_root('head')
     assert len(block_root.root) == 66
@@ -28,11 +28,6 @@ def test_get_block_root(consensus_client: ConsensusClient):
 
 @pytest.mark.integration
 @pytest.mark.testnet
-@pytest.mark.parametrize(
-    'consensus_client',
-    [{'endpoint': TESTNET_CONSENSUS_CLIENT_URI}],
-    indirect=True,
-)
 def test_get_block_details(consensus_client: ConsensusClient, web3):
     root = consensus_client.get_block_root('head').root
     block_details = consensus_client.get_block_details(root)
@@ -41,11 +36,6 @@ def test_get_block_details(consensus_client: ConsensusClient, web3):
 
 @pytest.mark.integration
 @pytest.mark.testnet
-@pytest.mark.parametrize(
-    'consensus_client',
-    [{'endpoint': TESTNET_CONSENSUS_CLIENT_URI}],
-    indirect=True,
-)
 def test_get_block_attestations(consensus_client: ConsensusClient):
     root = consensus_client.get_block_root('finalized').root
 
@@ -55,11 +45,6 @@ def test_get_block_attestations(consensus_client: ConsensusClient):
 
 @pytest.mark.integration
 @pytest.mark.testnet
-@pytest.mark.parametrize(
-    'consensus_client',
-    [{'endpoint': TESTNET_CONSENSUS_CLIENT_URI}],
-    indirect=True,
-)
 def test_get_attestation_committees(consensus_client: ConsensusClient):
     root = consensus_client.get_block_root('finalized').root
     block_details = consensus_client.get_block_details(root)
@@ -79,11 +64,6 @@ def test_get_attestation_committees(consensus_client: ConsensusClient):
 
 @pytest.mark.integration
 @pytest.mark.testnet
-@pytest.mark.parametrize(
-    'consensus_client',
-    [{'endpoint': TESTNET_CONSENSUS_CLIENT_URI}],
-    indirect=True,
-)
 def test_get_validators(consensus_client: ConsensusClient):
     root = consensus_client.get_block_root('finalized').root
     block_details = consensus_client.get_block_details(root)
@@ -98,11 +78,6 @@ def test_get_validators(consensus_client: ConsensusClient):
 
 @pytest.mark.integration
 @pytest.mark.testnet
-@pytest.mark.parametrize(
-    'consensus_client',
-    [{'endpoint': TESTNET_CONSENSUS_CLIENT_URI}],
-    indirect=True,
-)
 def test_get_state_view(consensus_client: ConsensusClient):
     root = consensus_client.get_block_root('finalized').root
     block_details = consensus_client.get_block_details(root)

--- a/tests/providers/test_consistency.py
+++ b/tests/providers/test_consistency.py
@@ -1,11 +1,13 @@
 # pylint: disable=protected-access
 import unittest
+import pytest
 from typing import Any
 from unittest.mock import Mock
 
 from src.providers.consistency import ProviderConsistencyModule, NotHealthyProvider, InconsistentProviders
 
 
+@pytest.mark.unit
 class TestProviderConsistencyModule(unittest.TestCase):
     def setUp(self):
         # Set up a concrete subclass for testing

--- a/tests/providers_clients/test_http_provider.py
+++ b/tests/providers_clients/test_http_provider.py
@@ -6,6 +6,7 @@ import pytest
 from src.providers.http_provider import HTTPProvider, NoHostsProvided, NotOkResponse
 
 
+@pytest.mark.unit
 def test_urljoin():
     join = HTTPProvider._urljoin
     assert join('http://localhost', 'api') == 'http://localhost/api'
@@ -18,11 +19,13 @@ def test_urljoin():
     assert join('http://localhost/token/', 'api') == 'http://localhost/token/api'
 
 
+@pytest.mark.unit
 def test_no_providers():
     with pytest.raises(NoHostsProvided):
         HTTPProvider([], 5 * 60, 1, 1)
 
 
+@pytest.mark.unit
 def test_all_fallbacks_ok():
     provider = HTTPProvider(['http://localhost:1', 'http://localhost:2'], 5 * 60, 1, 1)
     provider._get_without_fallbacks = lambda host, endpoint, path_params, query_params, stream: (host, endpoint)
@@ -30,12 +33,14 @@ def test_all_fallbacks_ok():
     assert len(provider.get_all_providers()) == 2
 
 
+@pytest.mark.unit
 def test_all_fallbacks_bad():
     provider = HTTPProvider(['http://localhost:1', 'http://localhost:2'], 5 * 60, 1, 1)
     with pytest.raises(Exception):
         provider._get('test')
 
 
+@pytest.mark.unit
 def test_first_fallback_bad():
     def _simple_get(host, endpoint, *_):
         if host == 'http://localhost:1':
@@ -47,6 +52,7 @@ def test_first_fallback_bad():
     assert provider._get('test') == ('http://localhost:2', 'test')
 
 
+@pytest.mark.unit
 def test_force_raise():
     class CustomError(Exception):
         pass

--- a/tests/providers_clients/test_keys_api_client.py
+++ b/tests/providers_clients/test_keys_api_client.py
@@ -17,9 +17,6 @@ from src.types import StakingModuleAddress
 from tests.factory.blockstamp import ReferenceBlockStampFactory
 
 
-@pytest.mark.usefixtures(
-    "contracts",
-)
 @pytest.mark.integration
 @pytest.mark.mainnet
 class TestIntegrationKeysAPIClient:

--- a/tests/utils/test_base64.py
+++ b/tests/utils/test_base64.py
@@ -5,11 +5,13 @@ import pytest
 from src.utils.base64 import decode_base64url
 
 
+@pytest.mark.unit
 def test_empty_string():
     """Test decoding an empty string."""
     assert decode_base64url("") == ""
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "encoded, expected",
     [
@@ -43,6 +45,7 @@ def test_valid_decoding(encoded, expected):
     assert decode_base64url(encoded) == expected
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "encoded_with_padding, expected",
     [
@@ -59,6 +62,7 @@ def test_handling_existing_correct_padding(encoded_with_padding, expected):
     assert decode_base64url(encoded_with_padding) == expected
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "invalid_input",
     [
@@ -74,6 +78,7 @@ def test_invalid_characters(invalid_input):
         decode_base64url(invalid_input)
 
 
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "invalid_length_input",
     [
@@ -88,6 +93,7 @@ def test_invalid_length_mod_4_is_1(invalid_length_input):
         decode_base64url(invalid_length_input)
 
 
+@pytest.mark.unit
 def test_non_utf8_result():
     """Test decoding data that isn't valid UTF-8."""
     # RFC 4648 vector: \xfb\xff\xbf -> "-_-_" (Base64Url) -> invalid UTF-8 bytes

--- a/tests/utils/test_build.py
+++ b/tests/utils/test_build.py
@@ -1,10 +1,12 @@
 import unittest
+import pytest
 from unittest.mock import patch, mock_open
 import json
 
 from src.utils.build import get_build_info, UNKNOWN_BUILD_INFO
 
 
+@pytest.mark.unit
 class TestGetBuildInfo(unittest.TestCase):
     @patch(
         'builtins.open', new_callable=mock_open, read_data='{"version": "1.0.0", "branch": "main", "commit": "abc123"}'

--- a/tests/utils/test_cache.py
+++ b/tests/utils/test_cache.py
@@ -1,4 +1,5 @@
 import random
+import pytest
 
 from hexbytes import HexBytes
 from web3.types import BlockIdentifier
@@ -13,6 +14,7 @@ class Calc:
         return a + b
 
 
+@pytest.mark.unit
 def test_clear_global_cache():
     calc = Calc()
     calc.get(1, 2)
@@ -39,6 +41,7 @@ class Contract(ContractInterface):
         return random.random()
 
 
+@pytest.mark.unit
 def test_cache_do_not_cache_contract_with_relative_blocks():
     c = Contract()
 

--- a/tests/utils/test_env.py
+++ b/tests/utils/test_env.py
@@ -5,6 +5,7 @@ import pytest
 from src.utils.env import from_file_or_env
 
 
+@pytest.mark.unit
 class TestFromFileOrEnv:
     @pytest.fixture()
     def file_path(self, tmp_path: Path) -> Path:

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -31,7 +31,6 @@ def contract_event(events):
 
 
 @pytest.mark.unit
-@pytest.mark.possible_integration
 def test_get_contract_events_in_past(contract_event):
     seconds_per_slot = 10
     bs = ReferenceBlockStampFactory.build(

--- a/tests/utils/test_jwt.py
+++ b/tests/utils/test_jwt.py
@@ -7,6 +7,7 @@ import pytest
 from src.utils.jwt import validate_jwt
 
 
+@pytest.mark.unit
 def test_valid_token():
     """Test valid token is accepted"""
     validate_jwt(
@@ -20,6 +21,7 @@ def test_valid_token():
     )
 
 
+@pytest.mark.unit
 def test_invalid_token_not_string():
     """Test non-string input raises ValueError."""
     with pytest.raises(ValueError, match="Token must be a string"):
@@ -28,6 +30,7 @@ def test_invalid_token_not_string():
         validate_jwt(None)
 
 
+@pytest.mark.unit
 def test_invalid_token_wrong_parts():
     """Test token string with incorrect number of segments."""
     with pytest.raises(ValueError, match="Token must have 3 parts"):
@@ -36,6 +39,7 @@ def test_invalid_token_wrong_parts():
         validate_jwt("header.payload.sig.extra")
 
 
+@pytest.mark.unit
 def test_invalid_token_bad_payload_encoding():
     """Test token with invalid Base64Url in the payload segment."""
     token = "header.payload_is_not_base64!!.signature"
@@ -43,24 +47,28 @@ def test_invalid_token_bad_payload_encoding():
         validate_jwt(token)
 
 
+@pytest.mark.unit
 def test_invalid_token_header_not_json():
     """Test token where header decodes but isn't valid JSON."""
     with pytest.raises(ValueError, match="Cannot parse header JSON"):
         validate_jwt(f"{base64.b64encode(b'not json').decode('UTF-8')}.payload.sign")
 
 
+@pytest.mark.unit
 def test_invalid_token_header_not_json_object():
     """Test token where header decodes but isn't valid JSON."""
     with pytest.raises(ValueError, match="Header is not a JSON object"):
         validate_jwt(f"{base64.b64encode(b'[1,2,3]').decode('UTF-8')}.payload.sign")
 
 
+@pytest.mark.unit
 def test_invalid_token_payload_not_json():
     """Test token where payload decodes but isn't valid JSON."""
     with pytest.raises(ValueError, match="Cannot parse payload JSON"):
         validate_jwt(f"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.{base64.b64encode(b'not json').decode('UTF-8')}.sign")
 
 
+@pytest.mark.unit
 def test_invalid_token_payload_not_json_object():
     """Test token where payload is valid JSON but not an object/dict."""
     with pytest.raises(ValueError, match="Payload is not a JSON object"):

--- a/tests/utils/test_range.py
+++ b/tests/utils/test_range.py
@@ -3,6 +3,7 @@ import pytest
 from src.utils.range import sequence
 
 
+@pytest.mark.unit
 def test_sequence():
     assert list(sequence(0, 3)) == [0, 1, 2, 3]
     assert list(sequence(1, 3)) == [1, 2, 3]
@@ -13,6 +14,7 @@ def test_sequence():
     assert list(sequence(-3, 0)) == [-3, -2, -1, 0]
 
 
+@pytest.mark.unit
 def test_sequence_raises():
     with pytest.raises(ValueError, match="start=3 > stop=1"):
         sequence(3, 1)

--- a/tests/utils/test_timeit.py
+++ b/tests/utils/test_timeit.py
@@ -6,6 +6,7 @@ import pytest
 from src.utils.timeit import timeit
 
 
+@pytest.mark.unit
 def test_timeit_log_fn_no_args():
     log_fn = Mock()
 
@@ -17,6 +18,7 @@ def test_timeit_log_fn_no_args():
     assert log_fn.call_args.args[0] == SimpleNamespace()
 
 
+@pytest.mark.unit
 def test_timeit_log_fn_args():
     log_fn = Mock()
 
@@ -28,6 +30,7 @@ def test_timeit_log_fn_args():
     assert log_fn.call_args.args[0] == SimpleNamespace(a=2, b=0, k="any")
 
 
+@pytest.mark.unit
 def test_timeit_log_fn_args_method():
     log_fn = Mock()
 
@@ -42,6 +45,7 @@ def test_timeit_log_fn_args_method():
     assert log_fn.call_args.args[0] == SimpleNamespace(a=42, b="any", self=some)
 
 
+@pytest.mark.unit
 def test_timeit_log_fn_called_on_exception():
     log_fn = Mock()
 
@@ -55,6 +59,7 @@ def test_timeit_log_fn_called_on_exception():
     log_fn.assert_not_called()
 
 
+@pytest.mark.unit
 def test_timeit_duration(monkeypatch: pytest.MonkeyPatch):
     log_fn = Mock()
 

--- a/tests/web3py/test_lido_validators.py
+++ b/tests/web3py/test_lido_validators.py
@@ -17,7 +17,7 @@ blockstamp = ReferenceBlockStampFactory.build()
 
 
 @pytest.mark.unit
-def test_get_lido_validators(web3, contracts):
+def test_get_lido_validators(web3):
     validators = ValidatorFactory.batch(30)
     lido_keys = LidoKeyFactory.generate_for_validators(validators[:10])
     lido_keys.extend(LidoKeyFactory.batch(10))
@@ -38,7 +38,7 @@ def test_get_lido_validators(web3, contracts):
 
 
 @pytest.mark.unit
-def test_kapi_has_lesser_keys_than_deposited_validators_count(web3, contracts):
+def test_kapi_has_lesser_keys_than_deposited_validators_count(web3):
     validators = ValidatorFactory.batch(10)
     lido_keys = [LidoKeyFactory.build()]
 
@@ -78,7 +78,7 @@ def test_kapi_has_lesser_keys_than_deposited_validators_count(web3, contracts):
 
 
 @pytest.mark.unit
-def test_get_lido_node_operators_by_modules(web3, contracts):
+def test_get_lido_node_operators_by_modules(web3):
     web3.lido_contracts.staking_router.get_staking_modules = Mock(
         return_value=[
             StakingModuleFactory.build(id=1),
@@ -94,7 +94,7 @@ def test_get_lido_node_operators_by_modules(web3, contracts):
 
 
 @pytest.mark.unit
-def test_get_node_operators(web3, contracts):
+def test_get_node_operators(web3):
     web3.lido_validators.get_lido_node_operators_by_modules = Mock(
         return_value={
             0: [0, 2, 3],
@@ -108,7 +108,7 @@ def test_get_node_operators(web3, contracts):
 
 
 @pytest.mark.unit
-def test_get_lido_validators_by_node_operator(web3, contracts):
+def test_get_lido_validators_by_node_operator(web3):
     # 2 NO in one module
     # 1 NO in 2 module
     sm1 = StakingModuleFactory.build(id=1)

--- a/tests/web3py/test_lido_validators.py
+++ b/tests/web3py/test_lido_validators.py
@@ -17,7 +17,7 @@ blockstamp = ReferenceBlockStampFactory.build()
 
 
 @pytest.mark.unit
-def test_get_lido_validators(web3, lido_validators, contracts):
+def test_get_lido_validators(web3, contracts):
     validators = ValidatorFactory.batch(30)
     lido_keys = LidoKeyFactory.generate_for_validators(validators[:10])
     lido_keys.extend(LidoKeyFactory.batch(10))
@@ -38,7 +38,7 @@ def test_get_lido_validators(web3, lido_validators, contracts):
 
 
 @pytest.mark.unit
-def test_kapi_has_lesser_keys_than_deposited_validators_count(web3, lido_validators, contracts):
+def test_kapi_has_lesser_keys_than_deposited_validators_count(web3, contracts):
     validators = ValidatorFactory.batch(10)
     lido_keys = [LidoKeyFactory.build()]
 
@@ -78,7 +78,7 @@ def test_kapi_has_lesser_keys_than_deposited_validators_count(web3, lido_validat
 
 
 @pytest.mark.unit
-def test_get_lido_node_operators_by_modules(web3, lido_validators, contracts):
+def test_get_lido_node_operators_by_modules(web3, contracts):
     web3.lido_contracts.staking_router.get_staking_modules = Mock(
         return_value=[
             StakingModuleFactory.build(id=1),
@@ -94,7 +94,7 @@ def test_get_lido_node_operators_by_modules(web3, lido_validators, contracts):
 
 
 @pytest.mark.unit
-def test_get_node_operators(web3, lido_validators, contracts):
+def test_get_node_operators(web3, contracts):
     web3.lido_validators.get_lido_node_operators_by_modules = Mock(
         return_value={
             0: [0, 2, 3],
@@ -108,7 +108,7 @@ def test_get_node_operators(web3, lido_validators, contracts):
 
 
 @pytest.mark.unit
-def test_get_lido_validators_by_node_operator(web3, lido_validators, contracts):
+def test_get_lido_validators_by_node_operator(web3, contracts):
     # 2 NO in one module
     # 1 NO in 2 module
     sm1 = StakingModuleFactory.build(id=1)

--- a/tests/web3py/test_middleware.py
+++ b/tests/web3py/test_middleware.py
@@ -9,8 +9,6 @@ from src.metrics.prometheus.basic import EL_REQUESTS_DURATION
 from src.variables import EXECUTION_CLIENT_URI
 from src.web3py.middleware import add_requests_metric_middleware, Web3MetricsMiddleware
 
-pytestmark = pytest.mark.integration
-
 
 @pytest.fixture()
 def provider():


### PR DESCRIPTION
## Description
- Removed old fixtures
- Removed "possible_integration" test tag
- "mainnet" and "testnet" tags now validates envs, "testnet" overrides envs
- Separate envs for "testnet" marked tests added
- CI timeout 60 min on tests added
- All tests marked now, deprecated to write tests without marks
- Marks compatibility check added 

## Related Issue/Task
- Related task: orc-370
- Epic: orc-371

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [x] Documentation updated (if required)
- [ ] New tests added (if applicable)
