### PR TITLE
fix: replace `get_buffered_ether` to `get_withdrawals_reserve`

### DIFF
--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -281,7 +281,7 @@ class Ejector(OracleModule[Web3]):
         return Wei(
             self.w3.lido_contracts.get_el_vault_balance(blockstamp)
             + self.w3.lido_contracts.get_withdrawal_balance(blockstamp)
-            + self.w3.lido_contracts.lido.get_buffered_ether(blockstamp.block_hash)
+            + self.w3.lido_contracts.lido.get_withdrawals_reserve(blockstamp.block_hash)
         )
 
     def _get_predicted_withdrawable_epoch(
@@ -357,7 +357,10 @@ class Ejector(OracleModule[Web3]):
 
         ao_frame_size = consensus_contract.get_frame_config(blockstamp.block_hash).epochs_per_frame
 
-        # Rounding frames number up
-        ao_frames = (epoches_number + ao_frame_size - 1) // ao_frame_size
+        # `get_deposits_reserve()` already reflects the reserve locked for the current accounting
+        # frame at `blockstamp`. Only additional fully covered accounting frames within
+        # `epoches_number` must be added here, so floor-division is intentional. Using ceil
+        # would over-count by adding a reserve for a partial / already-accounted frame.
+        ao_frames = epoches_number // ao_frame_size
 
         return Wei(ao_frames * reserve_per_frame)

--- a/src/providers/execution/contracts/lido.py
+++ b/src/providers/execution/contracts/lido.py
@@ -15,18 +15,15 @@ class LidoContract(ContractInterface):
     abi_path = './assets/Lido.json'
 
     @lru_cache(maxsize=1)
-    def get_buffered_ether(self, block_identifier: BlockIdentifier = 'latest') -> Wei:
+    def get_withdrawals_reserve(self, block_identifier: BlockIdentifier = 'latest') -> Wei:
         """
-        Get the amount of Ether temporary buffered on this contract balance
-        Buffered balance is kept on the contract from the moment the funds are received from user
-        until the moment they are actually sent to the official Deposit contract.
-        return amount of buffered funds in wei
+        Return the amount of ETH reserved to satisfy withdrawals, in wei.
         """
-        response = self.functions.getBufferedEther().call(block_identifier=block_identifier)
+        response = self.functions.getWithdrawalsReserve().call(block_identifier=block_identifier)
 
         logger.info(
             {
-                'msg': 'Call `getBufferedEther()`.',
+                'msg': 'Call `getWithdrawalsReserve()`.',
                 'value': response,
                 'block_identifier': repr(block_identifier),
                 'to': self.address,

--- a/src/services/withdrawal.py
+++ b/src/services/withdrawal.py
@@ -71,9 +71,9 @@ class Withdrawal:
         # This amount of eth could not be spent for deposits.
         unfinalized_steth = self.w3.lido_contracts.withdrawal_queue_nft.unfinalized_steth(self.blockstamp.block_hash)
 
-        reserved_buffer = min(withdrawals_reserve, unfinalized_steth)
+        reserved_withdrawals_eth = min(withdrawals_reserve, unfinalized_steth)
 
-        return Wei(withdrawal_vault_balance + el_rewards_vault_balance + reserved_buffer)
+        return Wei(withdrawal_vault_balance + el_rewards_vault_balance + reserved_withdrawals_eth)
 
     def _calculate_finalization_batches(self, share_rate: int, available_eth: int, until_timestamp: int) -> list[int]:
         max_length = self.w3.lido_contracts.withdrawal_queue_nft.max_batches_length(self.blockstamp.block_hash)

--- a/src/services/withdrawal.py
+++ b/src/services/withdrawal.py
@@ -11,7 +11,7 @@ from src.web3py.types import Web3
 
 class Withdrawal:
     """
-    Service calculates which withdrawal requests should be finalized using next factors:
+    Service calculates which withdrawal requests should be finalized using the next factors:
 
     1. Safe border epoch for the current reference slot.
     2. The amount of available ETH is determined from the Withdrawal Vault, EL Vault, and buffered ETH.
@@ -66,12 +66,12 @@ class Withdrawal:
         return last_finalized_id < last_requested_id
 
     def _get_available_eth(self, withdrawal_vault_balance: Wei, el_rewards_vault_balance: Wei) -> Wei:
-        buffered_ether = self.w3.lido_contracts.lido.get_buffered_ether(self.blockstamp.block_hash)
+        withdrawals_reserve = self.w3.lido_contracts.lido.get_withdrawals_reserve(self.blockstamp.block_hash)
 
         # This amount of eth could not be spent for deposits.
         unfinalized_steth = self.w3.lido_contracts.withdrawal_queue_nft.unfinalized_steth(self.blockstamp.block_hash)
 
-        reserved_buffer = min(buffered_ether, unfinalized_steth)
+        reserved_buffer = min(withdrawals_reserve, unfinalized_steth)
 
         return Wei(withdrawal_vault_balance + el_rewards_vault_balance + reserved_buffer)
 

--- a/tests/execution/contracts/test_contract_transformations.py
+++ b/tests/execution/contracts/test_contract_transformations.py
@@ -1125,10 +1125,10 @@ class TestHashConsensusContract:
 
 @pytest.mark.unit
 class TestLidoContract:
-    def test_get_buffered_ether(self):
+    def test_get_withdrawals_reserve(self):
         contract = _mock_contract()
-        contract.functions.getBufferedEther.return_value.call.return_value = 1000
-        result = LidoContract.get_buffered_ether(contract, block_identifier="latest")
+        contract.functions.getWithdrawalsReserve.return_value.call.return_value = 1000
+        result = LidoContract.get_withdrawals_reserve(contract, block_identifier="latest")
         assert result == 1000
 
     def test_total_supply(self):

--- a/tests/integration/contracts/test_lido.py
+++ b/tests/integration/contracts/test_lido.py
@@ -10,11 +10,11 @@ def test_lido_contract_call(lido_contract, accounting_oracle_contract, burner_co
     check_contract(
         lido_contract,
         [
-            ('get_buffered_ether', None, lambda response: check_value_type(response, int)),
+            ('get_beacon_stat', None, lambda response: check_value_type(response, BeaconStat)),
             ('total_supply', None, lambda response: check_value_type(response, int)),
             # Uncomment after SRv3 release on mainnet
             # ('get_deposits_reserve', ('latest',), lambda response: check_value_type(response, int)),
-            ('get_beacon_stat', None, lambda response: check_value_type(response, BeaconStat)),
+            # ('get_withdrawals_reserve', ('latest',), lambda response: check_value_type(response, int)),
         ],
         caplog,
     )

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -451,14 +451,14 @@ def test_get_predicted_withdrawable_balance(ejector: Ejector) -> None:
 def test_get_total_balance(ejector: Ejector, blockstamp: BlockStamp) -> None:
     ejector.w3.lido_contracts.get_withdrawal_balance = Mock(return_value=3)
     ejector.w3.lido_contracts.get_el_vault_balance = Mock(return_value=17)
-    ejector.w3.lido_contracts.lido.get_buffered_ether = Mock(return_value=1)
+    ejector.w3.lido_contracts.lido.get_withdrawals_reserve = Mock(return_value=1)
 
     result = ejector._get_total_el_balance(blockstamp)
     assert result == 21, "Unexpected total balance"
 
     ejector.w3.lido_contracts.get_withdrawal_balance.assert_called_once_with(blockstamp)
     ejector.w3.lido_contracts.get_el_vault_balance.assert_called_once_with(blockstamp)
-    ejector.w3.lido_contracts.lido.get_buffered_ether.assert_called_once_with(blockstamp.block_hash)
+    ejector.w3.lido_contracts.lido.get_withdrawals_reserve.assert_called_once_with(blockstamp.block_hash)
 
 
 @pytest.mark.unit
@@ -550,14 +550,14 @@ def test_get_deposit_lock_amount__calculates_frames_ceiling__scales_by_reserve(
     mock_consensus.get_frame_config.return_value = Mock(epochs_per_frame=epochs_per_frame)
     ejector.w3.eth.contract = Mock(return_value=mock_consensus)
 
-    # 0 epochs → ceil(0/10) = 0 frames → 0 locked
+    # 0 epochs → 0 // 10 = 0 frames → 0 locked
     assert ejector._get_deposit_lock_amount(0, ref_blockstamp) == Wei(0)
-    # Exactly one frame (10 epochs) → ceil(10/10) = 1 frame
+    # Exactly one frame (10 epochs) → 10 // 10 = 1 frame
     assert ejector._get_deposit_lock_amount(10, ref_blockstamp) == Wei(reserve_per_frame)
-    # One epoch over one frame → ceil(11/10) = 2 frames
-    assert ejector._get_deposit_lock_amount(11, ref_blockstamp) == Wei(2 * reserve_per_frame)
-    # 2.5 frames → ceil(25/10) = 3 frames
-    assert ejector._get_deposit_lock_amount(25, ref_blockstamp) == Wei(3 * reserve_per_frame)
+    # One epoch over one frame → 11 // 10 = 1 frames
+    assert ejector._get_deposit_lock_amount(11, ref_blockstamp) == Wei(1 * reserve_per_frame)
+    # 2.5 frames → 25 // 10 = 2 frames
+    assert ejector._get_deposit_lock_amount(25, ref_blockstamp) == Wei(2 * reserve_per_frame)
 
 
 class ForcedIterator:

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -554,7 +554,7 @@ def test_get_deposit_lock_amount__calculates_frames_ceiling__scales_by_reserve(
     assert ejector._get_deposit_lock_amount(0, ref_blockstamp) == Wei(0)
     # Exactly one frame (10 epochs) → 10 // 10 = 1 frame
     assert ejector._get_deposit_lock_amount(10, ref_blockstamp) == Wei(reserve_per_frame)
-    # One epoch over one frame → 11 // 10 = 1 frames
+    # One epoch over one frame → 11 // 10 = 1 frame
     assert ejector._get_deposit_lock_amount(11, ref_blockstamp) == Wei(1 * reserve_per_frame)
     # 2.5 frames → 25 // 10 = 2 frames
     assert ejector._get_deposit_lock_amount(25, ref_blockstamp) == Wei(2 * reserve_per_frame)


### PR DESCRIPTION
## Description
Use getWithdrawalsReserve instead of getBufferedEther. getWithdrawalsReserve should already contain eth amount without depsit reserve.

## Related Issue/Task
- Epic: Staking Router V3

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [ ] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
