### PR TITLE
fix: skip pending consolidations with slashed source validator

### DIFF
--- a/src/modules/oracles/accounting/accounting.py
+++ b/src/modules/oracles/accounting/accounting.py
@@ -264,9 +264,7 @@ class Accounting(OracleModule[Web3]):
             sum(pending.amount for _, pendings in lido_pending_balance_by_keys.values() for pending in pendings)
         )
         active_validators = self.w3.lido_validators.get_active_lido_validators(blockstamp)
-        topups_pending = Gwei(
-            sum(topup.amount for v in active_validators for topup in v.pending_topups)
-        )
+        topups_pending = Gwei(sum(topup.amount for v in active_validators for topup in v.pending_topups))
         return Gwei(new_validators_pending + topups_pending)
 
     def _get_newly_exited_validators_by_modules(

--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -344,7 +344,7 @@ class Ejector(OracleModule[Web3]):
         """
         Calculates the amount of ETH locked for depositing for a given epoches_number.
         """
-        reserve_per_frame = self.w3.lido_contracts.lido.get_deposits_reserve(blockstamp.block_hash)
+        reserve_per_frame = self.w3.lido_contracts.lido.get_deposits_reserve_target(blockstamp.block_hash)
 
         consensus_contract = cast(
             HashConsensusContract,
@@ -356,8 +356,7 @@ class Ejector(OracleModule[Web3]):
         )
 
         ao_frame_size = consensus_contract.get_frame_config(blockstamp.block_hash).epochs_per_frame
-
-        # `get_deposits_reserve()` already reflects the reserve locked for the current accounting
+        # `get_withdrawals_reserve` already reflects the reserve locked for the current accounting
         # frame at `blockstamp`. Only additional fully covered accounting frames within
         # `epoches_number` must be added here, so floor-division is intentional. Using ceil
         # would over-count by adding a reserve for a partial / already-accounted frame.

--- a/src/modules/oracles/staking_modules/common/distribution.py
+++ b/src/modules/oracles/staking_modules/common/distribution.py
@@ -345,9 +345,7 @@ class Distribution:
 
         distributed_sum = sum(rewards_distribution.values())
         if distributed_sum > rewards_to_distribute:
-            raise ValueError(
-                f"Invalid distribution: {distributed_sum=} > {rewards_to_distribute=}"
-            )
+            raise ValueError(f"Invalid distribution: {distributed_sum=} > {rewards_to_distribute=}")
 
         return rewards_distribution
 

--- a/src/modules/sidecars/performance/common/db.py
+++ b/src/modules/sidecars/performance/common/db.py
@@ -266,9 +266,9 @@ class DutiesDB:
             raise ValueError("Invalid epoch range")
 
         with self.get_session() as session:
-            present = set(session.exec(
-                select(Duty.epoch).where(Duty.epoch >= from_epoch, Duty.epoch <= to_epoch)
-            ).all())
+            present = set(
+                session.exec(select(Duty.epoch).where(Duty.epoch >= from_epoch, Duty.epoch <= to_epoch)).all()
+            )
 
         return [epoch for epoch in sequence(from_epoch, to_epoch) if epoch not in present]
 

--- a/src/providers/execution/contracts/lido.py
+++ b/src/providers/execution/contracts/lido.py
@@ -73,15 +73,15 @@ class LidoContract(ContractInterface):
         )
         return response
 
-    def get_deposits_reserve(self, block_identifier: BlockIdentifier) -> Wei:
+    def get_deposits_reserve_target(self, block_identifier: BlockIdentifier) -> Wei:
         """
         Returns the amount of ETH reserved for deposits every AO frame.
         """
-        response = self.functions.getDepositsReserve().call(block_identifier=block_identifier)
+        response = self.functions.getDepositsReserveTarget().call(block_identifier=block_identifier)
 
         logger.info(
             {
-                'msg': 'Call `getDepositsReserve()`.',
+                'msg': 'Call `getDepositsReserveTarget()`.',
                 'value': response,
                 'block_identifier': repr(block_identifier),
                 'to': self.address,

--- a/src/providers/execution/contracts/meta_registry.py
+++ b/src/providers/execution/contracts/meta_registry.py
@@ -25,21 +25,21 @@ class ExternalOperator:
 
     def get_gid(self) -> NodeOperatorGlobalIndex:
         """
-        Parse external_operator data attribute (8 bytes):
-        - Byte 0: type
-        - Byte 1: staking module id
-        - Bytes 2-7: node operator id (6 bytes)
+        Parse external_operator data attribute (10 bytes):
+        - Byte 0: OperatorType enum (1 byte)
+        - Byte 1: staking module id (uint8, 1 byte)
+        - Bytes 2-9: node operator id (uint64, 8 bytes)
         """
-        # Ensure we have exactly 8 bytes
-        if len(self.data) != 8:
-            raise ValueError(f"Expected 8 bytes, got {len(self.data)}")
+        # Ensure we have exactly 10 bytes
+        if len(self.data) != 10:
+            raise ValueError(f"Expected 10 bytes, got {len(self.data)}")
 
         # Parse the components
         # type_byte = data_bytes[0]  # Not used in return value
         staking_module_id = StakingModuleId(self.data[1])
 
-        # Node operator id is 6 bytes (bytes 2-7)
-        node_operator_id = NodeOperatorId(int.from_bytes(self.data[2:8], byteorder='big'))
+        # Node operator id is 8 bytes (bytes 2-9)
+        node_operator_id = NodeOperatorId(int.from_bytes(self.data[2:10], byteorder='big'))
 
         return staking_module_id, node_operator_id
 

--- a/src/web3py/extensions/lido_validators.py
+++ b/src/web3py/extensions/lido_validators.py
@@ -197,7 +197,7 @@ class LidoValidatorsProvider(Module):
         for consolidation in self.w3.cc.get_pending_consolidations(blockstamp):
             source_validator = validators_by_index[consolidation.source_index]
 
-            # All consolidation with source validator slashed skipped
+            # Skip consolidations whose source validator is slashed.
             # https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-process_pending_consolidations
             if source_validator.validator.slashed:
                 continue

--- a/src/web3py/extensions/lido_validators.py
+++ b/src/web3py/extensions/lido_validators.py
@@ -197,6 +197,11 @@ class LidoValidatorsProvider(Module):
         for consolidation in self.w3.cc.get_pending_consolidations(blockstamp):
             source_validator = validators_by_index[consolidation.source_index]
 
+            # All consolidation with source validator slashed skipped
+            # https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#new-process_pending_consolidations
+            if source_validator.validator.slashed:
+                continue
+
             req = ConsolidationRequest(
                 source_index=consolidation.source_index,
                 target_index=consolidation.target_index,

--- a/tests/execution/contracts/test_contract_transformations.py
+++ b/tests/execution/contracts/test_contract_transformations.py
@@ -109,16 +109,16 @@ class TestDepositContractGetDepositCount:
 
 
 # ---------------------------------------------------------------------------
-# ExternalOperator.get_gid — 8-byte data parsing across input types
+# ExternalOperator.get_gid — 10-byte data parsing across input types
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.unit
 class TestExternalOperatorGetGid:
-    # data layout: byte[0]=type, byte[1]=staking_module_id, byte[2:8]=node_operator_id
+    # data layout: byte[0]=type, byte[1]=staking_module_id, byte[2:10]=node_operator_id
 
     def _make_data(self, sm_id: int, no_id: int) -> bytes:
-        return bytes([0x01, sm_id]) + no_id.to_bytes(6, "big")
+        return bytes([0x01, sm_id]) + no_id.to_bytes(8, "big")
 
     def test_bytes_input(self):
         data = self._make_data(sm_id=2, no_id=3)
@@ -127,7 +127,7 @@ class TestExternalOperatorGetGid:
         assert no_id == 3
 
     def test_invalid_length_raises(self):
-        with pytest.raises(ValueError, match="Expected 8 bytes"):
+        with pytest.raises(ValueError, match="Expected 10 bytes"):
             ExternalOperator(data=b"\x01\x02").get_gid()
 
     def test_zero_ids(self):

--- a/tests/execution/contracts/test_contract_transformations.py
+++ b/tests/execution/contracts/test_contract_transformations.py
@@ -1145,10 +1145,10 @@ class TestLidoContract:
         assert result.deposited_validators == 100
         assert result.beacon_validators == 90
 
-    def test_get_deposits_reserve(self):
+    def test_get_deposits_reserve_target(self):
         contract = _mock_contract()
-        contract.functions.getDepositsReserve.return_value.call.return_value = 42
-        result = LidoContract.get_deposits_reserve(contract, block_identifier="latest")
+        contract.functions.getDepositsReserveTarget.return_value.call.return_value = 42
+        result = LidoContract.get_deposits_reserve_target(contract, block_identifier="latest")
         assert result == 42
 
 

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -544,7 +544,7 @@ def test_get_deposit_lock_amount__calculates_frames_ceiling__scales_by_reserve(
 ) -> None:
     reserve_per_frame = Wei(10 * GWEI_TO_WEI)
     epochs_per_frame = 10
-    ejector.w3.lido_contracts.lido.get_deposits_reserve = Mock(return_value=reserve_per_frame)
+    ejector.w3.lido_contracts.lido.get_deposits_reserve_target = Mock(return_value=reserve_per_frame)
     ejector.w3.lido_contracts.accounting_oracle.get_consensus_contract = Mock(return_value="0x" + "0" * 40)
     mock_consensus = Mock()
     mock_consensus.get_frame_config.return_value = Mock(epochs_per_frame=epochs_per_frame)

--- a/tests/web3py/test_lido_validators.py
+++ b/tests/web3py/test_lido_validators.py
@@ -427,14 +427,14 @@ def test_get_pending_lido_validators_second_deposit_for_invalid_key_skipped(web3
 
 
 @pytest.mark.unit
-def test_get_active_lido_validators__with_empty_data(web3):
+def test_get_active_lido_validators__with_empty_data__returns_empty_list(web3):
     """
     Test that `get_active_lido_validators` handles empty data inputs correctly.
     """
     blockstamp = ReferenceBlockStampFactory.build()
     web3.lido_validators._get_lido_validators_with_keys = Mock(return_value=([], []))
     web3.cc.get_pending_deposits = Mock(return_value=[])
-    web3.cc.get_pending_consolidations = Mock(return_value={})
+    web3.cc.get_pending_consolidations = Mock(return_value=[])
     web3.cc.get_validators_by_indexes = Mock(return_value={})
 
     active_validators = web3.lido_validators.get_active_lido_validators(blockstamp)

--- a/tests/web3py/test_lido_validators.py
+++ b/tests/web3py/test_lido_validators.py
@@ -424,3 +424,96 @@ def test_get_pending_lido_validators_second_deposit_for_invalid_key_skipped(web3
         result = web3.lido_validators.get_pending_lido_validators(ReferenceBlockStampFactory.build())
 
     assert result == {}
+
+
+@pytest.mark.unit
+def test_get_active_lido_validators__with_empty_data(web3):
+    """
+    Test that `get_active_lido_validators` handles empty data inputs correctly.
+    """
+    blockstamp = ReferenceBlockStampFactory.build()
+    web3.lido_validators._get_lido_validators_with_keys = Mock(return_value=([], []))
+    web3.cc.get_pending_deposits = Mock(return_value=[])
+    web3.cc.get_pending_consolidations = Mock(return_value={})
+    web3.cc.get_validators_by_indexes = Mock(return_value={})
+
+    active_validators = web3.lido_validators.get_active_lido_validators(blockstamp)
+
+    assert active_validators == []
+    web3.cc.get_pending_deposits.assert_called_once_with(blockstamp)
+    web3.cc.get_pending_consolidations.assert_called_once_with(blockstamp)
+    web3.lido_validators._get_lido_validators_with_keys.assert_called_once_with(blockstamp)
+
+
+@pytest.mark.unit
+def test_get_active_lido_validators__with_valid_data(web3):
+    """
+    Test `get_active_lido_validators` returns correct outputs based on mock data.
+    """
+    blockstamp = ReferenceBlockStampFactory.build()
+    mock_validators = LidoValidatorFactory.batch(5)
+    deposits_map = {mock_validators[0].validator.pubkey: [Mock(amount=1000)]}
+
+    web3.lido_validators._get_lido_validators_with_keys = Mock(return_value=(mock_validators, []))
+    web3.cc.get_pending_deposits = Mock(return_value=[Mock(pubkey=mock_validators[0].validator.pubkey, amount=1000)])
+    web3.cc.get_validators_by_indexes = Mock(return_value={v.index: v for v in mock_validators})
+    web3.cc.get_pending_consolidations = Mock(return_value=[])
+
+    active_validators = web3.lido_validators.get_active_lido_validators(blockstamp)
+
+    assert len(active_validators) == len(mock_validators)
+    assert sum(len(v.pending_topups) for v in active_validators) == 1
+    assert active_validators[0].pending_topups[0].amount == deposits_map[mock_validators[0].validator.pubkey][0].amount
+
+
+@pytest.mark.unit
+def test_get_active_lido_validators__with_slashed_sources(web3):
+    """
+    Test that consolidation requests whose source validator is slashed are skipped.
+    Both validators are still returned — only the consolidation record is dropped.
+    """
+    blockstamp = ReferenceBlockStampFactory.build()
+    validator1, validator2 = LidoValidatorFactory.batch(2)
+    validator1.validator.slashed = False
+    validator2.validator.slashed = True  # source is slashed → consolidation should be skipped
+    mock_validators = [validator1, validator2]
+
+    web3.lido_validators._get_lido_validators_with_keys = Mock(return_value=(mock_validators, []))
+    web3.cc.get_pending_deposits = Mock(return_value=[])
+    web3.cc.get_validators_by_indexes = Mock(return_value={v.index: v for v in mock_validators})
+    web3.cc.get_pending_consolidations = Mock(return_value=[Mock(source_index=validator2.index)])
+
+    active_validators = web3.lido_validators.get_active_lido_validators(blockstamp)
+
+    # All validators are returned regardless of slashed status
+    assert len(active_validators) == 2
+    # The consolidation from the slashed source must not be recorded
+    v2_result = next(v for v in active_validators if v.index == validator2.index)
+    assert v2_result.consolidating_as_source is None
+
+
+@pytest.mark.unit
+def test_get_active_lido_validators__handles_multiple_consolidations(web3):
+    """
+    Test `get_active_lido_validators` handles multiple consolidations correctly.
+    """
+    blockstamp = ReferenceBlockStampFactory.build()
+    mock_validators = LidoValidatorFactory.batch(3)
+    # Ensure source validators are not slashed so consolidations are processed
+    for v in mock_validators:
+        v.validator.slashed = False
+    consolidation_data = [
+        Mock(source_index=mock_validators[0].index, target_index=mock_validators[1].index),
+        Mock(source_index=mock_validators[2].index, target_index=mock_validators[1].index),
+    ]
+
+    web3.lido_validators._get_lido_validators_with_keys = Mock(return_value=(mock_validators, []))
+    web3.cc.get_pending_deposits = Mock(return_value=[])
+    web3.cc.get_validators_by_indexes = Mock(return_value={v.index: v for v in mock_validators})
+    web3.cc.get_pending_consolidations = Mock(return_value=consolidation_data)
+
+    active_validators = web3.lido_validators.get_active_lido_validators(blockstamp)
+
+    assert len(active_validators) == len(mock_validators)
+    assert active_validators[0].consolidating_as_source is not None
+    assert len(active_validators[1].consolidating_as_target) == 2


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on refactoring contract method names for clarity, updating related logic and tests, and improving robustness in validator handling. The most significant changes include renaming the Lido contract method for deposit reserve, updating all usages and tests accordingly, and enhancing the logic for handling slashed validators in consolidation requests.

### Lido contract method refactoring

* Renamed `get_deposits_reserve` to `get_deposits_reserve_target` in the `LidoContract` class, updating its implementation to call the correct contract method and adjusting logging accordingly.

### Validator handling improvements

* Modified `get_active_lido_validators` to skip consolidation requests where the source validator has been slashed, following consensus specs for correct protocol behavior.


Issues:
1. `get_predictable_full_balance `function you include any incoming consolidations (pending_consolidations) but the validator can be slashed before it and cancel the consolidation.
https://github.com/lidofinance/lido-oracle/blob/a857bc2ba781dc915fcd41436fe59633b0850dec/src/utils/validator_balance.py#L6-L18

2. In _get_deposit_lock_amount function (https://github.com/lidofinance/lido-oracle/blob/a857bc2ba781dc915fcd41436fe59633b0850dec/src/modules/oracles/ejector/ejector.py#L347-L347) you use get_deposits_reserve on-chain function to get the reserve for the current frame. However, you multiply the same value by the number of future frames which is incorrect because it can be smaller - you should use getDepositsReserveTarget for future frames.
