### PR TITLE
Feature/add chain id to telemetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lido-oracle"
-version = "7.1.0"
+version = "8.0.0"
 description = "Oracle daemon for the Lido decentralized staking protocol. It collects consensus-layer data — including the number of active validators and their aggregated balances — and securely reports this information to the Lido dApp smart contracts operating on the execution layer."
 authors = [
     "Dmitry Chernukhin",

--- a/src/web3py/extensions/telemetry_data_bus.py
+++ b/src/web3py/extensions/telemetry_data_bus.py
@@ -37,6 +37,7 @@ class TelemetryDataBus(Module):
         self._data_bus_w3 = None
         self._contract = None
         self._module_name = module_name
+        self._chain_id = w3.eth.chain_id
 
         if not data_bus_rpc or not data_bus_address:
             logger.warning({'msg': 'DataBus telemetry is not configured. Skipping initialization.'})
@@ -101,6 +102,7 @@ class TelemetryDataBus(Module):
             return
 
         message: dict = {
+            'chain_id': self._chain_id,
             'version': get_oracle_version(),
             'module': self._module_name,
         }

--- a/tests/fork/test_staking_module_oracle_cycle.py
+++ b/tests/fork/test_staking_module_oracle_cycle.py
@@ -64,7 +64,7 @@ def performance_local_db(testrun_path):
         self._setup_database()
 
     table = Duty.__table__
-    for col_name in ("attestations", "proposals_vids", "proposals_flags", "syncs_vids", "syncs_misses"):
+    for col_name in ("missed_attestation_vids", "proposals_vids", "proposals_flags", "syncs_vids", "syncs_misses"):
         if col_name in table.c:
             table.c[col_name].type = JSON()
 

--- a/tests/fork/test_telemetry_data_bus.py
+++ b/tests/fork/test_telemetry_data_bus.py
@@ -59,6 +59,7 @@ class TestTelemetryDataBusFork:
         (payload_bytes,) = decode(['bytes'], bytes(log['data']))
         payload = json.loads(payload_bytes.decode('utf-8'))
 
+        assert payload['chain_id'] == forked_el_client.eth.chain_id
         assert payload['module'] == 'accounting'
         assert payload['version'] == get_oracle_version()
         assert payload['data']['report_hash'] == '0x' + report_hash.hex()

--- a/tests/web3py/test_telemetry_data_bus.py
+++ b/tests/web3py/test_telemetry_data_bus.py
@@ -1,9 +1,11 @@
+import json
 from unittest.mock import Mock, patch
 
 import pytest
 
 from src import variables
 from src.metrics.prometheus.basic import TELEMETRY_ACCOUNT_BALANCE
+from src.utils.version import get_oracle_version
 from src.web3py.extensions.telemetry_data_bus import TelemetryDataBus, TelemetryEventId
 
 
@@ -69,6 +71,11 @@ class TestTelemetryDataBus:
         module.send_telemetry(TelemetryEventId.ORACLE_REPORT, data)
 
         mock_contract.send_message.assert_called_once()
+        payload = json.loads(mock_contract.send_message.call_args[0][1])
+        assert payload['chain_id'] == web3.eth.chain_id
+        assert payload['version'] == get_oracle_version()
+        assert payload['module'] == 'accounting'
+        assert payload['data'] == data
         mock_build_params.assert_called_once()
         mock_sign_and_send.assert_called_once()
         assert 'DataBus telemetry sent.' in caplog.text


### PR DESCRIPTION
## Description
This pull request updates the telemetry reporting for the Lido Oracle to include the `chain_id` in all telemetry messages, ensuring that messages can be accurately attributed to the correct blockchain network. It also bumps the package version to `8.0.0` and updates related tests to verify the new telemetry payload structure.

## Related Issue/Task
- Related task: n/a
- Epic: srv3

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [ ] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
