### PR TITLE
fix: fetch used module operators keys and add sanity checks

### DIFF
--- a/src/modules/csm/distribution.py
+++ b/src/modules/csm/distribution.py
@@ -111,7 +111,7 @@ class Distribution:
         )
 
     def _get_module_validators(self, blockstamp: ReferenceBlockStamp) -> ValidatorsByNodeOperator:
-        return self.w3.lido_validators.get_module_validators_by_node_operators(
+        return self.w3.lido_validators.get_used_module_validators_by_node_operators(
             StakingModuleAddress(self.w3.csm.module.address), blockstamp
         )
 

--- a/src/modules/submodules/oracle_module.py
+++ b/src/modules/submodules/oracle_module.py
@@ -15,7 +15,7 @@ from src.metrics.prometheus.basic import ORACLE_BLOCK_NUMBER, ORACLE_SLOT_NUMBER
 from src.modules.submodules.exceptions import IsNotMemberException, IncompatibleOracleVersion, ContractVersionMismatch
 from src.providers.http_provider import NotOkResponse
 from src.providers.ipfs import IPFSError
-from src.providers.keys.client import KeysOutdatedException
+from src.providers.keys.client import KAPIInconsistentData, KeysOutdatedException
 from src.utils.cache import clear_global_cache
 from src.web3py.extensions.lido_validators import CountOfKeysDiffersException
 from src.utils.blockstamp import build_blockstamp
@@ -102,6 +102,8 @@ class BaseModule(ABC):
             logger.error({'msg': ''.join(traceback.format_exception(error))})
         except (NoSlotsAvailable, SlotNotFinalized, InconsistentData) as error:
             logger.error({'msg': 'Inconsistent response from consensus layer node.', 'error': str(error)})
+        except KAPIInconsistentData as error:
+            logger.error({'msg': 'Inconsistent response from Keys API service', 'error': str(error)})
         except KeysOutdatedException as error:
             logger.error({'msg': 'Keys API service returns outdated data.', 'error': str(error)})
         except CountOfKeysDiffersException as error:

--- a/src/providers/keys/client.py
+++ b/src/providers/keys/client.py
@@ -16,9 +16,18 @@ class KAPIClientError(NotOkResponse):
     pass
 
 
+class KAPIInconsistentData(Exception):
+    pass
+
+
+class KAPIModule(TypedDict):
+    id: int
+    stakingModuleAddress: str
+
+
 class ModuleOperatorsKeys(TypedDict):
     keys: List[LidoKey]
-    module: dict
+    module: KAPIModule
     operators: list
 
 
@@ -36,7 +45,7 @@ class KeysAPIClient(HTTPProvider):
     PROMETHEUS_HISTOGRAM = KEYS_API_REQUESTS_DURATION
     PROVIDER_EXCEPTION = KAPIClientError
 
-    MODULE_OPERATORS_KEYS = 'v1/modules/{}/operators/keys'
+    USED_MODULE_OPERATORS_KEYS = 'v1/modules/{}/operators/keys?used=true'
     USED_KEYS = 'v1/keys?used=true'
     STATUS = 'v1/status'
 
@@ -61,17 +70,24 @@ class KeysAPIClient(HTTPProvider):
     @lru_cache(maxsize=1)
     def get_used_lido_keys(self, blockstamp: BlockStamp) -> list[LidoKey]:
         """Docs: https://keys-api.lido.fi/api/static/index.html#/keys/KeysController_get"""
-        return [LidoKey.from_response(**x) for x in self._get_with_blockstamp(self.USED_KEYS, blockstamp)]
+        data = list(map(lambda x: LidoKey.from_response(**x), self._get_with_blockstamp(self.USED_KEYS, blockstamp)))
+        self._check_used_keys(data)
+        return data
 
     @lru_cache(maxsize=1)
-    def get_module_operators_keys(
+    def get_used_module_operators_keys(
         self, module_address: StakingModuleAddress, blockstamp: BlockStamp
     ) -> ModuleOperatorsKeys:
         """
         Docs: https://keys-api.lido.fi/api/static/index.html#/operators-keys/SRModulesOperatorsKeysController_getOperatorsKeys
         """
-        data = cast(dict, self._get_with_blockstamp(self.MODULE_OPERATORS_KEYS.format(module_address), blockstamp))
+        data = cast(dict, self._get_with_blockstamp(self.USED_MODULE_OPERATORS_KEYS.format(module_address), blockstamp))
+        if (kapi_module_address := data['module']['stakingModuleAddress']) != module_address:
+            raise KAPIInconsistentData(f"Module address mismatch: {kapi_module_address=} != {module_address=}")
+
         data['keys'] = [LidoKey.from_response(**k) for k in data['keys']]
+        self._check_used_keys(data['keys'])
+
         return cast(ModuleOperatorsKeys, data)
 
     def get_status(self) -> KeysApiStatus:
@@ -82,3 +98,12 @@ class KeysAPIClient(HTTPProvider):
     def _get_chain_id_with_provider(self, provider_index: int) -> int:
         data, _ = self._get_without_fallbacks(self.hosts[provider_index], self.STATUS, retval_validator=data_is_dict)
         return KeysApiStatus.from_response(**data).chainId
+
+    def _check_used_keys(self, keys: list[LidoKey]):
+        keys_seen: dict[str, LidoKey] = {}
+        for k in keys:
+            if not k.used:
+                raise KAPIInconsistentData(f"Got unused key={k}")
+            if k.key in keys_seen:
+                raise KAPIInconsistentData(f"Got duplicated key={k}, previously found={keys_seen[k.key]}")
+            keys_seen[k.key] = k

--- a/src/web3py/extensions/lido_validators.py
+++ b/src/web3py/extensions/lido_validators.py
@@ -180,10 +180,10 @@ class LidoValidatorsProvider(Module):
         return no_validators
 
     @lru_cache(maxsize=1)
-    def get_module_validators_by_node_operators(
+    def get_used_module_validators_by_node_operators(
         self,
         module_address: StakingModuleAddress,
-        blockstamp: BlockStamp
+        blockstamp: BlockStamp,
     ) -> ValidatorsByNodeOperator:
         """
         Get module validators by querying the KeysAPI for the module keys.
@@ -195,21 +195,19 @@ class LidoValidatorsProvider(Module):
         Returns:
             ValidatorsByNodeOperator: A mapping of node operator IDs to their corresponding validators.
         """
-        # Fetch module operator keys from the KeysAPI
-        kapi = self.w3.kac.get_module_operators_keys(module_address, blockstamp)
-        if (kapi_module_address := kapi['module']['stakingModuleAddress']) != module_address:
-            raise ValueError(f"Module address mismatch: {kapi_module_address=} != {module_address=}")
-        operators = kapi['operators']
-        keys = {k.key: k for k in kapi['keys']}
-        validators = self.w3.cc.get_validators(blockstamp)
-        module_id = StakingModuleId(int(kapi['module']['id']))
+
+        kapi = self.w3.kac.get_used_module_operators_keys(module_address, blockstamp)
+        module_id = StakingModuleId(kapi['module']['id'])
+
 
         # Make sure even empty NO will be presented in dict
         no_validators: ValidatorsByNodeOperator = {
-            (module_id, NodeOperatorId(int(operator['index']))): [] for operator in operators
+            (module_id, NodeOperatorId(int(operator['index']))): [] for operator in kapi['operators']
         }
 
         # Map validators to their corresponding node operators
+        validators = self.w3.cc.get_validators(blockstamp)
+        keys = {k.key: k for k in kapi['keys']}
         for validator in validators:
             lido_key = keys.get(HexStr(validator.validator.pubkey))
             if not lido_key:

--- a/tests/providers_clients/test_keys_api_client.py
+++ b/tests/providers_clients/test_keys_api_client.py
@@ -9,9 +9,8 @@ from packaging.version import Version
 from web3 import Web3
 
 import src.providers.keys.client as keys_api_client_module
-from src import constants
-from src import variables
-from src.providers.keys.client import KAPIClientError, KeysAPIClient, KeysOutdatedException
+from src import constants, variables
+from src.providers.keys.client import KAPIClientError, KAPIInconsistentData, KeysAPIClient, KeysOutdatedException
 from src.providers.keys.types import LidoKey
 from src.types import StakingModuleAddress
 from tests.factory.blockstamp import ReferenceBlockStampFactory
@@ -20,7 +19,6 @@ from tests.factory.blockstamp import ReferenceBlockStampFactory
 @pytest.mark.integration
 @pytest.mark.mainnet
 class TestIntegrationKeysAPIClient:
-
     # https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#bls-signatures
     BLS_PUBLIC_KEY_SIZE = 48
     BLS_SIGNATURE_SIZE = 96
@@ -63,31 +61,39 @@ class TestIntegrationKeysAPIClient:
 
     def test_get_used_lido_keys__all_used_keys__response_data_is_valid(
         self,
-        keys_api_client,
+        keys_api_client: KeysAPIClient,
         empty_blockstamp,
     ):
         keys = keys_api_client.get_used_lido_keys(empty_blockstamp)
 
         assert len(keys) > 0
+        keys_seen: list[str] = []
         for lido_key in keys:
-            assert lido_key.used is True
+            assert lido_key.used
             self._assert_lido_key(lido_key)
+            assert lido_key.key not in keys_seen
+            keys_seen.append(lido_key.key)
 
-    def test_get_module_operators_keys__csm_module__response_data_is_valid(
+    def test_get_used_module_operators_keys__csm_module__response_data_is_valid(
         self,
-        keys_api_client,
+        keys_api_client: KeysAPIClient,
         empty_blockstamp,
     ):
-        csm_module_operators_keys = keys_api_client.get_module_operators_keys(
-            module_address=variables.CSM_MODULE_ADDRESS, blockstamp=empty_blockstamp
+        csm_module_operators_keys = keys_api_client.get_used_module_operators_keys(
+            module_address=variables.CSM_MODULE_ADDRESS,  # type: ignore
+            blockstamp=empty_blockstamp,
         )
 
         assert csm_module_operators_keys['module']['stakingModuleAddress'] == variables.CSM_MODULE_ADDRESS
         assert csm_module_operators_keys['module']['id'] >= 0
         assert len(csm_module_operators_keys['keys']) > 0
         assert len(csm_module_operators_keys['operators']) > 0
+        keys_seen: list[str] = []
         for lido_key in csm_module_operators_keys['keys']:
+            assert lido_key.used
             self._assert_lido_key(lido_key)
+            assert lido_key.key not in keys_seen
+            keys_seen.append(lido_key.key)
         for operator in csm_module_operators_keys['operators']:
             assert operator['index'] >= 0
             assert Web3.is_address(operator['rewardAddress'])
@@ -95,7 +101,7 @@ class TestIntegrationKeysAPIClient:
 
     def test_get_status__response_version_is_allowed(
         self,
-        keys_api_client,
+        keys_api_client: KeysAPIClient,
     ):
         status = keys_api_client.get_status()
 
@@ -128,7 +134,7 @@ class TestUnitKeysAPIClient:
     @responses.activate
     def test_get_used_lido_keys__empty_response__empty_list(
         self,
-        keys_api_client,
+        keys_api_client: KeysAPIClient,
         empty_blockstamp,
     ):
         responses.get(
@@ -152,7 +158,10 @@ class TestUnitKeysAPIClient:
 
     @responses.activate
     def test_get_used_lido_keys__outdated_block__raises_keys_outdated_exception(
-        self, keys_api_client, empty_blockstamp, monkeypatch
+        self,
+        keys_api_client: KeysAPIClient,
+        empty_blockstamp,
+        monkeypatch,
     ):
         responses.get(
             self.KEYS_API_MOCK_URL + keys_api_client.USED_KEYS,
@@ -177,7 +186,11 @@ class TestUnitKeysAPIClient:
         assert sleep_mock.call_count == keys_api_client.retry_count - 1
 
     @responses.activate
-    def test_get_used_lido_keys__server_error__raises_kapi_client_error(self, keys_api_client, empty_blockstamp):
+    def test_get_used_lido_keys__server_error__raises_kapi_client_error(
+        self,
+        keys_api_client: KeysAPIClient,
+        empty_blockstamp,
+    ):
         responses.get(
             self.KEYS_API_MOCK_URL + keys_api_client.USED_KEYS, status=500, json={'error': 'Internal Server Error'}
         )
@@ -186,7 +199,11 @@ class TestUnitKeysAPIClient:
             keys_api_client.get_used_lido_keys(empty_blockstamp)
 
     @responses.activate
-    def test_get_used_lido_keys__two_calls__one_http_request_cached(self, keys_api_client, empty_blockstamp):
+    def test_get_used_lido_keys__two_calls__one_http_request_cached(
+        self,
+        keys_api_client: KeysAPIClient,
+        empty_blockstamp,
+    ):
         responses.get(
             self.KEYS_API_MOCK_URL + keys_api_client.USED_KEYS,
             json={
@@ -202,14 +219,14 @@ class TestUnitKeysAPIClient:
         assert len(responses.calls) == 1
 
     @responses.activate
-    def test_get_module_operators_keys__empty_response__empty_lists(
+    def test_get_used_module_operators_keys__empty_response__empty_lists(
         self,
-        keys_api_client,
+        keys_api_client: KeysAPIClient,
         empty_blockstamp,
     ):
-        module_address = cast('0xdtestest', StakingModuleAddress)
+        module_address = cast(StakingModuleAddress, '0xdtestest')
         responses.get(
-            self.KEYS_API_MOCK_URL + keys_api_client.MODULE_OPERATORS_KEYS.format(module_address),
+            self.KEYS_API_MOCK_URL + keys_api_client.USED_MODULE_OPERATORS_KEYS.format(module_address),
             json={
                 'data': {'keys': [], 'module': {'stakingModuleAddress': str(module_address), 'id': 1}, 'operators': []},
                 'meta': {
@@ -223,18 +240,21 @@ class TestUnitKeysAPIClient:
             },
         )
 
-        result = keys_api_client.get_module_operators_keys(module_address, empty_blockstamp)
+        result = keys_api_client.get_used_module_operators_keys(module_address, empty_blockstamp)
 
         assert len(result['keys']) == 0
         assert len(result['operators']) == 0
 
     @responses.activate
-    def test_get_module_operators_keys__outdated_block__raises_keys_outdated_exception(
-        self, keys_api_client, empty_blockstamp, monkeypatch
+    def test_get_used_module_operators_keys__outdated_block__raises_keys_outdated_exception(
+        self,
+        keys_api_client: KeysAPIClient,
+        empty_blockstamp,
+        monkeypatch,
     ):
-        module_address = cast('0xdtestest', StakingModuleAddress)
+        module_address = cast(StakingModuleAddress, '0xdtestest')
         responses.get(
-            self.KEYS_API_MOCK_URL + keys_api_client.MODULE_OPERATORS_KEYS.format(module_address),
+            self.KEYS_API_MOCK_URL + keys_api_client.USED_MODULE_OPERATORS_KEYS.format(module_address),
             json={
                 'data': {'keys': [], 'module': {'stakingModuleAddress': str(module_address), 'id': 1}, 'operators': []},
                 'meta': {
@@ -251,27 +271,52 @@ class TestUnitKeysAPIClient:
 
         with monkeypatch.context() as m, pytest.raises(KeysOutdatedException):
             m.setattr(keys_api_client_module, 'sleep', sleep_mock)
-            keys_api_client.get_module_operators_keys(module_address, empty_blockstamp)
+            keys_api_client.get_used_module_operators_keys(module_address, empty_blockstamp)
 
         assert sleep_mock.call_count == keys_api_client.retry_count - 1
 
     @responses.activate
-    def test_get_module_operators_keys__server_error__raises_kapi_client_error(self, keys_api_client, empty_blockstamp):
-        module_address = cast('0xdtestest', StakingModuleAddress)
+    def test_get_used_lido_keys__used_False__raises_inconsistent_data_error(
+        self,
+        keys_api_client: KeysAPIClient,
+        empty_blockstamp,
+    ):
         responses.get(
-            self.KEYS_API_MOCK_URL + keys_api_client.MODULE_OPERATORS_KEYS.format(module_address),
+            self.KEYS_API_MOCK_URL + keys_api_client.USED_KEYS,
+            json={
+                'data': [{'key': '', 'used': False, 'operatorIndex': 0, 'moduleAddress': '', 'depositSignature': ''}],
+                'meta': {'elBlockSnapshot': {'blockNumber': 0}},
+            },
+        )
+
+        with pytest.raises(KAPIInconsistentData):
+            keys_api_client.get_used_lido_keys(empty_blockstamp)
+
+    @responses.activate
+    def test_get_used_module_operators_keys__server_error__raises_kapi_client_error(
+        self,
+        keys_api_client: KeysAPIClient,
+        empty_blockstamp,
+    ):
+        module_address = cast(StakingModuleAddress, '0xdtestest')
+        responses.get(
+            self.KEYS_API_MOCK_URL + keys_api_client.USED_MODULE_OPERATORS_KEYS.format(module_address),
             status=500,
             json={'error': 'Internal Server Error'},
         )
 
         with pytest.raises(KAPIClientError):
-            keys_api_client.get_module_operators_keys(module_address, empty_blockstamp)
+            keys_api_client.get_used_module_operators_keys(module_address, empty_blockstamp)
 
     @responses.activate
-    def test_get_module_operators_keys__two_calls__one_http_request_cached(self, keys_api_client, empty_blockstamp):
-        module_address = cast('0xdtestest', StakingModuleAddress)
+    def test_get_used_module_operators_keys__two_calls__one_http_request_cached(
+        self,
+        keys_api_client: KeysAPIClient,
+        empty_blockstamp,
+    ):
+        module_address = cast(StakingModuleAddress, '0xdtestest')
         responses.get(
-            self.KEYS_API_MOCK_URL + keys_api_client.MODULE_OPERATORS_KEYS.format(module_address),
+            self.KEYS_API_MOCK_URL + keys_api_client.USED_MODULE_OPERATORS_KEYS.format(module_address),
             json={
                 'data': {
                     'keys': [
@@ -290,8 +335,58 @@ class TestUnitKeysAPIClient:
             },
         )
 
-        result1 = keys_api_client.get_module_operators_keys(module_address, empty_blockstamp)
-        result2 = keys_api_client.get_module_operators_keys(module_address, empty_blockstamp)
+        result1 = keys_api_client.get_used_module_operators_keys(module_address, empty_blockstamp)
+        result2 = keys_api_client.get_used_module_operators_keys(module_address, empty_blockstamp)
 
         assert result1 == result2
         assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_get_used_module_operators_keys__invalid_module__raises_inconsistent_data_error(
+        self,
+        keys_api_client: KeysAPIClient,
+        empty_blockstamp,
+    ):
+        module_address = cast(StakingModuleAddress, '0xdtestest')
+        responses.get(
+            self.KEYS_API_MOCK_URL + keys_api_client.USED_MODULE_OPERATORS_KEYS.format(module_address),
+            json={
+                'data': {
+                    'keys': [],
+                    'module': {'stakingModuleAddress': 'SOME_OTHER_MODULE', 'id': 1},
+                },
+                'meta': {'elBlockSnapshot': {'blockNumber': 0}},
+            },
+        )
+
+        with pytest.raises(KAPIInconsistentData):
+            keys_api_client.get_used_module_operators_keys(module_address, empty_blockstamp)
+
+    @responses.activate
+    def test_get_used_module_operators_keys__used_False__raises_inconsistent_data_error(
+        self,
+        keys_api_client: KeysAPIClient,
+        empty_blockstamp,
+    ):
+        module_address = cast(StakingModuleAddress, '0xdtestest')
+        responses.get(
+            self.KEYS_API_MOCK_URL + keys_api_client.USED_MODULE_OPERATORS_KEYS.format(module_address),
+            json={
+                'data': {
+                    'keys': [
+                        {
+                            'key': '',
+                            'used': False,
+                            'operatorIndex': 0,
+                            'moduleAddress': str(module_address),
+                            'depositSignature': '',
+                        }
+                    ],
+                    'module': {'stakingModuleAddress': str(module_address), 'id': 1},
+                },
+                'meta': {'elBlockSnapshot': {'blockNumber': 0}},
+            },
+        )
+
+        with pytest.raises(KAPIInconsistentData):
+            keys_api_client.get_used_module_operators_keys(module_address, empty_blockstamp)


### PR DESCRIPTION
## Description

Fixes #740

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [x] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
