### PR TITLE
feat: add versions to perf logs

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -62,5 +62,6 @@ UINT256_MAX = 2**256 - 1
 
 ALLOWED_KAPI_VERSION = Version('1.5.0')
 CSM_STATE_VERSION = 1
+CSM_LOGS_VERSION = 1
 
 GENESIS_VALIDATORS_ROOT = bytes([0] * 32)  # all zeros for deposits

--- a/src/modules/csm/csm.py
+++ b/src/modules/csm/csm.py
@@ -20,7 +20,7 @@ from src.modules.csm.distribution import (
     StrikesValidator,
 )
 from src.modules.csm.helpers.last_report import LastReport
-from src.modules.csm.log import FramePerfLog
+from src.modules.csm.log import Logs
 from src.modules.csm.state import State
 from src.modules.csm.tree import RewardsTree, StrikesTree, Tree
 from src.modules.csm.types import ReportData, RewardsShares, StrikesList
@@ -253,8 +253,8 @@ class CSOracle(BaseModule, ConsensusModule):
         logger.info({"msg": "Tree dump uploaded to IPFS", "cid": repr(tree_cid)})
         return tree_cid
 
-    def publish_log(self, logs: list[FramePerfLog]) -> CID:
-        log_cid = self.w3.ipfs.publish(FramePerfLog.encode(logs))
+    def publish_log(self, logs: Logs) -> CID:
+        log_cid = self.w3.ipfs.publish(logs.encode())
         logger.info({"msg": "Frame(s) log uploaded to IPFS", "cid": repr(log_cid)})
         return log_cid
 

--- a/src/modules/csm/distribution.py
+++ b/src/modules/csm/distribution.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 
 from src.constants import MIN_ACTIVATION_BALANCE, MAX_EFFECTIVE_BALANCE_ELECTRA, EFFECTIVE_BALANCE_INCREMENT
 from src.modules.csm.helpers.last_report import LastReport
-from src.modules.csm.log import FramePerfLog, OperatorFrameSummary
+from src.modules.csm.log import FramePerfLog, OperatorFrameSummary, Logs
 from src.modules.csm.state import Frame, State, ValidatorDuties
 from src.modules.csm.types import (
     ParticipationShares,
@@ -49,7 +49,7 @@ class DistributionResult:
     total_rebate: RewardsShares = 0
     total_rewards_map: dict[NodeOperatorId, RewardsShares] = field(default_factory=lambda: defaultdict(RewardsShares))
     strikes: dict[StrikesValidator, StrikesList] = field(default_factory=lambda: defaultdict(StrikesList))
-    logs: list[FramePerfLog] = field(default_factory=list)
+    logs: Logs = field(default_factory=Logs)
 
 
 class Distribution:
@@ -100,7 +100,7 @@ class Distribution:
             for no_id, rewards in rewards_map_in_frame.items():
                 result.total_rewards_map[no_id] += rewards
 
-            result.logs.append(frame_log)
+            result.logs.frames.append(frame_log)
 
         if result.total_rewards != sum(result.total_rewards_map.values()):
             raise InconsistentData(

--- a/src/modules/csm/log.py
+++ b/src/modules/csm/log.py
@@ -2,6 +2,7 @@ import json
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 
+from src.constants import CSM_LOGS_VERSION
 from src.modules.csm.state import DutyAccumulator
 from src.modules.csm.types import RewardsShares
 from src.providers.execution.contracts.cs_parameters_registry import PerformanceCoefficients
@@ -43,14 +44,19 @@ class FramePerfLog:
         default_factory=lambda: defaultdict(OperatorFrameSummary)
     )
 
-    @staticmethod
-    def encode(logs: list['FramePerfLog']) -> bytes:
+
+@dataclass
+class Logs:
+    frames: list[FramePerfLog] = field(default_factory=list)
+    _ver: int = CSM_LOGS_VERSION
+
+    def encode(self) -> bytes:
         return (
             LogJSONEncoder(
                 indent=None,
                 separators=(',', ':'),
                 sort_keys=True,
             )
-            .encode([asdict(log) for log in logs])
+            .encode(asdict(self))
             .encode()
         )

--- a/tests/modules/csm/test_csm_distribution.py
+++ b/tests/modules/csm/test_csm_distribution.py
@@ -9,7 +9,6 @@ from web3.types import Wei
 
 from src.constants import (
     TOTAL_BASIS_POINTS,
-    MAX_EFFECTIVE_BALANCE_ELECTRA,
     MIN_ACTIVATION_BALANCE,
     EFFECTIVE_BALANCE_INCREMENT,
 )
@@ -315,8 +314,8 @@ def test_calculate_distribution(
     assert result.total_rebate == expected_total_rebate
     assert result.strikes == expected_strikes
 
-    assert len(result.logs) == len(frames)
-    for i, log in enumerate(result.logs):
+    assert len(result.logs.frames) == len(frames)
+    for i, log in enumerate(result.logs.frames):
         assert log.blockstamp == frame_blockstamps[i]
         assert log.frame == frames[i]
 

--- a/tests/modules/csm/test_csm_module.py
+++ b/tests/modules/csm/test_csm_module.py
@@ -7,9 +7,10 @@ from unittest.mock import Mock, PropertyMock, patch
 import pytest
 from hexbytes import HexBytes
 
-from src.constants import UINT64_MAX
+from src.constants import UINT64_MAX, CSM_LOGS_VERSION
 from src.modules.csm.csm import CSOracle, LastReport
 from src.modules.csm.distribution import Distribution
+from src.modules.csm.log import Logs
 from src.modules.csm.state import State
 from src.modules.csm.tree import RewardsTree, StrikesTree
 from src.modules.csm.types import StrikesList
@@ -402,7 +403,7 @@ class BuildReportTestParam:
                         total_rewards_map=defaultdict(int),
                         total_rebate=0,
                         strikes=defaultdict(dict),
-                        logs=[Mock()],
+                        logs=Logs(frames=[Mock()]),
                     )
                 ),
                 curr_rewards_tree_root=HexBytes(ZERO_HASH),
@@ -444,7 +445,7 @@ class BuildReportTestParam:
                         ),
                         total_rebate=1,
                         strikes=defaultdict(dict),
-                        logs=[Mock()],
+                        logs=Logs(frames=[Mock()]),
                     )
                 ),
                 curr_rewards_tree_root=HexBytes("NEW_TREE_ROOT".encode()),
@@ -494,7 +495,7 @@ class BuildReportTestParam:
                         ),
                         total_rebate=1,
                         strikes=defaultdict(dict),
-                        logs=[Mock()],
+                        logs=Logs(frames=[Mock()]),
                     )
                 ),
                 curr_rewards_tree_root=HexBytes("NEW_TREE_ROOT".encode()),
@@ -536,7 +537,7 @@ class BuildReportTestParam:
                         total_rewards_map=defaultdict(int),
                         total_rebate=0,
                         strikes=defaultdict(dict),
-                        logs=[Mock()],
+                        logs=Logs(frames=[Mock()]),
                     )
                 ),
                 curr_rewards_tree_root=HexBytes(32),
@@ -583,6 +584,7 @@ def test_build_report(module: CSOracle, param: BuildReportTestParam):
 
     assert module.make_rewards_tree.call_args == param.expected_make_rewards_tree_call_args
     assert report == param.expected_func_result
+    assert module.publish_log.call_args[0][0]._ver == CSM_LOGS_VERSION
 
 
 @pytest.mark.unit

--- a/tests/modules/csm/test_log.py
+++ b/tests/modules/csm/test_log.py
@@ -1,7 +1,8 @@
 import json
 import pytest
 
-from src.modules.csm.log import FramePerfLog, DutyAccumulator
+from src.constants import CSM_LOGS_VERSION
+from src.modules.csm.log import FramePerfLog, DutyAccumulator, Logs
 from src.providers.execution.contracts.cs_parameters_registry import PerformanceCoefficients
 from src.types import EpochNumber, NodeOperatorId, ReferenceBlockStamp
 from tests.factory.blockstamp import ReferenceBlockStampFactory
@@ -54,12 +55,15 @@ def test_logs_encode(log: FramePerfLog):
     log_2.distributed_rewards = 0
     log_2.rebate_to_protocol = 0
 
-    logs = [log, log_2]
+    logs = Logs(frames=[log, log_2])
 
-    encoded = FramePerfLog.encode(logs)
+    encoded = logs.encode()
 
-    decoded_logs = json.loads(encoded)
+    decoded_logs_data = json.loads(encoded)
 
+    assert decoded_logs_data['_ver'] == 1
+
+    decoded_logs = decoded_logs_data['frames']
     for decoded in decoded_logs:
         assert decoded["operators"]["42"]["validators"]["41337"]["attestation_duty"]["assigned"] == 220
         assert decoded["operators"]["42"]["validators"]["41337"]["attestation_duty"]["included"] == 119


### PR DESCRIPTION
## Description
Added Perf Log version to simplify schema selection for parsing data on UI.

## Related Issue/Task
- Related task: [CS-855](https://linear.app/lidofi/issue/CS-855/add-log-version-to-the-performance-log)

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)

## Checklist
- [x] New tests added (if applicable)
