### PR TITLE
feat: Improve vebo tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code local settings
+.claude/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -21,7 +21,7 @@ from src.providers.consensus.types import (
     BeaconStateView,
 )
 from src.providers.execution.contracts.exit_bus_oracle import ExitBusOracleContract
-from src.types import BlockStamp, Gwei, ReferenceBlockStamp, SlotNumber, Wei
+from src.types import BlockStamp, EpochNumber, Gwei, ReferenceBlockStamp, SlotNumber, Wei
 from src.utils.validator_balance import get_predictable_balance
 from src.web3py.extensions.lido_validators import (
     LidoValidator,
@@ -485,3 +485,145 @@ def test_ejector_get_processing_state(ejector: Ejector):
     result = ejector._get_processing_state(bs)
 
     assert accounting_processing_state == result
+
+
+@pytest.mark.unit
+def test_is_reporting_allowed(ejector: Ejector, ref_blockstamp: ReferenceBlockStamp) -> None:
+    ejector.report_contract.is_paused = Mock(return_value=False)
+    assert ejector.is_reporting_allowed(ref_blockstamp) is True
+    ejector.report_contract.is_paused.assert_called_once_with('latest')
+
+    ejector.report_contract.is_paused = Mock(return_value=True)
+    assert ejector.is_reporting_allowed(ref_blockstamp) is False
+    ejector.report_contract.is_paused.assert_called_once_with('latest')
+
+
+@pytest.mark.unit
+def test_is_contracts_addresses_changed(ejector: Ejector) -> None:
+    ejector.w3.lido_contracts.has_contract_address_changed = Mock(return_value=True)
+    assert ejector.is_contracts_addresses_changed() is True
+
+    ejector.w3.lido_contracts.has_contract_address_changed = Mock(return_value=False)
+    assert ejector.is_contracts_addresses_changed() is False
+
+
+@pytest.mark.unit
+def test_refresh_contracts(ejector: Ejector) -> None:
+    new_contract = Mock()
+    ejector.w3.lido_contracts.validators_exit_bus_oracle = new_contract
+    ejector.refresh_contracts()
+    assert ejector.report_contract is new_contract
+
+
+@pytest.mark.unit
+def test_execute_module_compatibility_check_fails(ejector: Ejector, blockstamp: BlockStamp) -> None:
+    ejector.get_blockstamp_for_report = Mock(return_value=blockstamp)
+    ejector._check_compatibility = Mock(return_value=False)
+    result = ejector.execute_module(last_finalized_blockstamp=blockstamp)
+    assert result is ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
+    ejector.get_blockstamp_for_report.assert_called_once_with(blockstamp)
+
+
+@pytest.mark.unit
+def test_get_deposit_lock_amount(ejector: Ejector, ref_blockstamp: ReferenceBlockStamp) -> None:
+    reserve_per_frame = Wei(10 * GWEI_TO_WEI)
+    epochs_per_frame = 10
+
+    ejector.w3.lido_contracts.lido.get_deposits_reserve = Mock(return_value=reserve_per_frame)
+    ejector.w3.lido_contracts.accounting_oracle.get_consensus_contract = Mock(return_value="0x" + "0" * 40)
+
+    mock_consensus = Mock()
+    mock_consensus.get_frame_config.return_value = Mock(epochs_per_frame=epochs_per_frame)
+    ejector.w3.eth.contract = Mock(return_value=mock_consensus)
+
+    # 0 epochs → ceil(0/10) = 0 frames → 0 locked
+    assert ejector._get_deposit_lock_amount(0, ref_blockstamp) == Wei(0)
+
+    # Exactly one frame (10 epochs) → ceil(10/10) = 1 frame
+    assert ejector._get_deposit_lock_amount(10, ref_blockstamp) == Wei(reserve_per_frame)
+
+    # One epoch over one frame → ceil(11/10) = 2 frames
+    assert ejector._get_deposit_lock_amount(11, ref_blockstamp) == Wei(2 * reserve_per_frame)
+
+    # 2.5 frames → ceil(25/10) = 3 frames
+    assert ejector._get_deposit_lock_amount(25, ref_blockstamp) == Wei(3 * reserve_per_frame)
+
+
+class ForcedIterator:
+    """Iterator that yields no regular validators but returns forced validators on demand."""
+
+    def __init__(self, forced_vals):
+        self.forced_vals = forced_vals
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        raise StopIteration
+
+    def get_remaining_forced_validators(self):
+        return self.forced_vals
+
+
+@pytest.mark.unit
+def test_get_validators_to_eject_with_forced_validators(
+    ejector: Ejector,
+    ref_blockstamp: ReferenceBlockStamp,
+    chain_config: ChainConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ejector.get_chain_config = Mock(return_value=chain_config)
+    ejector.w3.lido_contracts.withdrawal_queue_nft.unfinalized_steth = Mock(return_value=Wei(1000))
+    ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(0))
+    ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
+    ejector._get_total_el_balance = Mock(return_value=Wei(0))
+    ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
+    ejector._get_withdrawable_lido_validators_balance = Mock(return_value=Wei(0))
+    ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
+    ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
+
+    forced_gid = (StakingModuleId(1), NodeOperatorId(1))
+    forced_validator = build_extended_validator()
+    forced_iter = ForcedIterator([(forced_gid, forced_validator)])
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            ejector_module.ValidatorExitIterator,
+            "__iter__",
+            Mock(return_value=forced_iter),
+        )
+        result = ejector.get_validators_to_eject(ref_blockstamp)
+
+    assert len(result) == 1, "Forced validator should be included even when no regular ejections are needed"
+    assert result[0][0] == forced_gid
+    assert result[0][1].index == forced_validator.index
+
+
+@pytest.mark.unit
+def test_get_withdrawable_lido_validators_balance_skips_consolidating_source(
+    ejector: Ejector,
+    ref_blockstamp: ReferenceBlockStamp,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    normal_validator = build_extended_validator_with_balance(Gwei(42))
+    consolidating_validator = build_extended_validator_with_balance(Gwei(42))
+    # Mark as consolidation source — this validator should be excluded from withdrawable balance
+    consolidating_validator._consolidating_as_source = Mock()  # type: ignore[assignment]
+
+    ejector.w3.lido_validators.get_active_lido_validators = Mock(
+        return_value=[normal_validator, consolidating_validator]
+    )
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            ejector_module,
+            "is_fully_withdrawable_validator",
+            Mock(return_value=True),
+        )
+        # Use a different epoch to avoid LRU cache collision with other tests
+        result = ejector._get_withdrawable_lido_validators_balance(
+            EpochNumber(ref_blockstamp.ref_epoch + 1), ref_blockstamp
+        )
+
+    # Only the normal validator contributes; consolidating_as_source is skipped
+    assert result == normal_validator.balance * GWEI_TO_WEI

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -43,7 +43,7 @@ def build_extended_validator(**kwargs) -> LidoValidator:
         validator=lido_validator.validator,
         lido_id=lido_validator.lido_id,
         pending_topups=[],
-        consolidating_as_source=None,
+        consolidating_as_source=lido_validator.consolidating_as_source,
         consolidating_as_target=[],
     )
 
@@ -56,7 +56,7 @@ def build_extended_validator_with_balance(balance: float, meb: int = MAX_EFFECTI
         validator=lido_validator.validator,
         lido_id=lido_validator.lido_id,
         pending_topups=[],
-        consolidating_as_source=None,
+        consolidating_as_source=lido_validator.consolidating_as_source,
         consolidating_as_target=[],
     )
 
@@ -488,63 +488,74 @@ def test_ejector_get_processing_state(ejector: Ejector):
 
 
 @pytest.mark.unit
-def test_is_reporting_allowed(ejector: Ejector, ref_blockstamp: ReferenceBlockStamp) -> None:
+def test_is_reporting_allowed__reflects_pause_state(ejector: Ejector, ref_blockstamp: ReferenceBlockStamp) -> None:
     ejector.report_contract.is_paused = Mock(return_value=False)
-    assert ejector.is_reporting_allowed(ref_blockstamp) is True
+
+    result = ejector.is_reporting_allowed(ref_blockstamp)
+
+    assert result is True
     ejector.report_contract.is_paused.assert_called_once_with('latest')
 
     ejector.report_contract.is_paused = Mock(return_value=True)
-    assert ejector.is_reporting_allowed(ref_blockstamp) is False
+
+    result = ejector.is_reporting_allowed(ref_blockstamp)
+
+    assert result is False
     ejector.report_contract.is_paused.assert_called_once_with('latest')
 
 
 @pytest.mark.unit
-def test_is_contracts_addresses_changed(ejector: Ejector) -> None:
+def test_is_contracts_addresses_changed__returns_w3_result(ejector: Ejector) -> None:
     ejector.w3.lido_contracts.has_contract_address_changed = Mock(return_value=True)
+
     assert ejector.is_contracts_addresses_changed() is True
 
     ejector.w3.lido_contracts.has_contract_address_changed = Mock(return_value=False)
+
     assert ejector.is_contracts_addresses_changed() is False
 
 
 @pytest.mark.unit
-def test_refresh_contracts(ejector: Ejector) -> None:
+def test_refresh_contracts__updates_report_contract_from_w3(ejector: Ejector) -> None:
     new_contract = Mock()
     ejector.w3.lido_contracts.validators_exit_bus_oracle = new_contract
+
     ejector.refresh_contracts()
+
     assert ejector.report_contract is new_contract
 
 
 @pytest.mark.unit
-def test_execute_module_compatibility_check_fails(ejector: Ejector, blockstamp: BlockStamp) -> None:
+def test_execute_module__compatibility_check_fails__returns_next_finalized_epoch(
+    ejector: Ejector, blockstamp: BlockStamp
+) -> None:
     ejector.get_blockstamp_for_report = Mock(return_value=blockstamp)
     ejector._check_compatibility = Mock(return_value=False)
+
     result = ejector.execute_module(last_finalized_blockstamp=blockstamp)
+
     assert result is ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
     ejector.get_blockstamp_for_report.assert_called_once_with(blockstamp)
 
 
 @pytest.mark.unit
-def test_get_deposit_lock_amount(ejector: Ejector, ref_blockstamp: ReferenceBlockStamp) -> None:
+def test_get_deposit_lock_amount__calculates_frames_ceiling__scales_by_reserve(
+    ejector: Ejector, ref_blockstamp: ReferenceBlockStamp
+) -> None:
     reserve_per_frame = Wei(10 * GWEI_TO_WEI)
     epochs_per_frame = 10
-
     ejector.w3.lido_contracts.lido.get_deposits_reserve = Mock(return_value=reserve_per_frame)
     ejector.w3.lido_contracts.accounting_oracle.get_consensus_contract = Mock(return_value="0x" + "0" * 40)
-
     mock_consensus = Mock()
     mock_consensus.get_frame_config.return_value = Mock(epochs_per_frame=epochs_per_frame)
     ejector.w3.eth.contract = Mock(return_value=mock_consensus)
 
     # 0 epochs → ceil(0/10) = 0 frames → 0 locked
     assert ejector._get_deposit_lock_amount(0, ref_blockstamp) == Wei(0)
-
     # Exactly one frame (10 epochs) → ceil(10/10) = 1 frame
     assert ejector._get_deposit_lock_amount(10, ref_blockstamp) == Wei(reserve_per_frame)
-
     # One epoch over one frame → ceil(11/10) = 2 frames
     assert ejector._get_deposit_lock_amount(11, ref_blockstamp) == Wei(2 * reserve_per_frame)
-
     # 2.5 frames → ceil(25/10) = 3 frames
     assert ejector._get_deposit_lock_amount(25, ref_blockstamp) == Wei(3 * reserve_per_frame)
 
@@ -566,7 +577,7 @@ class ForcedIterator:
 
 
 @pytest.mark.unit
-def test_get_validators_to_eject_with_forced_validators(
+def test_get_validators_to_eject__forced_validators_present__included_in_result(
     ejector: Ejector,
     ref_blockstamp: ReferenceBlockStamp,
     chain_config: ChainConfig,
@@ -592,6 +603,7 @@ def test_get_validators_to_eject_with_forced_validators(
             "__iter__",
             Mock(return_value=forced_iter),
         )
+
         result = ejector.get_validators_to_eject(ref_blockstamp)
 
     assert len(result) == 1, "Forced validator should be included even when no regular ejections are needed"
@@ -600,15 +612,14 @@ def test_get_validators_to_eject_with_forced_validators(
 
 
 @pytest.mark.unit
-def test_get_withdrawable_lido_validators_balance_skips_consolidating_source(
+def test_get_withdrawable_lido_validators_balance__consolidating_as_source__excluded(
     ejector: Ejector,
     ref_blockstamp: ReferenceBlockStamp,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     normal_validator = build_extended_validator_with_balance(Gwei(42))
-    consolidating_validator = build_extended_validator_with_balance(Gwei(42))
     # Mark as consolidation source — this validator should be excluded from withdrawable balance
-    consolidating_validator._consolidating_as_source = Mock()  # type: ignore[assignment]
+    consolidating_validator = build_extended_validator_with_balance(Gwei(42), consolidating_as_source=Mock())
 
     ejector.w3.lido_validators.get_active_lido_validators = Mock(
         return_value=[normal_validator, consolidating_validator]

--- a/tests/modules/ejector/test_sweep.py
+++ b/tests/modules/ejector/test_sweep.py
@@ -125,7 +125,7 @@ def test_combined_withdrawals():
 
 
 @pytest.mark.unit
-def test_get_pending_partial_withdrawals_filters_exiting_validator():
+def test_get_pending_partial_withdrawals__exiting_validator__returns_empty():
     """Validators with exit_epoch != FAR_FUTURE_EPOCH are excluded from pending partial withdrawals."""
     validator = LidoValidatorFactory.build(
         balance=Gwei(MIN_ACTIVATION_BALANCE + 100),
@@ -140,12 +140,14 @@ def test_get_pending_partial_withdrawals_filters_exiting_validator():
         slashings=[],
         slot=32,
     )
+
     result = get_pending_partial_withdrawals(state)
+
     assert result == [], "Exiting validator should be excluded from pending partial withdrawals"
 
 
 @pytest.mark.unit
-def test_get_pending_partial_withdrawals_filters_low_effective_balance():
+def test_get_pending_partial_withdrawals__low_effective_balance__returns_empty():
     """Validators with effective_balance < MIN_ACTIVATION_BALANCE are excluded."""
     validator = LidoValidatorFactory.build(
         balance=Gwei(MIN_ACTIVATION_BALANCE + 100),
@@ -160,12 +162,14 @@ def test_get_pending_partial_withdrawals_filters_low_effective_balance():
         slashings=[],
         slot=32,
     )
+
     result = get_pending_partial_withdrawals(state)
+
     assert result == [], "Validator with effective_balance < MIN_ACTIVATION_BALANCE should be excluded"
 
 
 @pytest.mark.unit
-def test_get_pending_partial_withdrawals_filters_no_excess_balance():
+def test_get_pending_partial_withdrawals__no_excess_balance__returns_empty():
     """Validators with balance == MIN_ACTIVATION_BALANCE have no excess to withdraw."""
     validator = LidoValidatorFactory.build(
         balance=Gwei(MIN_ACTIVATION_BALANCE),  # Exactly at minimum — no excess balance
@@ -180,12 +184,14 @@ def test_get_pending_partial_withdrawals_filters_no_excess_balance():
         slashings=[],
         slot=32,
     )
+
     result = get_pending_partial_withdrawals(state)
+
     assert result == [], "Validator with balance == MIN_ACTIVATION_BALANCE has no excess balance"
 
 
 @pytest.mark.unit
-def test_predict_withdrawals_with_pending_partials_ratio(monkeypatch):
+def test_predict_withdrawals_number_in_sweep_cycle__pending_partials_exceed_ratio__capped(monkeypatch):
     """Pending partials in a sweep cycle are capped by the MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP ratio."""
     state = Mock(spec=BeaconStateView)
     num_validator_withdrawals = 5
@@ -194,9 +200,11 @@ def test_predict_withdrawals_with_pending_partials_ratio(monkeypatch):
     with monkeypatch.context() as m:
         m.setattr(sweep_module, "get_pending_partial_withdrawals", Mock(return_value=[Mock()] * num_pending_partials))
         m.setattr(sweep_module, "get_validators_withdrawals", Mock(return_value=[Mock()] * num_validator_withdrawals))
+
         result = sweep_module.predict_withdrawals_number_in_sweep_cycle(state, 32)
 
-    # ratio = MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP / (MAX_WITHDRAWALS_PER_PAYLOAD - MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP)
+    # ratio = MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
+    #       / (MAX_WITHDRAWALS_PER_PAYLOAD - MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP)
     #       = 8/(16-8) = 1.0
     # max_pending_in_cycle = ceil(5 * 1.0) = 5
     # actual_pending_in_cycle = min(20, 5) = 5
@@ -205,25 +213,25 @@ def test_predict_withdrawals_with_pending_partials_ratio(monkeypatch):
         MAX_WITHDRAWALS_PER_PAYLOAD - MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
     )
     max_pending = math.ceil(num_validator_withdrawals * ratio)
-    expected = num_validator_withdrawals + min(num_pending_partials, max_pending)
-    assert result == expected
+    assert result == num_validator_withdrawals + min(num_pending_partials, max_pending)
 
 
 @pytest.mark.unit
-def test_predict_withdrawals_empty_state(monkeypatch):
+def test_predict_withdrawals_number_in_sweep_cycle__empty_state__returns_zero(monkeypatch):
     """Empty state (no validators, no pending partials) produces zero withdrawals."""
     state = Mock(spec=BeaconStateView)
 
     with monkeypatch.context() as m:
         m.setattr(sweep_module, "get_pending_partial_withdrawals", Mock(return_value=[]))
         m.setattr(sweep_module, "get_validators_withdrawals", Mock(return_value=[]))
+
         result = sweep_module.predict_withdrawals_number_in_sweep_cycle(state, 32)
 
     assert result == 0
 
 
 @pytest.mark.unit
-def test_get_validators_withdrawals_empty():
+def test_get_validators_withdrawals__empty_validators__returns_empty():
     """Empty validator list produces no withdrawals."""
     state = BeaconStateViewFactory.build(
         slot=32,
@@ -232,5 +240,7 @@ def test_get_validators_withdrawals_empty():
         pending_partial_withdrawals=[],
         slashings=[],
     )
+
     result = get_validators_withdrawals(state, [], 32)
+
     assert result == []

--- a/tests/modules/ejector/test_sweep.py
+++ b/tests/modules/ejector/test_sweep.py
@@ -4,7 +4,12 @@ from unittest.mock import Mock
 import pytest
 
 import src.modules.oracles.ejector.sweep as sweep_module
-from src.constants import MAX_WITHDRAWALS_PER_PAYLOAD, MIN_ACTIVATION_BALANCE
+from src.constants import (
+    FAR_FUTURE_EPOCH,
+    MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP,
+    MAX_WITHDRAWALS_PER_PAYLOAD,
+    MIN_ACTIVATION_BALANCE,
+)
 from src.modules.common.types import ChainConfig
 from src.modules.oracles.ejector.sweep import (
     Withdrawal,
@@ -117,3 +122,114 @@ def test_combined_withdrawals():
     )
     result = sweep_module.predict_withdrawals_number_in_sweep_cycle(mock_state, 32)
     assert result == 10
+
+
+@pytest.mark.unit
+def test_get_pending_partial_withdrawals_filters_exiting_validator():
+    """Validators with exit_epoch != FAR_FUTURE_EPOCH are excluded from pending partial withdrawals."""
+    validator = LidoValidatorFactory.build(
+        balance=Gwei(MIN_ACTIVATION_BALANCE + 100),
+        validator=ValidatorStateFactory.build(
+            effective_balance=MIN_ACTIVATION_BALANCE,
+            exit_epoch=10,  # Validator is exiting — not FAR_FUTURE_EPOCH
+        ),
+    )
+    state = BeaconStateViewFactory.build_with_validators(
+        validators=[validator],
+        pending_partial_withdrawals=[PendingPartialWithdrawal(validator_index=0, amount=100, withdrawable_epoch=1)],
+        slashings=[],
+        slot=32,
+    )
+    result = get_pending_partial_withdrawals(state)
+    assert result == [], "Exiting validator should be excluded from pending partial withdrawals"
+
+
+@pytest.mark.unit
+def test_get_pending_partial_withdrawals_filters_low_effective_balance():
+    """Validators with effective_balance < MIN_ACTIVATION_BALANCE are excluded."""
+    validator = LidoValidatorFactory.build(
+        balance=Gwei(MIN_ACTIVATION_BALANCE + 100),
+        validator=ValidatorStateFactory.build(
+            effective_balance=MIN_ACTIVATION_BALANCE - 1,  # Below the minimum threshold
+            exit_epoch=FAR_FUTURE_EPOCH,
+        ),
+    )
+    state = BeaconStateViewFactory.build_with_validators(
+        validators=[validator],
+        pending_partial_withdrawals=[PendingPartialWithdrawal(validator_index=0, amount=100, withdrawable_epoch=1)],
+        slashings=[],
+        slot=32,
+    )
+    result = get_pending_partial_withdrawals(state)
+    assert result == [], "Validator with effective_balance < MIN_ACTIVATION_BALANCE should be excluded"
+
+
+@pytest.mark.unit
+def test_get_pending_partial_withdrawals_filters_no_excess_balance():
+    """Validators with balance == MIN_ACTIVATION_BALANCE have no excess to withdraw."""
+    validator = LidoValidatorFactory.build(
+        balance=Gwei(MIN_ACTIVATION_BALANCE),  # Exactly at minimum — no excess balance
+        validator=ValidatorStateFactory.build(
+            effective_balance=MIN_ACTIVATION_BALANCE,
+            exit_epoch=FAR_FUTURE_EPOCH,
+        ),
+    )
+    state = BeaconStateViewFactory.build_with_validators(
+        validators=[validator],
+        pending_partial_withdrawals=[PendingPartialWithdrawal(validator_index=0, amount=100, withdrawable_epoch=1)],
+        slashings=[],
+        slot=32,
+    )
+    result = get_pending_partial_withdrawals(state)
+    assert result == [], "Validator with balance == MIN_ACTIVATION_BALANCE has no excess balance"
+
+
+@pytest.mark.unit
+def test_predict_withdrawals_with_pending_partials_ratio(monkeypatch):
+    """Pending partials in a sweep cycle are capped by the MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP ratio."""
+    state = Mock(spec=BeaconStateView)
+    num_validator_withdrawals = 5
+    num_pending_partials = 20  # More pending partials than can fit per cycle
+
+    with monkeypatch.context() as m:
+        m.setattr(sweep_module, "get_pending_partial_withdrawals", Mock(return_value=[Mock()] * num_pending_partials))
+        m.setattr(sweep_module, "get_validators_withdrawals", Mock(return_value=[Mock()] * num_validator_withdrawals))
+        result = sweep_module.predict_withdrawals_number_in_sweep_cycle(state, 32)
+
+    # ratio = MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP / (MAX_WITHDRAWALS_PER_PAYLOAD - MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP) = 8/(16-8) = 1.0
+    # max_pending_in_cycle = ceil(5 * 1.0) = 5
+    # actual_pending_in_cycle = min(20, 5) = 5
+    # total = 5 + 5 = 10
+    ratio = MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP / (
+        MAX_WITHDRAWALS_PER_PAYLOAD - MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP
+    )
+    max_pending = math.ceil(num_validator_withdrawals * ratio)
+    expected = num_validator_withdrawals + min(num_pending_partials, max_pending)
+    assert result == expected
+
+
+@pytest.mark.unit
+def test_predict_withdrawals_empty_state(monkeypatch):
+    """Empty state (no validators, no pending partials) produces zero withdrawals."""
+    state = Mock(spec=BeaconStateView)
+
+    with monkeypatch.context() as m:
+        m.setattr(sweep_module, "get_pending_partial_withdrawals", Mock(return_value=[]))
+        m.setattr(sweep_module, "get_validators_withdrawals", Mock(return_value=[]))
+        result = sweep_module.predict_withdrawals_number_in_sweep_cycle(state, 32)
+
+    assert result == 0
+
+
+@pytest.mark.unit
+def test_get_validators_withdrawals_empty():
+    """Empty validator list produces no withdrawals."""
+    state = BeaconStateViewFactory.build(
+        slot=32,
+        validators=[],
+        balances=[],
+        pending_partial_withdrawals=[],
+        slashings=[],
+    )
+    result = get_validators_withdrawals(state, [], 32)
+    assert result == []

--- a/tests/modules/ejector/test_sweep.py
+++ b/tests/modules/ejector/test_sweep.py
@@ -196,7 +196,8 @@ def test_predict_withdrawals_with_pending_partials_ratio(monkeypatch):
         m.setattr(sweep_module, "get_validators_withdrawals", Mock(return_value=[Mock()] * num_validator_withdrawals))
         result = sweep_module.predict_withdrawals_number_in_sweep_cycle(state, 32)
 
-    # ratio = MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP / (MAX_WITHDRAWALS_PER_PAYLOAD - MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP) = 8/(16-8) = 1.0
+    # ratio = MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP / (MAX_WITHDRAWALS_PER_PAYLOAD - MAX_PENDING_PARTIALS_PER_WITHDRAWALS_SWEEP)
+    #       = 8/(16-8) = 1.0
     # max_pending_in_cycle = ceil(5 * 1.0) = 5
     # actual_pending_in_cycle = min(20, 5) = 5
     # total = 5 + 5 = 10

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -2,12 +2,13 @@ from unittest.mock import Mock
 
 import pytest
 
+from src.constants import FAR_FUTURE_EPOCH
 from src.modules.common.types import ChainConfig
 from src.services.exit_order_iterator import NodeOperatorStats, StakingModuleStats, ValidatorExitIterator
 from src.types import Gwei, NodeOperatorId, StakingModuleId
 from src.web3py.extensions.lido_validators import NodeOperator, NodeOperatorLimitMode, StakingModule
 from tests.factory.blockstamp import ReferenceBlockStampFactory
-from tests.factory.no_registry import LidoValidatorFactory
+from tests.factory.no_registry import LidoValidatorFactory, ValidatorStateFactory
 
 
 @pytest.fixture
@@ -189,3 +190,167 @@ def test_lowest_validators_index_predicate(iterator):
     iterator.exitable_validators = {(sm.id, no1.id): [Mock(index=5)], (sm.id, no2.id): [Mock(index=10)]}
     assert iterator._lowest_validator_index_predicate(NodeOperatorStats(no1, ms)) == 5
     assert iterator._lowest_validator_index_predicate(NodeOperatorStats(no2, ms)) == 10
+
+
+@pytest.mark.unit
+def test_get_remaining_forced_validators(iterator):
+    """Forced validators above their force exit target are returned by get_remaining_forced_validators."""
+    sm1 = make_staking_module(1)
+    no1 = make_node_operator(1, sm1, total_dep=3, target=1, limit_mode=NodeOperatorLimitMode.FORCE)
+    gid11 = (sm1.id, no1.id)
+
+    iterator.w3.lido_contracts.staking_router.get_staking_modules = Mock(return_value=[sm1])
+    iterator.w3.lido_validators.get_lido_node_operators_by_modules = Mock(return_value={sm1.id: [no1]})
+    iterator.w3.lido_validators.get_lido_validators_by_node_operators = Mock(
+        return_value={
+            gid11: [
+                LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch) for _ in range(3)
+            ]
+        }
+    )
+    iterator.lvs.get_recently_requested_to_exit_validators_by_node_operator = Mock(return_value={gid11: [-1]})
+    iterator.w3.lido_validators.get_pending_lido_validators = Mock(return_value={})
+    iterator._setup_cm_data = Mock()
+
+    iterator._prepare_data_structure()
+    iterator._calculate_lido_stats()
+
+    # These attributes are normally set by __iter__; set them manually for the test
+    iterator.exit_limit_in_gwei = Gwei(100_000 * 10**9)
+    iterator.max_current_exit_balance = Gwei(0)
+
+    # force_exit_to=1, predictable_validators=3 → 2 validators should be forcefully ejected
+    forced = iterator.get_remaining_forced_validators()
+    assert len(forced) == 2, "Expected 2 forced validators (3 validators, target 1)"
+    assert all(gid == gid11 for gid, _ in forced)
+
+
+@pytest.mark.unit
+def test_get_remaining_forced_validators_none_needed(iterator):
+    """When all validators are at or below their force exit target, returns empty list."""
+    sm1 = make_staking_module(1)
+    # target=2 > total deposited=1, so no forced exit is needed
+    no1 = make_node_operator(1, sm1, total_dep=1, target=2, limit_mode=NodeOperatorLimitMode.FORCE)
+    gid11 = (sm1.id, no1.id)
+
+    iterator.w3.lido_contracts.staking_router.get_staking_modules = Mock(return_value=[sm1])
+    iterator.w3.lido_validators.get_lido_node_operators_by_modules = Mock(return_value={sm1.id: [no1]})
+    iterator.w3.lido_validators.get_lido_validators_by_node_operators = Mock(
+        return_value={gid11: [LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch)]}
+    )
+    iterator.lvs.get_recently_requested_to_exit_validators_by_node_operator = Mock(return_value={gid11: [-1]})
+    iterator.w3.lido_validators.get_pending_lido_validators = Mock(return_value={})
+    iterator._setup_cm_data = Mock()
+
+    iterator._prepare_data_structure()
+    iterator._calculate_lido_stats()
+
+    iterator.exit_limit_in_gwei = Gwei(100_000 * 10**9)
+    iterator.max_current_exit_balance = Gwei(0)
+
+    forced = iterator.get_remaining_forced_validators()
+    assert forced == [], "No forced exits needed when validators are below target"
+
+
+@pytest.mark.unit
+def test_make_exit_predicate_on_exit_validator(iterator):
+    """Validators with exit_epoch != FAR_FUTURE_EPOCH are not exitable."""
+    gid = (StakingModuleId(1), NodeOperatorId(1))
+    iterator.lvs.get_recently_requested_to_exit_validators_by_node_operator = Mock(return_value={gid: []})
+
+    filt = iterator.get_can_request_exit_predicate(gid)
+
+    on_exit_validator = LidoValidatorFactory.build(
+        validator=ValidatorStateFactory.build(exit_epoch=100),  # Not FAR_FUTURE_EPOCH
+    )
+    assert not filt(on_exit_validator), "Validator already on exit should not be exitable"
+
+    active_validator = LidoValidatorFactory.build(
+        validator=ValidatorStateFactory.build(exit_epoch=FAR_FUTURE_EPOCH),
+    )
+    assert filt(active_validator), "Active validator should be exitable"
+
+
+@pytest.mark.unit
+def test_make_exit_predicate_consolidating_as_source(iterator):
+    """Validators with consolidating_as_source set are not exitable."""
+    gid = (StakingModuleId(1), NodeOperatorId(1))
+    iterator.lvs.get_recently_requested_to_exit_validators_by_node_operator = Mock(return_value={gid: []})
+
+    filt = iterator.get_can_request_exit_predicate(gid)
+
+    # Validator being used as a consolidation source should NOT be exitable
+    consolidating_validator = LidoValidatorFactory.build(
+        validator=ValidatorStateFactory.build(exit_epoch=FAR_FUTURE_EPOCH),
+    )
+    consolidating_validator._consolidating_as_source = Mock()  # type: ignore[assignment]
+
+    assert not filt(consolidating_validator), "Validator being consolidated as source should not be exitable"
+
+
+@pytest.mark.unit
+def test_no_weight_predicate(iterator):
+    """_no_weight_predicate returns 0 for zero balance, otherwise weight / predictable_balance."""
+    sm = make_staking_module(1)
+    no = make_node_operator(1, sm)
+    ms = StakingModuleStats(staking_module=sm)
+
+    # Zero predictable_balance → return 0
+    nos_zero = NodeOperatorStats(node_operator=no, module_stats=ms, predictable_validators=0)
+    assert iterator._no_weight_predicate(nos_zero) == 0
+
+    # Non-zero balance → return weight / predictable_balance
+    nos_with_balance = NodeOperatorStats(
+        node_operator=no,
+        module_stats=ms,
+        predictable_validators=1,
+        predictable_balance=Gwei(100 * 10**9),
+        weight=2.0,
+    )
+    expected = 2.0 / (100 * 10**9)
+    assert iterator._no_weight_predicate(nos_with_balance) == pytest.approx(expected)
+
+
+@pytest.mark.unit
+def test_max_share_rate_coefficient_predicate(iterator):
+    """_max_share_rate_coefficient_predicate orders modules by excess balance above their share threshold."""
+    threshold = int(0.15 * 10000)  # 15%
+    iterator.total_lido_predictable_balance = Gwei(3500 * 32 * 10**9)
+
+    sm1 = make_staking_module(1, threshold=threshold)
+    sm2 = make_staking_module(2, threshold=threshold)
+    sm3 = make_staking_module(3, threshold=threshold)
+
+    # SM1: balance 1000 vals, max allowed ~525 vals → positive excess
+    # SM2: balance 200 vals, max allowed ~525 vals → under limit (negative)
+    # SM3: balance 2000 vals, max allowed ~525 vals → higher positive excess
+    ms1 = StakingModuleStats(staking_module=sm1, predictable_balance=Gwei(1000 * 32 * 10**9))
+    ms2 = StakingModuleStats(staking_module=sm2, predictable_balance=Gwei(200 * 32 * 10**9))
+    ms3 = StakingModuleStats(staking_module=sm3, predictable_balance=Gwei(2000 * 32 * 10**9))
+
+    no1 = make_node_operator(1, sm1)
+    no2 = make_node_operator(2, sm2)
+    no3 = make_node_operator(3, sm3)
+
+    nos = [
+        NodeOperatorStats(node_operator=no1, module_stats=ms1),
+        NodeOperatorStats(node_operator=no2, module_stats=ms2),
+        NodeOperatorStats(node_operator=no3, module_stats=ms3),
+    ]
+
+    sorted_nos = sorted(nos, key=lambda x: -iterator._max_share_rate_coefficient_predicate(x))
+    assert sorted_nos[0].node_operator.id == NodeOperatorId(3), "SM3 has highest excess balance above threshold"
+    assert sorted_nos[1].node_operator.id == NodeOperatorId(1), "SM1 has moderate excess balance above threshold"
+    assert sorted_nos[2].node_operator.id == NodeOperatorId(2), "SM2 is under threshold limit"
+
+
+@pytest.mark.unit
+def test_max_share_rate_coefficient_predicate_zero_balance(iterator):
+    """_max_share_rate_coefficient_predicate returns -2 when module predictable_balance is zero."""
+    sm = make_staking_module(1)
+    ms = StakingModuleStats(staking_module=sm, predictable_balance=Gwei(0))
+    no = make_node_operator(1, sm)
+    nos = NodeOperatorStats(node_operator=no, module_stats=ms)
+
+    result = iterator._max_share_rate_coefficient_predicate(nos)
+    assert result == -2

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -193,7 +193,7 @@ def test_lowest_validators_index_predicate(iterator):
 
 
 @pytest.mark.unit
-def test_get_remaining_forced_validators(iterator):
+def test_get_remaining_forced_validators__force_target_exceeded__returns_excess(iterator):
     """Forced validators above their force exit target are returned by get_remaining_forced_validators."""
     sm1 = make_staking_module(1)
     no1 = make_node_operator(1, sm1, total_dep=3, target=1, limit_mode=NodeOperatorLimitMode.FORCE)
@@ -211,22 +211,21 @@ def test_get_remaining_forced_validators(iterator):
     iterator.lvs.get_recently_requested_to_exit_validators_by_node_operator = Mock(return_value={gid11: [-1]})
     iterator.w3.lido_validators.get_pending_lido_validators = Mock(return_value={})
     iterator._setup_cm_data = Mock()
-
     iterator._prepare_data_structure()
     iterator._calculate_lido_stats()
-
     # These attributes are normally set by __iter__; set them manually for the test
     iterator.exit_limit_in_gwei = Gwei(100_000 * 10**9)
     iterator.max_current_exit_balance = Gwei(0)
 
     # force_exit_to=1, predictable_validators=3 → 2 validators should be forcefully ejected
     forced = iterator.get_remaining_forced_validators()
+
     assert len(forced) == 2, "Expected 2 forced validators (3 validators, target 1)"
     assert all(gid == gid11 for gid, _ in forced)
 
 
 @pytest.mark.unit
-def test_get_remaining_forced_validators_none_needed(iterator):
+def test_get_remaining_forced_validators__below_target__returns_empty(iterator):
     """When all validators are at or below their force exit target, returns empty list."""
     sm1 = make_staking_module(1)
     # target=2 > total deposited=1, so no forced exit is needed
@@ -241,19 +240,19 @@ def test_get_remaining_forced_validators_none_needed(iterator):
     iterator.lvs.get_recently_requested_to_exit_validators_by_node_operator = Mock(return_value={gid11: [-1]})
     iterator.w3.lido_validators.get_pending_lido_validators = Mock(return_value={})
     iterator._setup_cm_data = Mock()
-
     iterator._prepare_data_structure()
     iterator._calculate_lido_stats()
-
+    # These attributes are normally set by __iter__; set them manually for the test
     iterator.exit_limit_in_gwei = Gwei(100_000 * 10**9)
     iterator.max_current_exit_balance = Gwei(0)
 
     forced = iterator.get_remaining_forced_validators()
+
     assert forced == [], "No forced exits needed when validators are below target"
 
 
 @pytest.mark.unit
-def test_make_exit_predicate_on_exit_validator(iterator):
+def test_get_can_request_exit_predicate__validator_on_exit__not_exitable(iterator):
     """Validators with exit_epoch != FAR_FUTURE_EPOCH are not exitable."""
     gid = (StakingModuleId(1), NodeOperatorId(1))
     iterator.lvs.get_recently_requested_to_exit_validators_by_node_operator = Mock(return_value={gid: []})
@@ -263,27 +262,25 @@ def test_make_exit_predicate_on_exit_validator(iterator):
     on_exit_validator = LidoValidatorFactory.build(
         validator=ValidatorStateFactory.build(exit_epoch=100),  # Not FAR_FUTURE_EPOCH
     )
-    assert not filt(on_exit_validator), "Validator already on exit should not be exitable"
-
     active_validator = LidoValidatorFactory.build(
         validator=ValidatorStateFactory.build(exit_epoch=FAR_FUTURE_EPOCH),
     )
+
+    assert not filt(on_exit_validator), "Validator already on exit should not be exitable"
     assert filt(active_validator), "Active validator should be exitable"
 
 
 @pytest.mark.unit
-def test_make_exit_predicate_consolidating_as_source(iterator):
+def test_get_can_request_exit_predicate__consolidating_as_source__not_exitable(iterator):
     """Validators with consolidating_as_source set are not exitable."""
     gid = (StakingModuleId(1), NodeOperatorId(1))
     iterator.lvs.get_recently_requested_to_exit_validators_by_node_operator = Mock(return_value={gid: []})
-
-    filt = iterator.get_can_request_exit_predicate(gid)
-
-    # Validator being used as a consolidation source should NOT be exitable
     consolidating_validator = LidoValidatorFactory.build(
         validator=ValidatorStateFactory.build(exit_epoch=FAR_FUTURE_EPOCH),
+        consolidating_as_source=Mock(),
     )
-    consolidating_validator._consolidating_as_source = Mock()  # type: ignore[assignment]
+
+    filt = iterator.get_can_request_exit_predicate(gid)
 
     assert not filt(consolidating_validator), "Validator being consolidated as source should not be exitable"
 


### PR DESCRIPTION
# Summary
                                                                                                                                         
  Improves unit test coverage for the VEBO (validator ejector) oracle module by adding new test cases across three test files.
                                                                                                                                         
  - test_ejector.py — adds tests for is_reporting_allowed, is_contracts_addresses_changed, refresh_contracts, execute_module (compatibility check failure path), _get_deposit_lock_amount (frame ceiling calculation), get_validators_to_eject (forced validators included), and _get_withdrawable_lido_validators_balance (consolidating-as-source validators excluded)                                 
  - test_sweep.py — adds tests for get_pending_partial_withdrawals (filters exiting validators, low effective balance, no excess balance) and predict_withdrawals_number_in_sweep_cycle (ratio capping, empty state)                                                            
  - test_validator_exit_order_iterator.py — adds tests for get_remaining_forced_validators (above/below force target), get_can_request_exit_predicate (on-exit and consolidating-as-source cases), _no_weight_predicate, and                                  
  _max_share_rate_coefficient_predicate    