### PR TITLE
feat: add lru_cache for `calculate_distribution`

### DIFF
--- a/src/modules/csm/csm.py
+++ b/src/modules/csm/csm.py
@@ -136,6 +136,7 @@ class CSOracle(BaseModule, ConsensusModule):
         current_frame = self.get_frame_number_by_slot(blockstamp)
         return LastReport.load(self.w3, blockstamp, current_frame)
 
+    @lru_cache(maxsize=1)
     def calculate_distribution(self, blockstamp: ReferenceBlockStamp, last_report: LastReport) -> DistributionResult:
         distribution = Distribution(self.w3, self.converter(blockstamp), self.state)
         result = distribution.calculate(blockstamp, last_report)

--- a/tests/modules/csm/test_csm_module.py
+++ b/tests/modules/csm/test_csm_module.py
@@ -635,6 +635,37 @@ def test_execute_module_processed(module: CSOracle):
     assert execute_delay is ModuleExecuteDelay.NEXT_SLOT
 
 
+@pytest.mark.unit
+def test_calculate_distribution_lru_cache(module: CSOracle):
+    blockstamp = Mock()
+    last_report = Mock()
+    mock_distribution_result = Mock()
+
+    with patch('src.modules.csm.csm.Distribution') as MockDistribution:
+        mock_distribution_instance = MockDistribution.return_value
+        mock_distribution_instance.calculate.return_value = mock_distribution_result
+
+        module.converter = Mock()
+        module.state = Mock()
+
+        result1 = module.calculate_distribution(blockstamp, last_report)
+
+        result2 = module.calculate_distribution(blockstamp, last_report)
+
+        assert result1 is result2
+        assert result1 is mock_distribution_result
+
+        assert MockDistribution.call_count == 1
+        assert mock_distribution_instance.calculate.call_count == 1
+
+        module.calculate_distribution.cache_clear()
+
+        result3 = module.calculate_distribution(blockstamp, last_report)
+
+        assert MockDistribution.call_count == 2
+        assert result3 is mock_distribution_result
+
+
 @dataclass(frozen=True)
 class RewardsTreeTestParam:
     shares: dict[NodeOperatorId, int]


### PR DESCRIPTION
## Description
To not recalculate distribution on IPFS publishing errors

## Related Issue/Task
- Related task: [CS-892](https://linear.app/lidofi/issue/CS-892/do-not-rebuild-report-on-ipfs-errors)

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)

## Checklist
- [x] New tests added (if applicable)

