### PR TITLE
feat: fix bunker mode edge case with cut slashings

### DIFF
--- a/src/services/bunker_cases/midterm_slashing_penalty.py
+++ b/src/services/bunker_cases/midterm_slashing_penalty.py
@@ -228,12 +228,11 @@ class MidtermSlashingPenalty:
         @see https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#modified-slash_validator
         We want to filter out epochs in the past which will not be relevant at the time of midterm penalty epoch.
 
-        Note: The start epoch logic handles circular buffer overwrites. When midterm_penalty_epoch is
-        less than one full cycle (EPOCHS_PER_SLASHINGS_VECTOR) after report_ref_epoch, we start from
-        report_ref_epoch + 1 so the report_ref_epoch bucket is preserved in the simulated slashing sum.
-        Once the prediction is a full cycle or more ahead, that ring-buffer slot will already be
-        overwritten by the time process_slashings() runs, so we start from report_ref_epoch and exclude
-        it as obsolete data.
+        Note: The epoch filtering logic handles circular buffer overwrites. We always start from
+        report_ref_epoch + 1 to preserve the report_ref_epoch bucket in the simulated slashing sum.
+        When the prediction is more than a full cycle ahead (difference > EPOCHS_PER_SLASHINGS_VECTOR),
+        all current slashing data will be overwritten by the time process_slashings() runs, so we
+        return an empty array as no current data is relevant.
 
         @see https://github.com/ethereum/consensus-specs/blob/622f109098e6453fb9dcd261eda22d57a47cae34/specs/phase0/beacon-chain.md?plain=1#L1762
         """
@@ -241,9 +240,11 @@ class MidtermSlashingPenalty:
         if len(slashings) != EPOCHS_PER_SLASHINGS_VECTOR:
             raise ValueError(f'Unexpected {len(slashings)=}: expected to be {EPOCHS_PER_SLASHINGS_VECTOR=}.')
 
-        if midterm_penalty_epoch - report_ref_epoch >= EPOCHS_PER_SLASHINGS_VECTOR:
+        if midterm_penalty_epoch - report_ref_epoch > EPOCHS_PER_SLASHINGS_VECTOR:
             # Data from report_ref_epoch will be overwritten in circular buffer by midterm_penalty_epoch
-            # All indexes are obsolete when covering full buffer or more
+            # Use strict inequality: API returns post-state, so data from report_ref_epoch is still valid
+            # when difference equals EPOCHS_PER_SLASHINGS_VECTOR, only overwritten when difference
+            # > EPOCHS_PER_SLASHINGS_VECTOR
             return []
 
         # Data from report_ref_epoch will still be valid at midterm_penalty_epoch

--- a/src/services/bunker_cases/midterm_slashing_penalty.py
+++ b/src/services/bunker_cases/midterm_slashing_penalty.py
@@ -228,20 +228,27 @@ class MidtermSlashingPenalty:
         @see https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#modified-slash_validator
         We want to filter out epochs in the past which will not be relevant at the time of midterm penalty epoch.
 
-        Note: The +1 offset (report_ref_epoch + 1) is required because process_slashings() in the consensus
-        spec uses sum(state.slashings) which includes ALL epochs, including the current epoch. Therefore,
-        when predicting future penalties, we must preserve slashing data from report_ref_epoch since it
-        will be included in the penalty calculation at midterm_penalty_epoch. We only exclude subsequent
-        epochs (report_ref_epoch + 1) through (midterm_penalty_epoch - 1) that become obsolete.
+        Note: The start epoch logic handles circular buffer overwrites. When midterm_penalty_epoch is
+        less than one full cycle (EPOCHS_PER_SLASHINGS_VECTOR) after report_ref_epoch, we start from
+        report_ref_epoch + 1 so the report_ref_epoch bucket is preserved in the simulated slashing sum.
+        Once the prediction is a full cycle or more ahead, that ring-buffer slot will already be
+        overwritten by the time process_slashings() runs, so we start from report_ref_epoch and exclude
+        it as obsolete data.
 
         @see https://github.com/ethereum/consensus-specs/blob/622f109098e6453fb9dcd261eda22d57a47cae34/specs/phase0/beacon-chain.md?plain=1#L1762
         """
 
         if len(slashings) != EPOCHS_PER_SLASHINGS_VECTOR:
             raise ValueError(f'Unexpected {len(slashings)=}: expected to be {EPOCHS_PER_SLASHINGS_VECTOR=}.')
-        # Start from report_ref_epoch + 1 to preserve current epoch slashing data
-        obsolete_indexes = {i % EPOCHS_PER_SLASHINGS_VECTOR for i in range(report_ref_epoch + 1, midterm_penalty_epoch)}
 
+        if midterm_penalty_epoch - report_ref_epoch >= EPOCHS_PER_SLASHINGS_VECTOR:
+            # Data from report_ref_epoch will be overwritten in circular buffer by midterm_penalty_epoch
+            start_epoch = report_ref_epoch
+        else:
+            # Data from report_ref_epoch will still be valid at midterm_penalty_epoch
+            start_epoch = report_ref_epoch + 1
+
+        obsolete_indexes = {i % EPOCHS_PER_SLASHINGS_VECTOR for i in range(start_epoch, midterm_penalty_epoch)}
         return [v for i, v in enumerate(slashings) if i not in obsolete_indexes]
 
     @staticmethod

--- a/src/services/bunker_cases/midterm_slashing_penalty.py
+++ b/src/services/bunker_cases/midterm_slashing_penalty.py
@@ -227,11 +227,20 @@ class MidtermSlashingPenalty:
         Slashings is a ring buffer on epochs.
         @see https://github.com/ethereum/consensus-specs/blob/dev/specs/electra/beacon-chain.md#modified-slash_validator
         We want to filter out epochs in the past which will not be relevant at the time of midterm penalty epoch.
+
+        Note: The +1 offset (report_ref_epoch + 1) is required because process_slashings() in the consensus
+        spec uses sum(state.slashings) which includes ALL epochs, including the current epoch. Therefore,
+        when predicting future penalties, we must preserve slashing data from report_ref_epoch since it
+        will be included in the penalty calculation at midterm_penalty_epoch. We only exclude subsequent
+        epochs (report_ref_epoch + 1) through (midterm_penalty_epoch - 1) that become obsolete.
+
+        @see https://github.com/ethereum/consensus-specs/blob/622f109098e6453fb9dcd261eda22d57a47cae34/specs/phase0/beacon-chain.md?plain=1#L1762
         """
 
         if len(slashings) != EPOCHS_PER_SLASHINGS_VECTOR:
             raise ValueError(f'Unexpected {len(slashings)=}: expected to be {EPOCHS_PER_SLASHINGS_VECTOR=}.')
-        obsolete_indexes = {i % EPOCHS_PER_SLASHINGS_VECTOR for i in range(report_ref_epoch, midterm_penalty_epoch)}
+        # Start from report_ref_epoch + 1 to preserve current epoch slashing data
+        obsolete_indexes = {i % EPOCHS_PER_SLASHINGS_VECTOR for i in range(report_ref_epoch + 1, midterm_penalty_epoch)}
 
         return [v for i, v in enumerate(slashings) if i not in obsolete_indexes]
 

--- a/src/services/bunker_cases/midterm_slashing_penalty.py
+++ b/src/services/bunker_cases/midterm_slashing_penalty.py
@@ -243,12 +243,11 @@ class MidtermSlashingPenalty:
 
         if midterm_penalty_epoch - report_ref_epoch >= EPOCHS_PER_SLASHINGS_VECTOR:
             # Data from report_ref_epoch will be overwritten in circular buffer by midterm_penalty_epoch
-            start_epoch = report_ref_epoch
-        else:
-            # Data from report_ref_epoch will still be valid at midterm_penalty_epoch
-            start_epoch = report_ref_epoch + 1
+            # All indexes are obsolete when covering full buffer or more
+            return []
 
-        obsolete_indexes = {i % EPOCHS_PER_SLASHINGS_VECTOR for i in range(start_epoch, midterm_penalty_epoch)}
+        # Data from report_ref_epoch will still be valid at midterm_penalty_epoch
+        obsolete_indexes = {i % EPOCHS_PER_SLASHINGS_VECTOR for i in range(report_ref_epoch + 1, midterm_penalty_epoch)}
         return [v for i, v in enumerate(slashings) if i not in obsolete_indexes]
 
     @staticmethod

--- a/tests/modules/accounting/bunker/test_bunker_midterm_penalty.py
+++ b/tests/modules/accounting/bunker/test_bunker_midterm_penalty.py
@@ -407,8 +407,10 @@ def test_cut_slashings_basic():
 
     result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
 
-    expected_indexes = {i % EPOCHS_PER_SLASHINGS_VECTOR for i in range(report_ref_epoch, midterm_penalty_epoch)}
-    assert midterm_penalty_epoch not in expected_indexes
+    # Fixed: Start from report_ref_epoch + 1 to preserve current epoch slashing data
+    expected_indexes = {i % EPOCHS_PER_SLASHINGS_VECTOR for i in range(report_ref_epoch + 1, midterm_penalty_epoch)}
+    # Verify that report_ref_epoch slashing data is preserved
+    assert report_ref_epoch % EPOCHS_PER_SLASHINGS_VECTOR not in expected_indexes
     expected = [slashings[i] for i in range(EPOCHS_PER_SLASHINGS_VECTOR) if i not in expected_indexes]
 
     assert result == expected, f"Expected {expected}, but got {result}"
@@ -438,11 +440,13 @@ def test_cut_slashings_no_obsolete_indexes():
 def test_cut_slashings_all_removed():
     slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
     report_ref_epoch = 1
-    midterm_penalty_epoch = report_ref_epoch + EPOCHS_PER_SLASHINGS_VECTOR  # Covers all indices
+    midterm_penalty_epoch = report_ref_epoch + EPOCHS_PER_SLASHINGS_VECTOR  # Covers all indices except report_ref_epoch
 
     result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
 
-    assert result == [], "Expected all elements to be removed, but some remain"
+    # Fixed: With corrected logic, slashing data from report_ref_epoch (index 1) is preserved
+    expected = [slashings[report_ref_epoch % EPOCHS_PER_SLASHINGS_VECTOR]]  # Only element at index 1 remains
+    assert result == expected, f"Expected {expected}, but got {result}"
 
 
 @pytest.mark.unit
@@ -535,3 +539,115 @@ def test_get_frame_cl_rebase_from_report_cl_rebase(report_cl_rebase, blockstamp,
 def test_get_midterm_slashing_epoch():
     result = MidtermSlashingPenalty.get_midterm_penalty_epoch(simple_validators(0, 0)[0])
     assert result == 4096
+
+
+@pytest.mark.unit
+def test_cut_slashings__epochs_exceeding_buffer_size__filters_correctly():
+    slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
+    report_ref_epoch = 16000  # > EPOCHS_PER_SLASHINGS_VECTOR (8192)
+    midterm_penalty_epoch = 16100
+
+    result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
+
+    # With report_ref_epoch=16000, midterm_penalty_epoch=16100:
+    # range(16001, 16100) = [16001, 16002, ..., 16099] (99 elements)
+    # 16000 % 8192 = 7808, 16001 % 8192 = 7809, ..., 16099 % 8192 = 7907
+    # So obsolete_indexes = {7809, 7810, 7811, ..., 7907} (99 elements)
+    # Expected result length = 8192 - 99 = 8093
+    assert len(result) == 8093
+    # Verify report_ref_epoch data is preserved: slashings[7808] should be in result
+    assert Gwei(7808) in result
+
+
+@pytest.mark.unit
+def test_cut_slashings__large_mainnet_epochs__preserves_report_ref_epoch():
+    slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
+    report_ref_epoch = 55000  # Realistic mainnet epoch
+    midterm_penalty_epoch = 55200
+
+    result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
+
+    # With report_ref_epoch=55000, midterm_penalty_epoch=55200:
+    # range(55001, 55200) = [55001, 55002, ..., 55199] (199 elements)
+    # 55000 % 8192 = 6616, 55001 % 8192 = 6617, ..., 55199 % 8192 = 6815
+    # So obsolete_indexes = {6617, 6618, ..., 6815} (199 elements)
+    # Expected result length = 8192 - 199 = 7993
+    assert len(result) == 7993
+    # Verify report_ref_epoch data is preserved: slashings[6616] should be in result
+    assert Gwei(6616) in result
+
+
+@pytest.mark.unit
+def test_cut_slashings__adjacent_epochs__returns_full_array():
+    slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
+    report_ref_epoch = 100
+    midterm_penalty_epoch = report_ref_epoch + 1  # Adjacent epochs
+
+    result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
+
+    # No epochs should be filtered out since range(101, 101) is empty
+    assert result == slashings
+
+
+@pytest.mark.unit
+def test_cut_slashings__genesis_epoch_zero__preserves_epoch_zero_data():
+    slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
+    report_ref_epoch = 0
+    midterm_penalty_epoch = 50
+
+    result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
+
+    # With report_ref_epoch=0, midterm_penalty_epoch=50:
+    # range(1, 50) = [1, 2, ..., 49] (49 elements)
+    # obsolete_indexes = {1, 2, 3, ..., 49} (49 elements)
+    # Expected result length = 8192 - 49 = 8143
+    assert len(result) == 8143
+    # Verify epoch 0 data is preserved: slashings[0] should be in result
+    assert Gwei(0) in result
+
+
+@pytest.mark.unit
+def test_cut_slashings__various_epoch_ranges__always_preserves_report_ref_epoch():
+    slashings = [Gwei(i * 100) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]  # Use distinct values
+
+    # Test case 1: Genesis case (0, 1000)
+    # range(1, 1000) = 999 elements, preserved index = 0, expected length = 8192 - 999 = 7193
+    result1 = MidtermSlashingPenalty._cut_slashings(slashings, 1000, 0)
+    assert len(result1) == 7193
+    assert Gwei(0) in result1
+
+    # Test case 2: Normal case (100, 200)
+    # range(101, 200) = 99 elements, preserved index = 100, expected length = 8192 - 99 = 8093
+    result2 = MidtermSlashingPenalty._cut_slashings(slashings, 200, 100)
+    assert len(result2) == 8093
+    assert Gwei(100 * 100) in result2
+
+    # Test case 3: Near buffer limit (8000, 8100)
+    # range(8001, 8100) = 99 elements, preserved index = 8000, expected length = 8192 - 99 = 8093
+    result3 = MidtermSlashingPenalty._cut_slashings(slashings, 8100, 8000)
+    assert len(result3) == 8093
+    assert Gwei(8000 * 100) in result3
+
+    # Test case 4: Large epoch values with wrapping (16000, 16100)
+    # 16000 % 8192 = 7808, range(16001, 16100) = 99 elements, expected length = 8192 - 99 = 8093
+    result4 = MidtermSlashingPenalty._cut_slashings(slashings, 16100, 16000)
+    assert len(result4) == 8093
+    assert Gwei(7808 * 100) in result4
+
+
+@pytest.mark.unit
+def test_cut_slashings__almost_full_cycle_range__preserves_two_elements():
+    slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
+    report_ref_epoch = 100
+    midterm_penalty_epoch = report_ref_epoch + EPOCHS_PER_SLASHINGS_VECTOR - 1  # Almost full cycle
+
+    result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
+
+    # With report_ref_epoch=100, midterm_penalty_epoch=100+8191=8291:
+    # range(101, 8291) = [101, 102, ..., 8290] (8190 elements)
+    # 101 % 8192 = 101, ..., 8191 % 8192 = 8191, 8192 % 8192 = 0, ..., 8290 % 8192 = 98
+    # obsolete_indexes = {101, 102, ..., 8191, 0, 1, ..., 98} (8190 elements)
+    # Only indices 99 and 100 remain, expected length = 2
+    assert len(result) == 2
+    assert Gwei(99) in result
+    assert Gwei(100) in result

--- a/tests/modules/accounting/bunker/test_bunker_midterm_penalty.py
+++ b/tests/modules/accounting/bunker/test_bunker_midterm_penalty.py
@@ -437,16 +437,18 @@ def test_cut_slashings_no_obsolete_indexes():
 
 
 @pytest.mark.unit
-def test_cut_slashings_all_removed():
+def test_cut_slashings__full_cycle_later__returns_empty_array():
     slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
     report_ref_epoch = 1
-    midterm_penalty_epoch = report_ref_epoch + EPOCHS_PER_SLASHINGS_VECTOR  # Covers all indices except report_ref_epoch
+    midterm_penalty_epoch = report_ref_epoch + EPOCHS_PER_SLASHINGS_VECTOR  # Exactly one full cycle later
 
     result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
 
-    # Fixed: With corrected logic, slashing data from report_ref_epoch (index 1) is preserved
-    expected = [slashings[report_ref_epoch % EPOCHS_PER_SLASHINGS_VECTOR]]  # Only element at index 1 remains
-    assert result == expected, f"Expected {expected}, but got {result}"
+    # With report_ref_epoch=1, midterm_penalty_epoch=1+8192=8193:
+    # Since midterm_penalty_epoch - report_ref_epoch = 8192 >= EPOCHS_PER_SLASHINGS_VECTOR,
+    # data from report_ref_epoch will be overwritten by the time penalty is applied
+    # range(1, 8193) covers all indices, expected result = empty array
+    assert result == [], f"Expected [], but got {result}"
 
 
 @pytest.mark.unit
@@ -651,3 +653,22 @@ def test_cut_slashings__almost_full_cycle_range__preserves_two_elements():
     assert len(result) == 2
     assert Gwei(99) in result
     assert Gwei(100) in result
+
+
+@pytest.mark.unit
+def test_cut_slashings__midterm_penalty_after_full_cycle__excludes_overwritten_data():
+    """Test that data from report_ref_epoch is excluded when midterm_penalty_epoch is a full cycle later"""
+    slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
+    report_ref_epoch = 100
+    midterm_penalty_epoch = report_ref_epoch + EPOCHS_PER_SLASHINGS_VECTOR  # Exactly one full cycle later
+
+    result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
+
+    # With report_ref_epoch=100, midterm_penalty_epoch=100+8192=8292:
+    # At epoch 8292, slashings[100] will be overwritten with data from epoch 8292
+    # So data from epoch 100 should NOT be preserved in the prediction
+    # range(101, 8292) covers all indices in the circular buffer
+    # Expected result: empty array (all data is obsolete when covering full cycle)
+    assert len(result) == 0
+    # Verify that report_ref_epoch data is NOT preserved (would be bug if present)
+    assert Gwei(100) not in result

--- a/tests/modules/accounting/bunker/test_bunker_midterm_penalty.py
+++ b/tests/modules/accounting/bunker/test_bunker_midterm_penalty.py
@@ -407,7 +407,7 @@ def test_cut_slashings_basic():
 
     result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
 
-    # Fixed: Start from report_ref_epoch + 1 to preserve current epoch slashing data
+    # Start from report_ref_epoch + 1 to preserve current epoch slashing data
     expected_indexes = {i % EPOCHS_PER_SLASHINGS_VECTOR for i in range(report_ref_epoch + 1, midterm_penalty_epoch)}
     # Verify that report_ref_epoch slashing data is preserved
     assert report_ref_epoch % EPOCHS_PER_SLASHINGS_VECTOR not in expected_indexes

--- a/tests/modules/accounting/bunker/test_bunker_midterm_penalty.py
+++ b/tests/modules/accounting/bunker/test_bunker_midterm_penalty.py
@@ -440,14 +440,14 @@ def test_cut_slashings_no_obsolete_indexes():
 def test_cut_slashings__full_cycle_later__returns_empty_array():
     slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
     report_ref_epoch = 1
-    midterm_penalty_epoch = report_ref_epoch + EPOCHS_PER_SLASHINGS_VECTOR  # Exactly one full cycle later
+    midterm_penalty_epoch = report_ref_epoch + EPOCHS_PER_SLASHINGS_VECTOR + 1  # More than full cycle later
 
     result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
 
-    # With report_ref_epoch=1, midterm_penalty_epoch=1+8192=8193:
-    # Since midterm_penalty_epoch - report_ref_epoch = 8192 >= EPOCHS_PER_SLASHINGS_VECTOR,
+    # With report_ref_epoch=1, midterm_penalty_epoch=1+8192+1=8194:
+    # Since midterm_penalty_epoch - report_ref_epoch = 8193 > EPOCHS_PER_SLASHINGS_VECTOR,
     # data from report_ref_epoch will be overwritten by the time penalty is applied
-    # range(1, 8193) covers all indices, expected result = empty array
+    # Expected result = empty array (all data is obsolete when exceeding full cycle)
     assert result == [], f"Expected [], but got {result}"
 
 
@@ -656,8 +656,7 @@ def test_cut_slashings__almost_full_cycle_range__preserves_two_elements():
 
 
 @pytest.mark.unit
-def test_cut_slashings__midterm_penalty_after_full_cycle__excludes_overwritten_data():
-    """Test that data from report_ref_epoch is excluded when midterm_penalty_epoch is a full cycle later"""
+def test_cut_slashings__equal_to_full_cycle__preserves_current_bucket():
     slashings = [Gwei(i) for i in range(EPOCHS_PER_SLASHINGS_VECTOR)]
     report_ref_epoch = 100
     midterm_penalty_epoch = report_ref_epoch + EPOCHS_PER_SLASHINGS_VECTOR  # Exactly one full cycle later
@@ -665,10 +664,10 @@ def test_cut_slashings__midterm_penalty_after_full_cycle__excludes_overwritten_d
     result = MidtermSlashingPenalty._cut_slashings(slashings, midterm_penalty_epoch, report_ref_epoch)
 
     # With report_ref_epoch=100, midterm_penalty_epoch=100+8192=8292:
-    # At epoch 8292, slashings[100] will be overwritten with data from epoch 8292
-    # So data from epoch 100 should NOT be preserved in the prediction
-    # range(101, 8292) covers all indices in the circular buffer
-    # Expected result: empty array (all data is obsolete when covering full cycle)
-    assert len(result) == 0
-    # Verify that report_ref_epoch data is NOT preserved (would be bug if present)
-    assert Gwei(100) not in result
+    # Since API returns post-state, data from epoch 100 is STILL VALID when difference = EPOCHS_PER_SLASHINGS_VECTOR
+    # At epoch 8292, slashings[100] contains data from epoch 100, not yet overwritten
+    # range(101, 8292) covers indices {101, 102, ..., 8191, 0, 1, ..., 99} - excludes index 100
+    # Expected result: only slashings[100] remains (1 element)
+    assert len(result) == 1
+    # Verify that report_ref_epoch data is preserved (as per post-state API behavior)
+    assert Gwei(100) in result


### PR DESCRIPTION
## Description

fix bunker mode edge case with cut slashings
https://github.com/lidofinance/lido-oracle/issues/881

## Related Issue/Task
- Related task: n/a
- Epic: srv3

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)
FYI: FAILED tests/integration/contracts/test_staking_router.py::test_staking_router - TypeError: StakingRouterContract.get_staking_modules() missing 1 required positional argument: 'block_identifier' - failed from  parent branch feat/oracle-v8, and will be fixed separately in feat/oracle-v8.

## Checklist
- [ ] Documentation updated (if required)
- [x] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
