### PR TITLE
fix: retry on stream

### DIFF
--- a/src/providers/consensus/client.py
+++ b/src/providers/consensus/client.py
@@ -237,8 +237,9 @@ class ConsensusClient(HTTPProvider):
             path_params=(state_id,),
             stream=True,
             validate_response=data_is_transient_dict,
+            stream_consumer=lambda d: list(d["block_roots"]),
         )
-        return list(data["block_roots"])
+        return data
 
     def get_validators(self, blockstamp: BlockStamp) -> list[Validator]:
         return self.get_state_view(blockstamp).indexed_validators

--- a/src/providers/http_provider.py
+++ b/src/providers/http_provider.py
@@ -116,6 +116,7 @@ class HTTPProvider(ProviderConsistencyModule, ABC):
         force_raise: Callable[..., Exception | None] = lambda _: None,
         validate_response: ReturnValueValidator = data_is_any,
         stream: bool = False,
+        stream_consumer: Callable[[Any], Any] | None = None,
     ) -> tuple[Any, dict]:
         """
         Plain or streamed GET request with fallbacks
@@ -123,6 +124,10 @@ class HTTPProvider(ProviderConsistencyModule, ABC):
 
         force_raise - function that returns an Exception if it should be thrown immediately.
         Sometimes NotOk response from first provider is the response that we are expecting.
+
+        stream_consumer - when stream=True, a callable that consumes the stream data and
+        returns the final result. Must be provided for streamed requests so that mid-stream
+        failures are caught inside the fallback loop and trigger retry with the next host.
         """
         errors: list[Exception] = []
 
@@ -135,6 +140,7 @@ class HTTPProvider(ProviderConsistencyModule, ABC):
                     query_params,
                     stream=stream,
                     validate_response=validate_response,
+                    stream_consumer=stream_consumer,
                 )
             except Exception as e:  # pylint: disable=W0703
                 errors.append(e)
@@ -162,6 +168,7 @@ class HTTPProvider(ProviderConsistencyModule, ABC):
         query_params: dict | None = None,
         stream: bool = False,
         validate_response: ReturnValueValidator = data_is_any,
+        stream_consumer: Callable[[Any], Any] | None = None,
     ) -> tuple[Any, dict]:
         """
         Simple GET request without fallbacks
@@ -223,6 +230,8 @@ class HTTPProvider(ProviderConsistencyModule, ABC):
             data = json_response
 
         validate_response(data, meta, endpoint=endpoint)
+        if stream_consumer is not None:
+            data = stream_consumer(data)
         return data, meta
 
     def _post(

--- a/tests/providers_clients/test_http_provider.py
+++ b/tests/providers_clients/test_http_provider.py
@@ -79,6 +79,7 @@ def test_force_raise():
         None,
         stream=False,
         validate_response=data_is_any,
+        stream_consumer=None,
     )
 
 
@@ -116,6 +117,46 @@ def test_custom_error_provided():
 
     with pytest.raises(CustomError):
         provider.call()
+
+
+@pytest.mark.unit
+def test_stream_consumer_applied_to_data():
+    """stream_consumer receives the parsed data and its return value is used."""
+    provider = HTTPProvider(['http://localhost:1'], 5 * 60, 1, 1)
+    provider.PROMETHEUS_HISTOGRAM = CL_REQUESTS_DURATION
+
+    resp = Response()
+    resp.status_code = 200
+    resp._content = b'{"data": [1, 2, 3]}'
+    provider.session.get = Mock(return_value=resp)
+
+    data, _ = provider._get_without_fallbacks('http://localhost:1', 'test', stream_consumer=lambda d: list(reversed(d)))
+    assert data == [3, 2, 1]
+
+
+@pytest.mark.unit
+def test_stream_consumer_failure_triggers_fallback():
+    """When stream_consumer raises, _get must fall back to the next host."""
+    provider = HTTPProvider(['http://localhost:1', 'http://localhost:2'], 5 * 60, 1, 1)
+    provider.PROMETHEUS_HISTOGRAM = CL_REQUESTS_DURATION
+
+    resp = Response()
+    resp.status_code = 200
+    resp._content = b'{"data": [1, 2, 3]}'
+    provider.session.get = Mock(return_value=resp)
+
+    call_count = 0
+
+    def consumer(data):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise OSError('Mid-stream failure')
+        return list(data)
+
+    data, _ = provider._get('test', stream_consumer=consumer)
+    assert data == [1, 2, 3]
+    assert call_count == 2
 
 
 @pytest.mark.unit


### PR DESCRIPTION
# Problem                                                                                                                                
         
  When fetching large streamed responses (e.g. `get_block_roots`), mid-stream failures were unrecoverable — they would not trigger a retry on the next configured host.                                                                                                           
   
  The root cause: json_stream_requests.load(response) returns a lazy iterator. The actual network I/O happens when the caller iterates it, which was after returning from _get_without_fallbacks. So the fallback loop in _get had already exited successfully — any mid-stream connection drop or timeout raised outside the retry loop, with no fallback possible.                                        
  ```                
  # Before: consumption happened outside the fallback loop
  data, _ = self._get(..., stream=True)                                                                                                  
  return list(data["block_roots"])  # ← network I/O here, no retry if this fails
  ```                                                         
                                                                                                                                         
 # Fix                                                                                                                                    
                                                                                                                                         
  Introduce a stream_consumer parameter to `_get / _get_without_fallbacks`. When provided, the consumer is called inside `_get_without_fallbacks`, before returning — still within the try/except of the fallback loop. Any exception raised during stream consumption (mid-stream I/O failure, truncated response, etc.) is caught by the loop and triggers a retry on the next host.            
  
  ```                
  # After: consumption happens inside the fallback loop
  data, _ = self._get(..., stream=True, stream_consumer=lambda d: list(d["block_roots"]))
  return data  # ← already fully consumed, failures retried
```                                                                              
   
 # Changes                                                                                                                                
                  
  - src/providers/http_provider.py — add stream_consumer: Callable | None to _get and _get_without_fallbacks; call it on data before returning       
  - src/providers/consensus/client.py — pass stream_consumer=lambda d: list(d["block_roots"]) to get_block_roots; remove post-call consumption                                                                                                                            
  - tests/providers_clients/test_http_provider.py — two new tests: stream_consumer is applied to data; stream_consumer failure triggers fallback to next host       