### PR TITLE
fix: prevent negative prev_ref_slot when initial_epoch is zero

### DIFF
--- a/src/services/staking_vaults.py
+++ b/src/services/staking_vaults.py
@@ -810,7 +810,8 @@ class StakingVaultsService:
         else:
             # Fresh devnet: no previous Oracle report, use initial epoch
             # To align with the accounting contract (_get_slots_elapsed_from_last_report)
-            prev_ref_slot = SlotNumber(frame_config.initial_epoch * chain_config.slots_per_epoch - 1)
+            initial_ref_slot = frame_config.initial_epoch * chain_config.slots_per_epoch
+            prev_ref_slot = SlotNumber(initial_ref_slot - 1) if initial_ref_slot > 0 else SlotNumber(0)
 
         slots_per_frame = frame_config.epochs_per_frame * chain_config.slots_per_epoch
         prev_report_blockstamp = get_blockstamp(

--- a/src/services/staking_vaults.py
+++ b/src/services/staking_vaults.py
@@ -808,8 +808,8 @@ class StakingVaultsService:
         if last_processing_ref_slot:
             prev_ref_slot = SlotNumber(int(last_processing_ref_slot))
         else:
-            # Fresh devnet: no previous Oracle report, use initial epoch
-            # To align with the accounting contract (_get_slots_elapsed_from_last_report)
+            # Fresh devnet: no previous Oracle report, derive a starting ref slot
+            # This approximates the accounting contract's _get_slots_elapsed_from_last_report
             initial_ref_slot = frame_config.initial_epoch * chain_config.slots_per_epoch
             prev_ref_slot = SlotNumber(initial_ref_slot - 1) if initial_ref_slot > 0 else SlotNumber(0)
 

--- a/tests/modules/accounting/staking_vault/test_fee_get_vaults.py
+++ b/tests/modules/accounting/staking_vault/test_fee_get_vaults.py
@@ -111,6 +111,48 @@ class TestGetVaultsFees:
 
         assert fees[vault_adr].prev_fee == 0
 
+    def test_initial_epoch_zero_uses_non_negative_prev_ref_slot(self, service):
+        # Setup
+        vault_adr = VaultAddresses.VAULT_0
+        vault = VaultInfoFactory.build(vault=vault_adr, liability_shares=0, max_liability_shares=0)
+        blockstamp = self.make_blockstamp(block=10, slot=100)
+
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.return_value = 0
+        service._get_prev_vault_ipfs_report = MagicMock(return_value=None)
+        service._get_vault_events_for_fees = MagicMock(return_value=({}, set()))
+        service._calculate_vault_fee_components = MagicMock(return_value=(Decimal(0), Decimal(0), Decimal(0), 0))
+
+        with patch("src.services.staking_vaults.get_blockstamp", return_value=MagicMock(block_number=0)) as get_bs_mock:
+            # Act
+            service.get_vaults_fees(
+                blockstamp=blockstamp,
+                vaults={vault_adr: vault},
+                vaults_total_values={},
+                latest_onchain_ipfs_report_data=OnChainIpfsVaultReportDataFactory.build(report_cid=""),
+                core_apr_ratio=Decimal("0"),
+                pre_total_pooled_ether=Wei(0),
+                pre_total_shares=0,
+                frame_config=FrameConfig(initial_epoch=0, epochs_per_frame=1, fast_lane_length_slots=0),
+                chain_config=ChainConfig(slots_per_epoch=32, seconds_per_slot=12, genesis_time=0),
+                current_frame=FrameNumber(0),
+            )
+
+        # Assert
+        assert get_bs_mock.call_args.kwargs["slot"] == SlotNumber(0)
+        service._calculate_vault_fee_components.assert_called_once_with(
+            vault_address=vault_adr,
+            vault_info=vault,
+            vault_total_value=0,
+            vault_events=[],
+            report_interval_seconds=100 * 12,
+            prev_ref_slot_timestamp=0,
+            current_ref_slot_timestamp=100 * 12,
+            core_apr_ratio=Decimal(0),
+            pre_total_pooled_ether=0,
+            pre_total_shares=0,
+            block_timestamps={},
+        )
+
     def test_raises_if_liability_shares_mismatch(self, service, vault_hub_mock):
         # Setup
         vault_adr = VaultAddresses.VAULT_0


### PR DESCRIPTION
This pull request addresses an edge case in the staking vaults fee calculation logic to ensure correct handling when the initial epoch is zero. It also adds a corresponding test to verify this behavior.

Bug fix for initial epoch handling:

* Updated the logic in `get_vaults_fees` in `src/services/staking_vaults.py` to ensure that when `initial_epoch` is zero, the previous reference slot (`prev_ref_slot`) is set to `SlotNumber(0)` instead of a negative value. This prevents invalid slot numbers in devnet or initial deployment scenarios.

Testing improvements:

* Added a new test `test_initial_epoch_zero_uses_non_negative_prev_ref_slot` in `tests/modules/accounting/staking_vault/test_fee_get_vaults.py` to verify that the fee calculation uses a non-negative previous reference slot when `initial_epoch` is zero, and that the downstream fee calculation receives the correct parameters.