### PR TITLE
Feature/orc 575 oracle metrics and alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ poetry-lock: up
 
 lint: up
 	$(EXEC_CMD) ruff format tests
-	$(EXEC_CMD) ruff check src tests
+	$(EXEC_CMD) ruff check --fix tests
+	$(EXEC_CMD) ruff check src
 	$(EXEC_CMD) pyright src
 
 isort: up

--- a/README.md
+++ b/README.md
@@ -234,29 +234,7 @@ In manual mode all sleeps are disabled and `ALLOW_REPORTING_IN_BUNKER_MODE` is T
 
 ### Alerts
 
-A few basic alerts, which can be configured in the [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/).
-
-```yaml
-groups:
-  - name: oracle-alerts
-    rules:
-      - alert: AccountBalance
-        expr: lido_oracle_account_balance / 10^18 < 1
-        for: 10m
-        labels:
-          severity: critical
-        annotations:
-          summary: "Dangerously low account balance"
-          description: "Account balance is less than 1 ETH. Address: {.labels.address}: {.value} ETH"
-      - alert: OutdatedData
-        expr: (lido_oracle_genesis_time + ignoring (state) lido_oracle_slot_number{state="head"} * 12) < time() - 300
-        for: 1h
-        labels:
-          severity: critical
-        annotations:
-          summary: "Outdated Consensus Layer HEAD slot"
-          description: "Processed by Oracle HEAD slot {.value} too old"
-```
+Check out our [alerting guide](docs/alerts.md) for Prometheus Alertmanager configuration examples.
 
 ### Metrics
 

--- a/docs/alerts.md
+++ b/docs/alerts.md
@@ -1,0 +1,184 @@
+# Alerts Examples
+
+This document provides **example** Prometheus alerts for monitoring Oracle health. These are starting points that you should adjust based on your infrastructure and operational requirements.
+
+All examples use [Prometheus Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/) format.
+
+## Basic Alerts
+
+### Account Balance
+
+Alert when the Oracle member account balance is critically low:
+
+```yaml
+- alert: OracleAccountBalanceLow
+  expr: lido_oracle_account_balance / 10^18 < 1
+  for: 10m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Dangerously low account balance"
+    description: "Account balance is less than 1 ETH. Address: {{ $labels.address }}: {{ $value }} ETH"
+```
+
+### Outdated Consensus Layer Data
+
+Alert when the Oracle is processing stale CL data:
+
+```yaml
+- alert: OracleOutdatedCLData
+  expr: (lido_oracle_genesis_time + ignoring(state) lido_oracle_slot_number{state="head"} * 12) < time() - 300
+  for: 1h
+  labels:
+    severity: critical
+  annotations:
+    summary: "Outdated Consensus Layer HEAD slot"
+    description: "Processed by Oracle HEAD slot {{ $value }} too old"
+```
+
+## Cycle Health Alerts
+
+These alerts monitor the Oracle's operational cycles using the `lido_oracle_cycle_count` and `lido_oracle_last_cycle_timestamp` metrics.
+
+> **Note:** The default `MAX_CYCLE_LIFETIME_IN_SECONDS` is 3000 (50 minutes), meaning a single cycle can take up to 50 minutes to complete. Alert thresholds are set accordingly to avoid false positives.
+
+### High Error Rate
+
+Alert when the error rate is too high:
+
+```yaml
+- alert: OracleHighErrorRate
+  expr: |
+    (
+      rate(lido_oracle_cycle_count{result="error"}[1h])
+      /
+      (rate(lido_oracle_cycle_count{result="success"}[1h]) + rate(lido_oracle_cycle_count{result="error"}[1h]) > 0)
+    ) > 0.5
+  for: 30m
+  labels:
+    severity: warning
+  annotations:
+    summary: "High Oracle cycle error rate"
+    description: "More than 50% of Oracle cycles are failing. Error rate: {{ $value | humanizePercentage }}"
+```
+
+### No Successful Cycles
+
+Alert when there are no successful cycles for a prolonged period:
+
+```yaml
+- alert: OracleNoSuccessfulCycles
+  expr: time() - lido_oracle_last_cycle_timestamp{result="success"} > 7200
+  for: 5m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Oracle has not completed a successful cycle recently"
+    description: "No successful Oracle cycle in the last 2 hours. Last successful cycle was {{ $value | humanizeDuration }} ago."
+```
+
+### Oracle Completely Stuck
+
+Alert when the Oracle has stopped processing cycles entirely (no cycles at all, not even errors):
+
+```yaml
+- alert: OracleStuck
+  expr: time() - max(lido_oracle_last_cycle_timestamp) > 7200
+  for: 5m
+  labels:
+    severity: critical
+  annotations:
+    summary: "Oracle appears to be stuck"
+    description: "No Oracle cycles (successful or failed) have completed in the last 2 hours. The Oracle process may have crashed or hung."
+```
+
+> **Note:** Uses `max()` to get the most recent cycle timestamp regardless of result type. The `last_cycle_timestamp{result="error"}` metric only appears after the first error occurs.
+
+## Transaction Alerts
+
+### Failed Transactions
+
+Alert when transactions are failing:
+
+```yaml
+- alert: OracleTransactionFailures
+  expr: increase(lido_oracle_transactions_count{status="failure"}[24h]) > 0
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Oracle transaction failures detected"
+    description: "{{ $value }} failed transactions in the last 24 hours."
+```
+
+## Full Configuration Example
+
+Example Alertmanager rules file with all alerts combined:
+
+```yaml
+groups:
+  - name: oracle-basic
+    rules:
+      - alert: OracleAccountBalanceLow
+        expr: lido_oracle_account_balance / 10^18 < 1
+        for: 10m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Dangerously low account balance"
+          description: "Account balance is less than 1 ETH. Address: {{ $labels.address }}: {{ $value }} ETH"
+
+      - alert: OracleOutdatedCLData
+        expr: (lido_oracle_genesis_time + ignoring(state) lido_oracle_slot_number{state="head"} * 12) < time() - 300
+        for: 1h
+        labels:
+          severity: critical
+        annotations:
+          summary: "Outdated Consensus Layer HEAD slot"
+          description: "Processed by Oracle HEAD slot {{ $value }} too old"
+
+  - name: oracle-cycle-health
+    rules:
+      - alert: OracleHighErrorRate
+        expr: |
+          (
+            rate(lido_oracle_cycle_count{result="error"}[1h])
+            /
+            (rate(lido_oracle_cycle_count{result="success"}[1h]) + rate(lido_oracle_cycle_count{result="error"}[1h]) > 0)
+          ) > 0.5
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High Oracle cycle error rate"
+          description: "More than 50% of Oracle cycles are failing."
+
+      - alert: OracleNoSuccessfulCycles
+        expr: time() - lido_oracle_last_cycle_timestamp{result="success"} > 7200
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Oracle has not completed a successful cycle recently"
+          description: "No successful Oracle cycle in the last 2 hours."
+
+      - alert: OracleStuck
+        expr: time() - max(lido_oracle_last_cycle_timestamp) > 7200
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Oracle appears to be stuck"
+          description: "No Oracle cycles have completed in the last 2 hours."
+
+  - name: oracle-transactions
+    rules:
+      - alert: OracleTransactionFailures
+        expr: increase(lido_oracle_transactions_count{status="failure"}[24h]) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oracle transaction failures detected"
+          description: "Failed transactions detected in the last 24 hours."
+```

--- a/src/main.py
+++ b/src/main.py
@@ -95,7 +95,7 @@ def main(module_name: OracleModule):
 
     logger.info({'msg': 'Initialize prometheus metrics.'})
     init_metrics()
-    init_basic_metrics()
+    init_basic_metrics(web3)
 
     instance: Accounting | Ejector | CSOracle
     if module_name == OracleModule.ACCOUNTING:

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,7 @@
 import sys
-from typing import Iterator, cast
+from collections.abc import Iterator
+from decimal import getcontext
+from typing import cast
 
 from packaging.version import Version
 from prometheus_client import start_http_server
@@ -20,9 +22,9 @@ from src.utils.build import get_build_info
 from src.utils.exception import IncompatibleException
 from src.web3py.contract_tweak import tweak_w3_contracts
 from src.web3py.extensions import (
+    IPFS,
     ConsensusClientModule,
     FallbackProviderModule,
-    IPFS,
     KeysAPIClientModule,
     LazyCSM,
     LidoContracts,
@@ -30,7 +32,7 @@ from src.web3py.extensions import (
     TransactionUtils,
 )
 from src.web3py.types import Web3
-from decimal import getcontext
+
 
 getcontext().prec = PRECISION_E27
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from src import constants, variables
 from src.constants import PRECISION_E27
 from src.metrics.healthcheck_server import start_pulse_server
 from src.metrics.logging import logging
-from src.metrics.prometheus.basic import BUILD_INFO, ENV_VARIABLES_INFO
+from src.metrics.prometheus.basic import BUILD_INFO, ENV_VARIABLES_INFO, init_basic_metrics
 from src.modules.accounting.accounting import Accounting
 from src.modules.checks.checks_module import ChecksModule
 from src.modules.csm.csm import CSOracle
@@ -93,6 +93,7 @@ def main(module_name: OracleModule):
 
     logger.info({'msg': 'Initialize prometheus metrics.'})
     init_metrics()
+    init_basic_metrics()
 
     instance: Accounting | Ejector | CSOracle
     if module_name == OracleModule.ACCOUNTING:

--- a/src/metrics/prometheus/basic.py
+++ b/src/metrics/prometheus/basic.py
@@ -11,6 +11,11 @@ class Status(Enum):
     FAILURE = 'failure'
 
 
+class CycleResult(Enum):
+    SUCCESS = 'success'
+    ERROR = 'error'
+
+
 BUILD_INFO = Info(
     'build',
     'Build info',
@@ -88,3 +93,32 @@ TRANSACTIONS_COUNT = Counter(
     ['status'],
     namespace=PROMETHEUS_PREFIX,
 )
+
+CYCLE_COUNT = Counter(
+    'cycle_count',
+    'Total count of oracle cycles',
+    ['result'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+LAST_CYCLE_TIMESTAMP = Gauge(
+    'last_cycle_timestamp',
+    'Unix timestamp of the last completed oracle cycle',
+    ['result'],
+    namespace=PROMETHEUS_PREFIX,
+)
+
+
+def init_basic_metrics() -> None:
+    """
+    Initialize metrics with all expected label combinations.
+
+    This ensures metrics exist with value 0 even before first use,
+    preventing issues with Prometheus queries like increase() returning
+    nothing (instead of 0) after service restarts.
+    """
+    for status in Status:
+        TRANSACTIONS_COUNT.labels(status=status.value)
+    for result in CycleResult:
+        CYCLE_COUNT.labels(result=result.value)
+        LAST_CYCLE_TIMESTAMP.labels(result=result.value)

--- a/src/metrics/prometheus/basic.py
+++ b/src/metrics/prometheus/basic.py
@@ -1,3 +1,4 @@
+import time
 from enum import Enum
 
 from prometheus_client import Counter, Gauge, Histogram, Info
@@ -121,4 +122,4 @@ def init_basic_metrics() -> None:
         TRANSACTIONS_COUNT.labels(status=status.value)
     for result in CycleResult:
         CYCLE_COUNT.labels(result=result.value)
-        LAST_CYCLE_TIMESTAMP.labels(result=result.value)
+    LAST_CYCLE_TIMESTAMP.labels(result=CycleResult.SUCCESS.value).set(time.time())

--- a/src/metrics/prometheus/basic.py
+++ b/src/metrics/prometheus/basic.py
@@ -4,6 +4,7 @@ from enum import Enum
 from prometheus_client import Counter, Gauge, Histogram, Info
 from prometheus_client.utils import INF
 
+from src import variables
 from src.variables import PROMETHEUS_PREFIX
 
 
@@ -110,16 +111,23 @@ LAST_CYCLE_TIMESTAMP = Gauge(
 )
 
 
-def init_basic_metrics() -> None:
+def init_basic_metrics(w3) -> None:
     """
-    Initialize metrics with all expected label combinations.
+    Initialize metrics with their current values.
 
-    This ensures metrics exist with value 0 even before first use,
-    preventing issues with Prometheus queries like increase() returning
-    nothing (instead of 0) after service restarts.
+    Ensures Gauge metrics (LAST_CYCLE_TIMESTAMP, ACCOUNT_BALANCE) are populated
+    with actual values at startup, making them immediately available for monitoring.
+    Counter metrics are initialized with label combinations for consistency.
     """
     for status in Status:
         TRANSACTIONS_COUNT.labels(status=status.value)
+
     for result in CycleResult:
         CYCLE_COUNT.labels(result=result.value)
+
     LAST_CYCLE_TIMESTAMP.labels(result=CycleResult.SUCCESS.value).set(time.time())
+
+    if variables.ACCOUNT:
+        ACCOUNT_BALANCE.labels(address=variables.ACCOUNT.address).set(
+            w3.eth.get_balance(variables.ACCOUNT.address)
+        )

--- a/src/modules/submodules/oracle_module.py
+++ b/src/modules/submodules/oracle_module.py
@@ -73,7 +73,7 @@ class BaseModule(ABC):
         Main cycle logic: fetch the last finalized slot, refresh contracts if necessary,
         and execute the module's business logic.
         """
-        cycle_error = True
+        cycle_result = CycleResult.ERROR
         try:
             blockstamp = self._receive_last_finalized_slot()
 
@@ -83,12 +83,12 @@ class BaseModule(ABC):
                     'msg': 'Skipping the report. Waiting for new finalized slot.',
                     'slot_threshold': self._slot_threshold,
                 })
-                cycle_error = False
+                cycle_result = CycleResult.SUCCESS
                 return
 
             self.refresh_contracts_if_address_change()
             self.run_cycle(blockstamp)
-            cycle_error = False
+            cycle_result = CycleResult.SUCCESS
         except IsNotMemberException as error:
             logger.error({'msg': 'Provided account is not part of Oracle`s committee.'})
             raise error
@@ -123,7 +123,6 @@ class BaseModule(ABC):
         except ValueError as error:
             logger.error({'msg': 'Unexpected error.', 'error': str(error)})
         finally:
-            cycle_result = CycleResult.ERROR if cycle_error else CycleResult.SUCCESS
             CYCLE_COUNT.labels(result=cycle_result.value).inc()
             LAST_CYCLE_TIMESTAMP.labels(result=cycle_result.value).set(time.time())
 

--- a/src/modules/submodules/oracle_module.py
+++ b/src/modules/submodules/oracle_module.py
@@ -78,6 +78,7 @@ class BaseModule(ABC):
                     'msg': 'Skipping the report. Waiting for new finalized slot.',
                     'slot_threshold': self._slot_threshold,
                 })
+                cycle_error = False
                 return
 
             self.refresh_contracts_if_address_change()
@@ -116,10 +117,10 @@ class BaseModule(ABC):
             logger.error({'msg': 'IPFS provider error.', 'error': str(error)})
         except ValueError as error:
             logger.error({'msg': 'Unexpected error.', 'error': str(error)})
-
-        cycle_result = CycleResult.ERROR if cycle_error else CycleResult.SUCCESS
-        CYCLE_COUNT.labels(result=cycle_result.value).inc()
-        LAST_CYCLE_TIMESTAMP.labels(result=cycle_result.value).set(time.time())
+        finally:
+            cycle_result = CycleResult.ERROR if cycle_error else CycleResult.SUCCESS
+            CYCLE_COUNT.labels(result=cycle_result.value).inc()
+            LAST_CYCLE_TIMESTAMP.labels(result=cycle_result.value).set(time.time())
 
     @staticmethod
     def _reset_cycle_timeout():

--- a/src/modules/submodules/oracle_module.py
+++ b/src/modules/submodules/oracle_module.py
@@ -11,7 +11,7 @@ from timeout_decorator import timeout, TimeoutError as DecoratorTimeoutError
 from web3.exceptions import Web3Exception
 
 from src.metrics.healthcheck_server import pulse
-from src.metrics.prometheus.basic import ORACLE_BLOCK_NUMBER, ORACLE_SLOT_NUMBER
+from src.metrics.prometheus.basic import CYCLE_COUNT, CycleResult, LAST_CYCLE_TIMESTAMP, ORACLE_BLOCK_NUMBER, ORACLE_SLOT_NUMBER
 from src.modules.submodules.exceptions import IsNotMemberException, IncompatibleOracleVersion, ContractVersionMismatch
 from src.providers.http_provider import NotOkResponse
 from src.providers.ipfs import IPFSError
@@ -68,6 +68,7 @@ class BaseModule(ABC):
         and execute the module's business logic.
         """
         # pylint: disable=too-many-branches
+        cycle_error = True
         try:
             blockstamp = self._receive_last_finalized_slot()
 
@@ -81,6 +82,7 @@ class BaseModule(ABC):
 
             self.refresh_contracts_if_address_change()
             self.run_cycle(blockstamp)
+            cycle_error = False
         except IsNotMemberException as error:
             logger.error({'msg': 'Provided account is not part of Oracle`s committee.'})
             raise error
@@ -114,6 +116,10 @@ class BaseModule(ABC):
             logger.error({'msg': 'IPFS provider error.', 'error': str(error)})
         except ValueError as error:
             logger.error({'msg': 'Unexpected error.', 'error': str(error)})
+
+        cycle_result = CycleResult.ERROR if cycle_error else CycleResult.SUCCESS
+        CYCLE_COUNT.labels(result=cycle_result.value).inc()
+        LAST_CYCLE_TIMESTAMP.labels(result=cycle_result.value).set(time.time())
 
     @staticmethod
     def _reset_cycle_timeout():

--- a/src/modules/submodules/oracle_module.py
+++ b/src/modules/submodules/oracle_module.py
@@ -2,29 +2,35 @@ import logging
 import signal
 import time
 import traceback
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from dataclasses import asdict
 from enum import Enum
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
-from timeout_decorator import timeout, TimeoutError as DecoratorTimeoutError
+from timeout_decorator import TimeoutError as DecoratorTimeoutError, timeout
 from web3.exceptions import Web3Exception
-
-from src.metrics.healthcheck_server import pulse
-from src.metrics.prometheus.basic import CYCLE_COUNT, CycleResult, LAST_CYCLE_TIMESTAMP, ORACLE_BLOCK_NUMBER, ORACLE_SLOT_NUMBER
-from src.modules.submodules.exceptions import IsNotMemberException, IncompatibleOracleVersion, ContractVersionMismatch
-from src.providers.http_provider import NotOkResponse
-from src.providers.ipfs import IPFSError
-from src.providers.keys.client import KAPIInconsistentData, KeysOutdatedException
-from src.utils.cache import clear_global_cache
-from src.web3py.extensions.lido_validators import CountOfKeysDiffersException
-from src.utils.blockstamp import build_blockstamp
-from src.utils.slot import NoSlotsAvailable, SlotNotFinalized, InconsistentData
-from src.web3py.types import Web3
 from web3_multi_provider import NoActiveProviderError
 
 from src import variables
-from src.types import SlotNumber, BlockStamp, BlockRoot
+from src.metrics.healthcheck_server import pulse
+from src.metrics.prometheus.basic import (
+    CYCLE_COUNT,
+    LAST_CYCLE_TIMESTAMP,
+    ORACLE_BLOCK_NUMBER,
+    ORACLE_SLOT_NUMBER,
+    CycleResult,
+)
+from src.modules.submodules.exceptions import ContractVersionMismatch, IncompatibleOracleVersion, IsNotMemberException
+from src.providers.http_provider import NotOkResponse
+from src.providers.ipfs import IPFSError
+from src.providers.keys.client import KAPIInconsistentData, KeysOutdatedException
+from src.types import BlockRoot, BlockStamp, SlotNumber
+from src.utils.blockstamp import build_blockstamp
+from src.utils.cache import clear_global_cache
+from src.utils.slot import InconsistentData, NoSlotsAvailable, SlotNotFinalized
+from src.web3py.extensions.lido_validators import CountOfKeysDiffersException
+from src.web3py.types import Web3
+
 
 logger = logging.getLogger(__name__)
 
@@ -62,12 +68,11 @@ class BaseModule(ABC):
         self._sleep_cycle()
 
     @timeout(variables.MAX_CYCLE_LIFETIME_IN_SECONDS)
-    def _cycle(self):
+    def _cycle(self):  # noqa: C901
         """
         Main cycle logic: fetch the last finalized slot, refresh contracts if necessary,
         and execute the module's business logic.
         """
-        # pylint: disable=too-many-branches
         cycle_error = True
         try:
             blockstamp = self._receive_last_finalized_slot()

--- a/tests/modules/submodules/test_oracle_module.py
+++ b/tests/modules/submodules/test_oracle_module.py
@@ -9,17 +9,17 @@ from timeout_decorator import TimeoutError as DecoratorTimeoutError
 from web3_multi_provider.multi_http_provider import NoActiveProviderError
 
 from src import variables
+from src.metrics.prometheus.basic import (
+    CYCLE_COUNT,
+    LAST_CYCLE_TIMESTAMP,
+    TRANSACTIONS_COUNT,
+    CycleResult,
+    Status,
+    init_basic_metrics,
+)
 from src.modules.submodules.exceptions import (
     IncompatibleOracleVersion,
     IsNotMemberException,
-)
-from src.metrics.prometheus.basic import (
-    CYCLE_COUNT,
-    CycleResult,
-    LAST_CYCLE_TIMESTAMP,
-    TRANSACTIONS_COUNT,
-    Status,
-    init_basic_metrics,
 )
 from src.modules.submodules.oracle_module import BaseModule, ModuleExecuteDelay
 from src.providers.http_provider import NotOkResponse

--- a/tests/modules/submodules/test_oracle_module.py
+++ b/tests/modules/submodules/test_oracle_module.py
@@ -171,7 +171,7 @@ def test_init_basic_metrics__all_labels__metrics_exist():
         assert TRANSACTIONS_COUNT.labels(status=status.value) is not None
     for result in CycleResult:
         assert CYCLE_COUNT.labels(result=result.value) is not None
-        assert LAST_CYCLE_TIMESTAMP.labels(result=result.value) is not None
+    assert LAST_CYCLE_TIMESTAMP.labels(result=CycleResult.SUCCESS.value)._value.get() > 0
 
 
 @pytest.mark.unit

--- a/tests/modules/submodules/test_oracle_module.py
+++ b/tests/modules/submodules/test_oracle_module.py
@@ -10,6 +10,7 @@ from web3_multi_provider.multi_http_provider import NoActiveProviderError
 
 from src import variables
 from src.metrics.prometheus.basic import (
+    ACCOUNT_BALANCE,
     CYCLE_COUNT,
     LAST_CYCLE_TIMESTAMP,
     TRANSACTIONS_COUNT,
@@ -164,14 +165,16 @@ def test_run_cycle_fails_on_critical_exceptions(oracle: BaseModule, ex: Exceptio
 
 
 @pytest.mark.unit
-def test_init_basic_metrics__all_labels__metrics_exist():
-    init_basic_metrics()
+def test_init_basic_metrics__all_labels__metrics_exist(web3):
+    with patch.object(variables, 'ACCOUNT', Mock(address='0x0000000000000000000000000000000000000001')):
+        init_basic_metrics(web3)
 
-    for status in Status:
-        assert TRANSACTIONS_COUNT.labels(status=status.value) is not None
-    for result in CycleResult:
-        assert CYCLE_COUNT.labels(result=result.value) is not None
-    assert LAST_CYCLE_TIMESTAMP.labels(result=CycleResult.SUCCESS.value)._value.get() > 0
+        for status in Status:
+            assert TRANSACTIONS_COUNT.labels(status=status.value) is not None
+        for result in CycleResult:
+            assert CYCLE_COUNT.labels(result=result.value) is not None
+        assert LAST_CYCLE_TIMESTAMP.labels(result=CycleResult.SUCCESS.value)._value.get() > 0
+        assert ACCOUNT_BALANCE.labels(address='0x0000000000000000000000000000000000000001')._value.get() >= 0
 
 
 @pytest.mark.unit

--- a/tests/modules/submodules/test_oracle_module.py
+++ b/tests/modules/submodules/test_oracle_module.py
@@ -13,6 +13,14 @@ from src.modules.submodules.exceptions import (
     IncompatibleOracleVersion,
     IsNotMemberException,
 )
+from src.metrics.prometheus.basic import (
+    CYCLE_COUNT,
+    CycleResult,
+    LAST_CYCLE_TIMESTAMP,
+    TRANSACTIONS_COUNT,
+    Status,
+    init_basic_metrics,
+)
 from src.modules.submodules.oracle_module import BaseModule, ModuleExecuteDelay
 from src.providers.http_provider import NotOkResponse
 from src.providers.keys.client import KeysOutdatedException
@@ -153,3 +161,61 @@ def test_run_cycle_fails_on_critical_exceptions(oracle: BaseModule, ex: Exceptio
         pytest.raises(type(ex), match="Fake exception"),
     ):
         oracle._cycle()
+
+
+@pytest.mark.unit
+def test_init_basic_metrics__all_labels__metrics_exist():
+    init_basic_metrics()
+
+    for status in Status:
+        assert TRANSACTIONS_COUNT.labels(status=status.value) is not None
+    for result in CycleResult:
+        assert CYCLE_COUNT.labels(result=result.value) is not None
+        assert LAST_CYCLE_TIMESTAMP.labels(result=result.value) is not None
+
+
+@pytest.mark.unit
+@responses.activate
+def test_cycle__successful_execution__records_success_metric(oracle: BaseModule):
+    oracle.w3.lido_contracts = MagicMock()
+    responses.get(f'http://localhost:{variables.HEALTHCHECK_SERVER_PORT}/pulse/', status=HTTPStatus.OK)
+    before = CYCLE_COUNT.labels(result=CycleResult.SUCCESS.value)._value.get()
+
+    with (
+        patch.object(oracle, "_receive_last_finalized_slot", return_value=MagicMock(slot_number=1111111)),
+        patch.object(oracle.w3.lido_contracts, "has_contract_address_changed", return_value=False),
+        patch.object(oracle, "execute_module", return_value=ModuleExecuteDelay.NEXT_FINALIZED_EPOCH),
+    ):
+        oracle._cycle()
+
+    assert CYCLE_COUNT.labels(result=CycleResult.SUCCESS.value)._value.get() == before + 1
+    assert LAST_CYCLE_TIMESTAMP.labels(result=CycleResult.SUCCESS.value)._value.get() > 0
+
+
+@pytest.mark.unit
+def test_cycle__retryable_error__records_error_metric(oracle: BaseModule):
+    oracle.w3.lido_contracts = MagicMock()
+    before = CYCLE_COUNT.labels(result=CycleResult.ERROR.value)._value.get()
+
+    with (
+        patch.object(oracle, "_receive_last_finalized_slot", return_value=MagicMock(slot_number=1111111)),
+        patch.object(oracle.w3.lido_contracts, "has_contract_address_changed", return_value=False),
+        patch.object(oracle, "execute_module", side_effect=RequestsConnectionError("Fake")),
+    ):
+        oracle._cycle()
+
+    assert CYCLE_COUNT.labels(result=CycleResult.ERROR.value)._value.get() == before + 1
+    assert LAST_CYCLE_TIMESTAMP.labels(result=CycleResult.ERROR.value)._value.get() > 0
+
+
+@pytest.mark.unit
+def test_cycle__slot_below_threshold__records_success_metric(oracle: BaseModule):
+    oracle._slot_threshold = 999999
+    success_before = CYCLE_COUNT.labels(result=CycleResult.SUCCESS.value)._value.get()
+    error_before = CYCLE_COUNT.labels(result=CycleResult.ERROR.value)._value.get()
+
+    with patch.object(oracle, "_receive_last_finalized_slot", return_value=MagicMock(slot_number=1)):
+        oracle._cycle()
+
+    assert CYCLE_COUNT.labels(result=CycleResult.SUCCESS.value)._value.get() == success_before + 1
+    assert CYCLE_COUNT.labels(result=CycleResult.ERROR.value)._value.get() == error_before


### PR DESCRIPTION
## Description
  1. init_basic_metrics() — pre-initializes all label combinations for TRANSACTIONS_COUNT, CYCLE_COUNT, and LAST_CYCLE_TIMESTAMP at startup, so metrics exist with value 0 immediately and Prometheus queries work correctly across restarts.
  2. New metrics for oracle health monitoring:
  - lido_oracle_cycle_count{result="success|error"} (Counter) — total completed cycles by result, allows alerting on error rate growth
  - lido_oracle_last_cycle_timestamp{result="success|error"} (Gauge) — unix timestamp of the last cycle, allows alerting on time() - gauge > threshold to detect a stalled oracle
  3. Cycle metrics are recorded in BaseModule._cycle() via a finally block, covering all three modules (accounting, ejector, csm). Skip cycles (waiting for new finalized slot) count as success since the oracle is operating normally.

## Related Issue/Task
- Related task: ORC-575
- Epic: v8

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [x] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
