### PR TITLE
fix: use `/usr/bin/env` in shebang

### DIFF
--- a/kubo/020-pin-cids.sh
+++ b/kubo/020-pin-cids.sh
@@ -1,4 +1,4 @@
-#!/bin/env sh
+#!/usr/bin/env sh
 
 set -eu
 


### PR DESCRIPTION
## Description
changed the shebang to `/usr/bin/env sh` so the script works on more systems.


## How Has This Been Tested?
Describe how you tested the changes:
- [ ] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [ ] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
