### PR TITLE
fix: Include pending topups into cl pending balance

### DIFF
--- a/src/modules/oracles/accounting/accounting.py
+++ b/src/modules/oracles/accounting/accounting.py
@@ -251,11 +251,23 @@ class Accounting(OracleModule[Web3]):
         return validator_balance_sum
 
     def _get_cl_pending_validators_balance(self, blockstamp: ReferenceBlockStamp) -> Gwei:
-        """Calculate the total balance of all pending Lido validators on the Consensus Layer."""
+        """Calculate the total balance of all pending Lido validators on the Consensus Layer.
+
+        Includes both new validators awaiting activation and pending top-up deposits for
+        existing active validators. Top-ups must be included because they are not yet reflected
+        in validator.balance on the CL; if they remain unprocessed across a frame boundary,
+        they would otherwise be invisible to the contract's accounting (absent from both
+        clPendingBalanceAtLastReport and depositedForCurrentReport).
+        """
         lido_pending_balance_by_keys = self.w3.lido_validators.get_pending_lido_validators(blockstamp)
-        return Gwei(
+        new_validators_pending = Gwei(
             sum(pending.amount for _, pendings in lido_pending_balance_by_keys.values() for pending in pendings)
         )
+        active_validators = self.w3.lido_validators.get_active_lido_validators(blockstamp)
+        topups_pending = Gwei(
+            sum(topup.amount for v in active_validators for topup in v.pending_topups)
+        )
+        return Gwei(new_validators_pending + topups_pending)
 
     def _get_newly_exited_validators_by_modules(
         self,

--- a/src/modules/oracles/accounting/accounting.py
+++ b/src/modules/oracles/accounting/accounting.py
@@ -251,7 +251,7 @@ class Accounting(OracleModule[Web3]):
         return validator_balance_sum
 
     def _get_cl_pending_validators_balance(self, blockstamp: ReferenceBlockStamp) -> Gwei:
-        """Calculate the total balance of all pending Lido validators on the Consensus Layer.
+        """Calculate the total pending balance on the Consensus Layer.
 
         Includes both new validators awaiting activation and pending top-up deposits for
         existing active validators. Top-ups must be included because they are not yet reflected

--- a/tests/modules/accounting/test_accounting_module.py
+++ b/tests/modules/accounting/test_accounting_module.py
@@ -142,7 +142,9 @@ def test_get_cl_pending_validators_balance(accounting: Accounting):
 
 
 @pytest.mark.unit
-def test_get_cl_pending_validators_balance_includes_topups(accounting: Accounting):
+def test_get_cl_pending_validators_balance__active_validators_with_pending_topups__includes_topups(
+    accounting: Accounting,
+):
     bs = ReferenceBlockStampFactory.build()
 
     pending_validators_data = {

--- a/tests/modules/accounting/test_accounting_module.py
+++ b/tests/modules/accounting/test_accounting_module.py
@@ -30,7 +30,7 @@ from src.modules.oracles.accounting.types import (
     VaultsTreeRoot,
 )
 from src.services.withdrawal import Withdrawal
-from src.types import BlockStamp, Gwei, ReferenceBlockStamp, StakingModuleId
+from src.types import BlockStamp, Gwei, ReferenceBlockStamp, SlotNumber, StakingModuleId
 from src.web3py.extensions.lido_validators import NodeOperatorId, StakingModule
 from tests.factory.base_oracle import AccountingProcessingStateFactory
 from tests.factory.blockstamp import BlockStampFactory, ReferenceBlockStampFactory
@@ -125,7 +125,7 @@ def test_get_cl_validators_balance(accounting: Accounting):
 
 
 @pytest.mark.unit
-def test_get_cl_pending_validators_balance(accounting: Accounting):
+def test_get_cl_pending_validators_balance__pending_new_validators__sums_all_deposits(accounting: Accounting):
     bs = ReferenceBlockStampFactory.build()
 
     # Mock pending validators data structure
@@ -185,7 +185,7 @@ def test_get_finalization_data(accounting: Accounting, post_total_pooled_ether, 
         fee_distribution=ReportSimulationFeeDistribution(
             module_fee_recipients=[],
             module_ids=[],
-            module_shares_to_mint=0,
+            module_shares_to_mint=[0],
             treasury_shares_to_mint=0,
         ),
         principal_cl_balance=0,
@@ -529,10 +529,10 @@ def test_simulate_rebase_after_report(
             withdrawals_vault_transfer=Wei(0),
             el_rewards_vault_transfer=Wei(0),
             ether_to_finalize_wq=Wei(0),
-            shares_to_finalize_wq=0,
-            shares_to_burn_for_withdrawals=0,
-            total_shares_to_burn=0,
-            shares_to_mint_as_fees=0,
+            shares_to_finalize_wq=Shares(0),
+            shares_to_burn_for_withdrawals=Shares(0),
+            total_shares_to_burn=Shares(0),
+            shares_to_mint_as_fees=Shares(0),
             fee_distribution=ReportSimulationFeeDistribution(
                 module_fee_recipients=[],
                 module_ids=[],
@@ -620,7 +620,7 @@ def test_accounting_get_processing_state_no_yet_init_epoch(accounting: Accountin
 
     accounting.report_contract.get_processing_state = Mock(side_effect=ContractCustomError('0xcd0883ea', '0xcd0883ea'))
     accounting.get_initial_or_current_frame = Mock(
-        return_value=CurrentFrame(ref_slot=100, report_processing_deadline_slot=200)
+        return_value=CurrentFrame(ref_slot=SlotNumber(100), report_processing_deadline_slot=SlotNumber(200))
     )
     processing_state = accounting._get_processing_state(bs)
 
@@ -701,7 +701,7 @@ def test_get_finalization_data_zero_shares(accounting: Accounting):
         fee_distribution=ReportSimulationFeeDistribution(
             module_fee_recipients=[],
             module_ids=[],
-            module_shares_to_mint=0,
+            module_shares_to_mint=[0],
             treasury_shares_to_mint=0,
         ),
         principal_cl_balance=0,
@@ -727,11 +727,13 @@ def test_get_finalization_data_zero_shares(accounting: Accounting):
 
 
 @pytest.mark.unit
-def test_get_cl_pending_validators_balance_empty(accounting: Accounting):
+def test_get_cl_pending_validators_balance__no_pending_validators__returns_zero(accounting: Accounting):
     bs = ReferenceBlockStampFactory.build()
     accounting.w3.lido_validators.get_pending_lido_validators = Mock(return_value={})
     accounting.w3.lido_validators.get_active_lido_validators = Mock(return_value=[])
+
     balance = accounting._get_cl_pending_validators_balance(bs)
+
     assert balance == 0
 
 

--- a/tests/modules/accounting/test_accounting_module.py
+++ b/tests/modules/accounting/test_accounting_module.py
@@ -134,10 +134,30 @@ def test_get_cl_pending_validators_balance(accounting: Accounting):
         'key2': ('wc2', [Mock(amount=3000)]),
     }
     accounting.w3.lido_validators.get_pending_lido_validators = Mock(return_value=pending_validators_data)
+    accounting.w3.lido_validators.get_active_lido_validators = Mock(return_value=[])
 
     balance = accounting._get_cl_pending_validators_balance(bs)
 
     assert balance == 6000
+
+
+@pytest.mark.unit
+def test_get_cl_pending_validators_balance_includes_topups(accounting: Accounting):
+    bs = ReferenceBlockStampFactory.build()
+
+    pending_validators_data = {
+        'key1': ('wc1', [Mock(amount=1000)]),
+    }
+    accounting.w3.lido_validators.get_pending_lido_validators = Mock(return_value=pending_validators_data)
+    active_validators = [
+        LidoValidatorFactory.build(pending_topups=[Mock(amount=500), Mock(amount=300)]),
+        LidoValidatorFactory.build(pending_topups=[Mock(amount=200)]),
+    ]
+    accounting.w3.lido_validators.get_active_lido_validators = Mock(return_value=active_validators)
+
+    balance = accounting._get_cl_pending_validators_balance(bs)
+
+    assert balance == 2000  # 1000 (new validator) + 500 + 300 + 200 (topups)
 
 
 @pytest.mark.unit
@@ -708,6 +728,7 @@ def test_get_finalization_data_zero_shares(accounting: Accounting):
 def test_get_cl_pending_validators_balance_empty(accounting: Accounting):
     bs = ReferenceBlockStampFactory.build()
     accounting.w3.lido_validators.get_pending_lido_validators = Mock(return_value={})
+    accounting.w3.lido_validators.get_active_lido_validators = Mock(return_value=[])
     balance = accounting._get_cl_pending_validators_balance(bs)
     assert balance == 0
 


### PR DESCRIPTION
# Summary
                                                                                                                                         
  - Bug fix: _get_cl_pending_validators_balance was only counting pending deposits for new validators (keys not yet activated on the CL).
   Pending top-up deposits for existing active validators were silently omitted.                                                         
   
#  Problem                                                                                                                                
                  
  With Pectra/EIP-7251, additional deposits can be sent to existing validators as top-ups. These land in the CL's pending_deposits queue and are attached to LidoValidator.pending_topups, but _get_cl_pending_validators_balance only iterated over `get_pending_lido_validators`, which filters exclusively for keys not yet in the active validator set.                                   
                  
  This created an accounting gap across frame boundaries: if a top-up deposit was queued in frame N but not yet processed by the CL at frame N+1's reference slot, it would be invisible to the contract's accounting — absent from both `clPendingBalanceAtLastReport` (which stores the oracle's reported pending balance, excluding top-ups) and `depositedForCurrentReport`(which no longer covers it since it was deposited in a prior frame).

#  Fix

  `_get_cl_pending_validators_balance` now sums two components:                                                                            
  1. Pending deposits for new validators awaiting activation (existing behavior)
  2. Pending top-up amounts for existing active validators (validator.pending_topups)                                                    
                                                                                     
  get_active_lido_validators is already @lru_cache'd, so this adds no extra RPC calls. 