### PR TITLE
fix: fetch used module operators keys and add sanity checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
           EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}
           CONSENSUS_CLIENT_URI: ${{ secrets.CONSENSUS_CLIENT_URI }}
           KEYS_API_URI: ${{ secrets.KEYS_API_URI }}
+          CSM_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F"
 
   linters:
     runs-on: ubuntu-latest

--- a/src/modules/submodules/oracle_module.py
+++ b/src/modules/submodules/oracle_module.py
@@ -14,7 +14,7 @@ from src.metrics.prometheus.basic import ORACLE_BLOCK_NUMBER, ORACLE_SLOT_NUMBER
 from src.modules.submodules.exceptions import IsNotMemberException, IncompatibleOracleVersion, ContractVersionMismatch
 from src.providers.http_provider import NotOkResponse
 from src.providers.ipfs import IPFSError
-from src.providers.keys.client import KeysOutdatedException
+from src.providers.keys.client import KAPIInconsistentData, KeysOutdatedException
 from src.utils.cache import clear_global_cache
 from src.web3py.extensions.lido_validators import CountOfKeysDiffersException
 from src.utils.blockstamp import build_blockstamp
@@ -101,6 +101,8 @@ class BaseModule(ABC):
             logger.error({'msg': ''.join(traceback.format_exception(error))})
         except (NoSlotsAvailable, SlotNotFinalized, InconsistentData) as error:
             logger.error({'msg': 'Inconsistent response from consensus layer node.', 'error': str(error)})
+        except KAPIInconsistentData as error:
+            logger.error({'msg': 'Inconsistent response from Keys API service', 'error': str(error)})
         except KeysOutdatedException as error:
             logger.error({'msg': 'Keys API service returns outdated data.', 'error': str(error)})
         except CountOfKeysDiffersException as error:

--- a/src/providers/keys/client.py
+++ b/src/providers/keys/client.py
@@ -83,10 +83,10 @@ class KeysAPIClient(HTTPProvider):
         Docs: https://keys-api.lido.fi/api/static/index.html#/operators-keys/SRModulesOperatorsKeysController_getOperatorsKeys
         """
         data = cast(dict, self._get_with_blockstamp(self.USED_MODULE_OPERATORS_KEYS.format(module_address), blockstamp))
-        data['keys'] = [LidoKey.from_response(**k) for k in data['keys']]
-
         if (kapi_module_address := data['module']['stakingModuleAddress']) != module_address:
             raise KAPIInconsistentData(f"Module address mismatch: {kapi_module_address=} != {module_address=}")
+
+        data['keys'] = [LidoKey.from_response(**k) for k in data['keys']]
         self._check_used_keys(data['keys'])
 
         return cast(ModuleOperatorsKeys, data)

--- a/tests/providers_clients/test_keys_api_client.py
+++ b/tests/providers_clients/test_keys_api_client.py
@@ -21,10 +21,14 @@ empty_blockstamp = ReferenceBlockStampFactory.build(block_number=0)
 
 
 @pytest.mark.integration
-def test_get_used_lido_keys(keys_api_client):
+def test_get_used_lido_keys(keys_api_client: KeysAPIClient):
     lido_keys = keys_api_client.get_used_lido_keys(empty_blockstamp)
+    keys_seen: list[str] = []
     for lido_key in lido_keys:
         assert lido_key.used
+        assert lido_key.key not in keys_seen
+        keys_seen.append(lido_key.key)
+
     assert lido_keys
 
 
@@ -39,10 +43,13 @@ def test_get_used_module_operators_keys__csm_module(keys_api_client: KeysAPIClie
     assert csm_module_operators_keys['module']['id'] >= 0
     assert len(csm_module_operators_keys['keys']) > 0
     assert len(csm_module_operators_keys['operators']) > 0
+    keys_seen: list[str] = []
     for lido_key in csm_module_operators_keys['keys']:
         assert lido_key.used
         assert lido_key.operatorIndex >= 0
         assert Web3.is_address(lido_key.moduleAddress)
+        assert lido_key.key not in keys_seen
+        keys_seen.append(lido_key.key)
     for operator in csm_module_operators_keys['operators']:
         assert operator['index'] >= 0
         assert operator['moduleAddress'] == variables.CSM_MODULE_ADDRESS

--- a/tests/providers_clients/test_keys_api_client.py
+++ b/tests/providers_clients/test_keys_api_client.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 import pytest
+from web3 import Web3
 
 import src.providers.keys.client as keys_api_client_module
 from src import variables
@@ -22,7 +23,29 @@ empty_blockstamp = ReferenceBlockStampFactory.build(block_number=0)
 @pytest.mark.integration
 def test_get_used_lido_keys(keys_api_client):
     lido_keys = keys_api_client.get_used_lido_keys(empty_blockstamp)
+    for lido_key in lido_keys:
+        assert lido_key.used
     assert lido_keys
+
+
+@pytest.mark.integration
+def test_get_used_module_operators_keys__csm_module(keys_api_client: KeysAPIClient):
+    csm_module_operators_keys = keys_api_client.get_used_module_operators_keys(
+        module_address=variables.CSM_MODULE_ADDRESS,  # type: ignore
+        blockstamp=empty_blockstamp,
+    )
+
+    assert csm_module_operators_keys['module']['stakingModuleAddress'] == variables.CSM_MODULE_ADDRESS
+    assert csm_module_operators_keys['module']['id'] >= 0
+    assert len(csm_module_operators_keys['keys']) > 0
+    assert len(csm_module_operators_keys['operators']) > 0
+    for lido_key in csm_module_operators_keys['keys']:
+        assert lido_key.used
+        assert lido_key.operatorIndex >= 0
+        assert Web3.is_address(lido_key.moduleAddress)
+    for operator in csm_module_operators_keys['operators']:
+        assert operator['index'] >= 0
+        assert operator['moduleAddress'] == variables.CSM_MODULE_ADDRESS
 
 
 @pytest.mark.integration
@@ -33,7 +56,6 @@ def test_get_status(keys_api_client):
 
 @pytest.mark.unit
 def test_get_with_blockstamp_retries_exhausted(keys_api_client, monkeypatch):
-    variables.HTTP_REQUEST_SLEEP_BEFORE_RETRY_IN_SECONDS = 1
     keys_api_client._get = Mock(
         return_value=(
             None,


### PR DESCRIPTION
## Description

Fixes #740

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [x] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
