### PR TITLE
[CSM v2] fix: Fulu fork epoch duties

### DIFF
--- a/src/modules/csm/checkpoint.py
+++ b/src/modules/csm/checkpoint.py
@@ -384,7 +384,14 @@ class FrameCheckpointProcessor:
         checkpoint_slot: SlotNumber
     ) -> BlockRoot:
         dependent_root = None
-        dependent_slot = self.converter.get_epoch_last_slot(EpochNumber(epoch - 1))
+        cc_config = self.cc.get_config_spec()
+        # `dependent_root` on Fulu Fork Epoch duties is equal to the last slot of `epoch - 1`, as usual.
+        # AFTER Fulu Fork Epoch epochs duties have `dependent_root` that equals to the last slot of `epoch - 2`.
+        dependent_epoch = EpochNumber(epoch - 1)
+        is_after_fulu_fork = epoch > cc_config.FULU_FORK_EPOCH
+        if is_after_fulu_fork:
+            dependent_epoch = EpochNumber(epoch - 2)
+        dependent_slot = self.converter.get_epoch_last_slot(dependent_epoch)
         try:
             while not dependent_root:
                 dependent_root = self._select_block_root_by_slot(

--- a/src/providers/consensus/client.py
+++ b/src/providers/consensus/client.py
@@ -190,7 +190,8 @@ class ConsensusClient(HTTPProvider):
             data_is_list(data, meta, endpoint=endpoint)
             # It is recommended by spec to use the dependent root to ensure the epoch is correct
             if meta["dependent_root"] != expected_dependent_root:
-                raise ValueError(
+                # TODO: Rise error when all clients return correct dependent root after Fulu Fork Epoch
+                logger.warning(
                     "Dependent root for proposer duties request mismatch: "
                     f"{meta['dependent_root']=} is not {expected_dependent_root=}. "
                     "Probably, CL node is not fully synced."

--- a/src/providers/consensus/types.py
+++ b/src/providers/consensus/types.py
@@ -27,6 +27,7 @@ class BeaconSpecResponse(Nested, FromResponse):
     SECONDS_PER_SLOT: int
     DEPOSIT_CONTRACT_ADDRESS: str
     SLOTS_PER_HISTORICAL_ROOT: int
+    FULU_FORK_EPOCH: int
 
 
 @dataclass


### PR DESCRIPTION
## Description
We faced an issue with eth/v1/validator/duties/proposer/{epoch} on Hoodi after Fulu fork for Lighthouse:
For example, /eth/v1/validator/duties/proposer/50700 returns "dependent_root": 0x136c16abf7ed785f6babd0ff2b779d29a3c174355c22fafd5eb801c1d81a63ac (the last slot of {epoch} - 2) in body, but it should be 0xd2b43eb8f039f728881167d117bf939a03d3e0e824c61402d76045eed28bcfa5 (the last slot of {epoch} - 1) due to https://ethereum.github.io/beacon-APIs/#/Validator/getProposerDuties. 

As a second source, we used Nimbus - http://unstable.hoodi.beacon-api.nimbus.team/eth/v1/validator/duties/proposer/50700

Version: Lighthouse/v8.0.0-rc.2-b59feb0/x86_64-linux

We found no changes for this response in other nodes' source code:
Prysm - https://github.com/OffchainLabs/prysm/blob/develop/beacon-chain/rpc/eth/validator/handlers.go#L1473
Lodestar - https://github.com/ChainSafe/lodestar/blob/rc/v1.36.0/packages/state-transition/src/util/shufflingDecisionRoot.ts#L13
Nimbus - https://github.com/status-im/nimbus-eth2/blob/unstable/beacon_chain/spec/beaconstate.nim#L2814

## How Has This Been Tested?
Describe how you tested the changes:
- [X] Local tests (Fork tests on Hoodi)

## Checklist
- [ ] New tests added
