### PR TITLE
feat: add `0x02` support

### DIFF
--- a/src/modules/csm/distribution.py
+++ b/src/modules/csm/distribution.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from copy import deepcopy
 from dataclasses import dataclass, field
 
-from src.constants import MIN_ACTIVATION_BALANCE, MAX_EFFECTIVE_BALANCE_ELECTRA
+from src.constants import MIN_ACTIVATION_BALANCE, MAX_EFFECTIVE_BALANCE_ELECTRA, EFFECTIVE_BALANCE_INCREMENT
 from src.modules.csm.helpers.last_report import LastReport
 from src.modules.csm.log import FramePerfLog, OperatorFrameSummary
 from src.modules.csm.state import Frame, State, ValidatorDuties
@@ -258,8 +258,11 @@ class Distribution:
             #    87.55 ≈ 88 of 103 participation shares should be counted for the operator key's reward.
             #    The rest 15 participation shares should be counted for the protocol's rebate.
             #
-            val_effective_balance = min(validator.validator.effective_balance, MAX_EFFECTIVE_BALANCE_ELECTRA)
-            participation_share_multiplier = max(1, val_effective_balance // MIN_ACTIVATION_BALANCE)
+            val_effective_balance = min(
+                max(MIN_ACTIVATION_BALANCE, validator.validator.effective_balance),
+                MAX_EFFECTIVE_BALANCE_ELECTRA
+            )
+            participation_share_multiplier = val_effective_balance // EFFECTIVE_BALANCE_INCREMENT
             #
             # Due to CL rewarding process, validators are getting rewards in proportion to their effective balance:
             # https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md#helpers

--- a/tests/modules/csm/test_csm_distribution.py
+++ b/tests/modules/csm/test_csm_distribution.py
@@ -7,8 +7,12 @@ import pytest
 from hexbytes import HexBytes
 from web3.types import Wei
 
-from src.constants import TOTAL_BASIS_POINTS, MAX_EFFECTIVE_BALANCE_ELECTRA, MIN_ACTIVATION_BALANCE, \
-    EFFECTIVE_BALANCE_INCREMENT
+from src.constants import (
+    TOTAL_BASIS_POINTS,
+    MAX_EFFECTIVE_BALANCE_ELECTRA,
+    MIN_ACTIVATION_BALANCE,
+    EFFECTIVE_BALANCE_INCREMENT,
+)
 from src.modules.csm.distribution import Distribution, ValidatorDuties, ValidatorDutiesOutcome
 from src.modules.csm.log import FramePerfLog, ValidatorFrameSummary, OperatorFrameSummary
 from src.modules.csm.state import DutyAccumulator, State, NetworkDuties, Frame

--- a/tests/modules/csm/test_csm_distribution.py
+++ b/tests/modules/csm/test_csm_distribution.py
@@ -7,7 +7,8 @@ import pytest
 from hexbytes import HexBytes
 from web3.types import Wei
 
-from src.constants import TOTAL_BASIS_POINTS, MAX_EFFECTIVE_BALANCE_ELECTRA, MIN_ACTIVATION_BALANCE
+from src.constants import TOTAL_BASIS_POINTS, MAX_EFFECTIVE_BALANCE_ELECTRA, MIN_ACTIVATION_BALANCE, \
+    EFFECTIVE_BALANCE_INCREMENT
 from src.modules.csm.distribution import Distribution, ValidatorDuties, ValidatorDutiesOutcome
 from src.modules.csm.log import FramePerfLog, ValidatorFrameSummary, OperatorFrameSummary
 from src.modules.csm.state import DutyAccumulator, State, NetworkDuties, Frame
@@ -912,7 +913,7 @@ def test_get_network_performance_raises_error_for_invalid_performance():
             False,
             0.5,
             1,
-            ValidatorDutiesOutcome(participation_share=10, rebate_share=0, strikes=0),
+            ValidatorDutiesOutcome(participation_share=10 * 32, rebate_share=0, strikes=0),
         ),
         (
             ValidatorDuties(
@@ -923,7 +924,7 @@ def test_get_network_performance_raises_error_for_invalid_performance():
             False,
             0.5,
             0.85,
-            ValidatorDutiesOutcome(participation_share=9, rebate_share=1, strikes=0),
+            ValidatorDutiesOutcome(participation_share=272, rebate_share=48, strikes=0),
         ),
         (
             ValidatorDuties(
@@ -1254,7 +1255,7 @@ def test_get_validator_duties_outcome_scales_by_effective_balance(multiplier: in
         log_operator,
     )
 
-    expected_assigned = 10 * multiplier
+    expected_assigned = 10 * MIN_ACTIVATION_BALANCE * multiplier // EFFECTIVE_BALANCE_INCREMENT
     expected_participation = math.ceil(expected_assigned * reward_share)
     expected_rebate = expected_assigned - expected_participation
 


### PR DESCRIPTION
## Description
Account for effective balance in rewards distribution process

## Related Issue/Task
- Related task: [CS-857](https://linear.app/lidofi/issue/CS-857/sort-validators-by-effective-balance-and-not-validator-index-in-cm-v2), [CS-858](https://linear.app/lidofi/issue/CS-858/account-for-the-validator-balance-when-distributing-rewards)
- Epic: CMv2 + CSMv3

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (`pytest tests/modules/csm/test_csm_distribution.py`)

## Checklist
- [ ] Documentation updated (if required)
- [x] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
