### PR TITLE
fix: add force limit withdrawal

### DIFF
--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -164,10 +164,6 @@ class Ejector(OracleModule[Web3]):
         # Get all balance available to use to fulfill on closes exit epoch
         predictable_el_balance = self._get_predicted_el_balance(Gwei(0), blockstamp)
 
-        if to_withdraw_amount <= predictable_el_balance:
-            logger.info({'msg': 'Predicted EL balance is enough to fulfill withdrawal queue.'})
-            return []
-
         validators_to_eject: list[tuple[NodeOperatorGlobalIndex, LidoValidator]] = []
         total_balance_to_eject_gwei = Gwei(0)
         validators_iterator = iter(
@@ -178,17 +174,20 @@ class Ejector(OracleModule[Web3]):
             )
         )
 
-        for gid, next_validator in validators_iterator:
-            validators_to_eject.append((gid, next_validator))
+        if to_withdraw_amount > predictable_el_balance:
+            for gid, next_validator in validators_iterator:
+                validators_to_eject.append((gid, next_validator))
 
-            val_balance = get_predictable_balance(next_validator)
+                val_balance = get_predictable_balance(next_validator)
 
-            total_balance_to_eject_gwei += val_balance
+                total_balance_to_eject_gwei += val_balance
 
-            predictable_el_balance = self._get_predicted_el_balance(total_balance_to_eject_gwei, blockstamp)
+                predictable_el_balance = self._get_predicted_el_balance(total_balance_to_eject_gwei, blockstamp)
 
-            if predictable_el_balance + gwei_to_wei(total_balance_to_eject_gwei) > to_withdraw_amount:
-                break
+                if predictable_el_balance + gwei_to_wei(total_balance_to_eject_gwei) > to_withdraw_amount:
+                    break
+        else:
+            logger.info({'msg': 'Predicted EL balance is enough to fulfill withdrawal queue.'})
 
         forced_validators = validators_iterator.get_remaining_forced_validators()
         if forced_validators:

--- a/tests/fork/test_delegation.py
+++ b/tests/fork/test_delegation.py
@@ -74,7 +74,7 @@ def hash_consensus_with_delegation_member(web3_with_delegation, delegation_addre
     hash_consensus.functions.grantRole(manage_role, consensus_admin).transact({'from': consensus_admin})
 
     current_quorum = hash_consensus.functions.getQuorum().call()
-    hash_consensus.functions.addMember(delegation_address, current_quorum).transact({'from': consensus_admin})
+    hash_consensus.functions.addMember(delegation_address, current_quorum + 1).transact({'from': consensus_admin})
 
     # Warp time past one frame + fast lane to guarantee a fresh frame outside the fast-lane window
     frame_config = hash_consensus.functions.getFrameConfig().call()

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -612,6 +612,41 @@ def test_get_validators_to_eject__forced_validators_present__included_in_result(
 
 
 @pytest.mark.unit
+def test_get_validators_to_eject__forced_validators_present__included_without_wr_pressure(
+    ejector: Ejector,
+    ref_blockstamp: ReferenceBlockStamp,
+    chain_config: ChainConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ejector.get_chain_config = Mock(return_value=chain_config)
+    ejector.w3.lido_contracts.withdrawal_queue_nft.unfinalized_steth = Mock(return_value=Wei(0))
+    ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(0))
+    ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
+    ejector._get_total_el_balance = Mock(return_value=Wei(0))
+    ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
+    ejector._get_withdrawable_lido_validators_balance = Mock(return_value=Wei(0))
+    ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
+    ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
+
+    forced_gid = (StakingModuleId(1), NodeOperatorId(1))
+    forced_validator = build_extended_validator()
+    forced_iter = ForcedIterator([(forced_gid, forced_validator)])
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            ejector_module.ValidatorExitIterator,
+            "__iter__",
+            Mock(return_value=forced_iter),
+        )
+
+        result = ejector.get_validators_to_eject(ref_blockstamp)
+
+    assert len(result) == 1, "Forced validator should be included when withdrawal queue pressure is absent"
+    assert result[0][0] == forced_gid
+    assert result[0][1].index == forced_validator.index
+
+
+@pytest.mark.unit
 def test_get_withdrawable_lido_validators_balance__consolidating_as_source__excluded(
     ejector: Ejector,
     ref_blockstamp: ReferenceBlockStamp,


### PR DESCRIPTION
## Description

This pull request updates the logic for selecting validators to eject and adds a new unit test to improve coverage of forced validator ejection scenarios. The main changes clarify when validators should be ejected, ensuring forced validators are always included even if there is no withdrawal queue pressure.

Added a new unit test `test_get_validators_to_eject__forced_validators_present__included_without_wr_pressure` in `test_ejector.py` to verify that forced validators are included in the result even when there is no withdrawal queue pressure.

## Related Issue/Task
- Related task: n/a
- Epic: srv3

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [x] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
