### PR TITLE
[CSM v2] fix: missing pivot slot in block roots

### DIFF
--- a/src/modules/csm/checkpoint.py
+++ b/src/modules/csm/checkpoint.py
@@ -170,15 +170,14 @@ class FrameCheckpointProcessor:
         # If `s` is `checkpoint_slot -> state.slot`, then it cannot yet be in `block_roots`.
         # So it is the index that will be overwritten in the next slot, i.e. the index of the oldest root.
         pivot_index = checkpoint_slot % SLOTS_PER_HISTORICAL_ROOT
-
-        # Replace duplicated roots with `None` to mark missing slots
-        br = [br[i] if i == pivot_index or br[i] != br[i - 1] else None for i in range(len(br))]
-
         # The oldest root can be missing, so we need to check it and mark it as well as other missing slots
         pivot_block_root = br[pivot_index]
         slot_by_pivot_block_root = self.cc.get_block_header(pivot_block_root).data.header.message.slot
-        calculated_pivot_slot = checkpoint_slot - SLOTS_PER_HISTORICAL_ROOT
+        calculated_pivot_slot = max(checkpoint_slot - SLOTS_PER_HISTORICAL_ROOT, 0)
         is_pivot_missing = slot_by_pivot_block_root != calculated_pivot_slot
+
+        # Replace duplicated roots with `None` to mark missing slots
+        br = [br[i] if i == pivot_index or br[i] != br[i - 1] else None for i in range(len(br))]
         if is_pivot_missing:
             br[pivot_index] = None
 

--- a/src/modules/csm/checkpoint.py
+++ b/src/modules/csm/checkpoint.py
@@ -165,13 +165,24 @@ class FrameCheckpointProcessor:
     def _get_block_roots(self, checkpoint_slot: SlotNumber):
         logger.info({"msg": f"Get block roots for slot {checkpoint_slot}"})
         # Checkpoint for us like a time point, that's why we use slot, not root.
+        br = self.cc.get_state_block_roots(checkpoint_slot)
         # `s % 8192 = i` is the index where slot `s` will be located.
         # If `s` is `checkpoint_slot -> state.slot`, then it cannot yet be in `block_roots`.
         # So it is the index that will be overwritten in the next slot, i.e. the index of the oldest root.
         pivot_index = checkpoint_slot % SLOTS_PER_HISTORICAL_ROOT
-        br = self.cc.get_state_block_roots(checkpoint_slot)
-        # Replace duplicated roots to None to mark missed slots
-        return [br[i] if i == pivot_index or br[i] != br[i - 1] else None for i in range(len(br))]
+
+        # Replace duplicated roots with `None` to mark missing slots
+        br = [br[i] if i == pivot_index or br[i] != br[i - 1] else None for i in range(len(br))]
+
+        # The oldest root can be missing, so we need to check it and mark it as well as other missing slots
+        pivot_block_root = br[pivot_index]
+        slot_by_pivot_block_root = self.cc.get_block_header(pivot_block_root).data.header.message.slot
+        calculated_pivot_slot = checkpoint_slot - SLOTS_PER_HISTORICAL_ROOT
+        is_pivot_missing = slot_by_pivot_block_root != calculated_pivot_slot
+        if is_pivot_missing:
+            br[pivot_index] = None
+
+        return br
 
     def _select_block_roots(
         self, block_roots: list[BlockRoot | None], duty_epoch: EpochNumber, checkpoint_slot: SlotNumber

--- a/tests/modules/csm/test_checkpoint.py
+++ b/tests/modules/csm/test_checkpoint.py
@@ -132,39 +132,50 @@ def consensus_client():
 
 
 @pytest.fixture
-def mock_get_state_block_roots(consensus_client):
-    def _get_state_block_roots(state_id):
-        return [f'0x{r}' for r in range(state_id, state_id + 8192)]
-
-    consensus_client.get_state_block_roots = Mock(side_effect=_get_state_block_roots)
+def missing_slots():
+    return set()
 
 
 @pytest.fixture
-def mock_get_state_block_roots_with_duplicates(consensus_client):
-    def _get_state_block_roots(state_id):
-        br = [f'0x{r}' for r in range(0, 8192)]
-        return [br[i - 1] if i % 2 == 0 else br[i] for i in range(len(br))]
+def mock_get_state_block_roots(consensus_client, missing_slots):
+
+    def _get_state_block_roots(state_id: int):
+        roots_count = 8192
+        br = ["0x0"] * roots_count
+        for i in range(min(roots_count, state_id), 0, -1):
+            slot = state_id - i
+            index = slot % roots_count
+            prev_slot_index = (slot - 1) % roots_count
+            br[index] = br[prev_slot_index] if slot in missing_slots else f"0x{slot}"
+        oldest_slot = max(state_id - roots_count, 0)
+        oldest_slot_index = state_id % roots_count
+        br[oldest_slot_index] = f"0x{max(oldest_slot - 1, 0)}" if oldest_slot in missing_slots else f"0x{oldest_slot}"
+        return br
+
+    def _get_block_header(state_id: str):
+        return Mock(
+            data=Mock(header=Mock(message=Mock(slot=int(state_id.split('0x')[1])))),
+        )
 
     consensus_client.get_state_block_roots = Mock(side_effect=_get_state_block_roots)
+    consensus_client.get_block_header = Mock(side_effect=_get_block_header)
 
 
 @pytest.mark.unit
-def test_checkpoints_processor_get_block_roots(consensus_client, mock_get_state_block_roots, converter: Web3Converter):
-    state = ...
-    finalized_blockstamp = ...
-    processor = FrameCheckpointProcessor(
-        consensus_client,
-        converter,
-        state,
-        finalized_blockstamp,
-    )
-    roots = processor._get_block_roots(0)
-    assert len([r for r in roots if r is not None]) == 8192
-
-
-@pytest.mark.unit
-def test_checkpoints_processor_get_block_roots_with_duplicates(
-    consensus_client, mock_get_state_block_roots_with_duplicates, converter: Web3Converter
+@pytest.mark.parametrize(
+    "state_id, missing_slots, expected_existing_roots_count",
+    [
+        pytest.param(8192, set(), 8192, id="all slots present"),
+        pytest.param(8192, {8191}, 8191, id="last slot is missing"),
+        pytest.param(8192, {100, 2543, 3666, 4444, 8191}, 8187, id="multiple missing slots"),
+        pytest.param(8192, {1000, 1001, 1002, 1003, 1004, 1005}, 8186, id="multiple missing slots in a row"),
+        pytest.param(8192, {8193}, 8192, id="future missing slot"),
+        pytest.param(100500, {11}, 8192, id="past missing slot"),
+        pytest.param(15000, {15000 - 8192}, 8191, id="the oldest slot is missing"),
+    ],
+)
+def test_checkpoints_processor_get_block_roots(
+    consensus_client, mock_get_state_block_roots, converter: Web3Converter, state_id, expected_existing_roots_count
 ):
     state = ...
     finalized_blockstamp = ...
@@ -174,8 +185,8 @@ def test_checkpoints_processor_get_block_roots_with_duplicates(
         state,
         finalized_blockstamp,
     )
-    roots = processor._get_block_roots(1)
-    assert len([r for r in roots if r is not None]) == 4096
+    roots = processor._get_block_roots(state_id)
+    assert len([r for r in roots if r is not None]) == expected_existing_roots_count
 
 
 @pytest.fixture
@@ -197,7 +208,7 @@ def test_checkpoints_processor_select_block_roots(
         converter,
         finalized_blockstamp,
     )
-    roots = processor._get_block_roots(0)
+    roots = processor._get_block_roots(8192)
     selected = processor._select_block_roots(roots, 10, 8192)
     duty_epoch_roots, next_epoch_roots = selected
     assert len(duty_epoch_roots) == 32
@@ -218,7 +229,7 @@ def test_checkpoints_processor_select_block_roots_out_of_range(
         converter,
         finalized_blockstamp,
     )
-    roots = processor._get_block_roots(0)
+    roots = processor._get_block_roots(8192)
     with pytest.raises(checkpoint_module.SlotOutOfRootsRange, match="Slot is out of the state block roots range"):
         processor._select_block_roots(roots, 255, 8192)
 

--- a/tests/modules/csm/test_checkpoint.py
+++ b/tests/modules/csm/test_checkpoint.py
@@ -141,14 +141,14 @@ def mock_get_state_block_roots(consensus_client, missing_slots):
 
     def _get_state_block_roots(state_id: int):
         roots_count = 8192
-        br = ["0x0"] * roots_count
+        br = [checkpoint_module.ZERO_BLOCK_ROOT] * roots_count
         for i in range(min(roots_count, state_id), 0, -1):
             slot = state_id - i
             index = slot % roots_count
             prev_slot_index = (slot - 1) % roots_count
             br[index] = br[prev_slot_index] if slot in missing_slots else f"0x{slot}"
         oldest_slot = max(state_id - roots_count, 0)
-        oldest_slot_index = state_id % roots_count
+        oldest_slot_index = oldest_slot % roots_count
         br[oldest_slot_index] = f"0x{max(oldest_slot - 1, 0)}" if oldest_slot in missing_slots else f"0x{oldest_slot}"
         return br
 
@@ -165,6 +165,8 @@ def mock_get_state_block_roots(consensus_client, missing_slots):
 @pytest.mark.parametrize(
     "state_id, missing_slots, expected_existing_roots_count",
     [
+        pytest.param(5, set(), 5, id="chain before 8192 slots"),
+        pytest.param(15, {1, 3}, 13, id="missing slots in chain before 8192 slots"),
         pytest.param(8192, set(), 8192, id="all slots present"),
         pytest.param(8192, {8191}, 8191, id="last slot is missing"),
         pytest.param(8192, {100, 2543, 3666, 4444, 8191}, 8187, id="multiple missing slots"),


### PR DESCRIPTION
## Description
There is a case when slot on pivot_index is missing and have the same root as the last slot from the previous checkpoint. Now we are not marking it as missing and it causes double root processing. The fix is simple: get slot number of root on pivot_index and compare it with calculated pivot slot max(checkpoint_slot - SLOTS_PER_HISTORICAL_ROOT, 0) and if they are not equal it means that pivot slot is missing

## Checklist
- [x] New tests added
