### PR TITLE
feat(orc-686): add names checking not only types

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -76,3 +76,5 @@ SECONDS_IN_YEAR = int(365.25 * 24 * 60 * 60)
 # Module types
 CURATED_V1_TYPE = b'curated-onchain-v1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 CURATED_V2_TYPE = b'curated-onchain-v2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+CURATED_MODULE_NAME = 'Curated'
+CURATED_V2_MODULE_NAME = 'curated-onchain-v1'

--- a/src/constants.py
+++ b/src/constants.py
@@ -74,7 +74,8 @@ STAKING_MODULE_LOGS_VERSION = 1
 SECONDS_IN_YEAR = int(365.25 * 24 * 60 * 60)
 
 # Module types and names
+CURATED_V1_MODULE_NAME = 'curated-onchain-v1'
 CURATED_V1_TYPE = b'curated-onchain-v1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+
+CURATED_V2_MODULE_NAME = 'curated-onchain-v2'
 CURATED_V2_TYPE = b'curated-onchain-v2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-CURATED_MODULE_NAME = 'Curated'
-CURATED_V2_MODULE_NAME = 'curated-onchain-v1'

--- a/src/constants.py
+++ b/src/constants.py
@@ -73,7 +73,7 @@ STAKING_MODULE_LOGS_VERSION = 1
 
 SECONDS_IN_YEAR = int(365.25 * 24 * 60 * 60)
 
-# Module types
+# Module types and names
 CURATED_V1_TYPE = b'curated-onchain-v1\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 CURATED_V2_TYPE = b'curated-onchain-v2\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
 CURATED_MODULE_NAME = 'Curated'

--- a/src/services/exit_order_iterator.py
+++ b/src/services/exit_order_iterator.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass
 from typing import cast
 
 from src.constants import (
+    CURATED_MODULE_NAME,
     CURATED_V1_TYPE,
+    CURATED_V2_MODULE_NAME,
     CURATED_V2_TYPE,
     ETH1_ADDRESS_WITHDRAWAL_PREFIX,
     MAX_EFFECTIVE_BALANCE,
@@ -84,15 +86,9 @@ class WeightsNotUpdatedError(Exception):
     """
 
 
-class CuratedModuleNotFoundError(Exception):
+class InvalidCuratedModuleConfigError(Exception):
     """
-    Exception raised when Curated Module v1 and Curated Module v2 not found.
-    """
-
-
-class ModulesWithSameTypeError(Exception):
-    """
-    Exception raised when multiple curated module v1 or v2 found.
+    Exception raised when curated modules cannot be uniquely identified from the current SR config.
     """
 
 
@@ -245,10 +241,8 @@ class ValidatorExitIterator:
         self.cm_v2_id = cm_v2[0]
 
     def _fetch_curated_modules(self) -> tuple[CMv1, CMv2]:
-        cm_v1_id = None
-        cm_v1_contract = None
-        cm_v2_id = None
-        cm_v2_contract = None
+        cm_v1_modules: list[CMv1] = []
+        cm_v2_modules: list[CMv2] = []
 
         for module in self.module_stats.values():
             sm_contract = cast(
@@ -262,29 +256,30 @@ class ValidatorExitIterator:
 
             sm_type = sm_contract.get_type(self.blockstamp.block_hash)
 
-            if sm_type == CURATED_V1_TYPE:
-                if cm_v1_id is not None:
-                    raise ModulesWithSameTypeError(
-                        f'Multiple curated module v1 found: {cm_v1_id} and {module.staking_module.id}'
-                    )
-                cm_v1_id = module.staking_module.id
-                cm_v1_contract = sm_contract
+            if sm_type == CURATED_V1_TYPE and module.staking_module.name == CURATED_MODULE_NAME:
+                cm_v1_modules.append((module.staking_module.id, sm_contract))
 
-            elif sm_type == CURATED_V2_TYPE:
-                if cm_v2_id is not None:
-                    raise ModulesWithSameTypeError(
-                        f'Multiple curated module v2 found: {cm_v2_id} and {module.staking_module.id}'
-                    )
-                cm_v2_id = module.staking_module.id
-                cm_v2_contract = sm_contract
+            elif sm_type == CURATED_V2_TYPE and module.staking_module.name == CURATED_V2_MODULE_NAME:
+                cm_v2_modules.append((module.staking_module.id, sm_contract))
 
-        if not (cm_v1_id and cm_v1_contract and cm_v2_id and cm_v2_contract):
-            msg = f'Curated Module v1 or v2 not found. CMv1 id: {cm_v1_id} | CMV2 id: {cm_v2_id}'
+        errors = []
+        if len(cm_v1_modules) != 1:
+            errors.append(
+                f'expected exactly one curated module named {CURATED_MODULE_NAME}, '
+                f'found ids: {[module_id for module_id, _ in cm_v1_modules]}'
+            )
+        if len(cm_v2_modules) != 1:
+            errors.append(
+                f'expected exactly one curated module v2 named {CURATED_V2_MODULE_NAME}, '
+                f'found ids: {[module_id for module_id, _ in cm_v2_modules]}'
+            )
 
+        if errors:
+            msg = '; '.join(errors)
             logger.error({'msg': msg})
-            raise CuratedModuleNotFoundError(msg)
+            raise InvalidCuratedModuleConfigError(msg)
 
-        return (cm_v1_id, cm_v1_contract), (cm_v2_id, cm_v2_contract)
+        return cm_v1_modules[0], cm_v2_modules[0]
 
     def _setup_weights(self, curated_module: CMv2) -> None:
         staking_module_id, sm_contract = curated_module

--- a/src/services/exit_order_iterator.py
+++ b/src/services/exit_order_iterator.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import cast
 
 from src.constants import (
-    CURATED_MODULE_NAME,
+    CURATED_V1_MODULE_NAME,
     CURATED_V1_TYPE,
     CURATED_V2_MODULE_NAME,
     CURATED_V2_TYPE,
@@ -256,7 +256,7 @@ class ValidatorExitIterator:
 
             sm_type = sm_contract.get_type(self.blockstamp.block_hash)
 
-            if sm_type == CURATED_V1_TYPE and module.staking_module.name == CURATED_MODULE_NAME:
+            if sm_type == CURATED_V1_TYPE and module.staking_module.name == CURATED_V1_MODULE_NAME:
                 cm_v1_modules.append((module.staking_module.id, sm_contract))
 
             elif sm_type == CURATED_V2_TYPE and module.staking_module.name == CURATED_V2_MODULE_NAME:
@@ -265,7 +265,7 @@ class ValidatorExitIterator:
         errors = []
         if len(cm_v1_modules) != 1:
             errors.append(
-                f'expected exactly one curated module named {CURATED_MODULE_NAME}, '
+                f'expected exactly one curated module named {CURATED_V1_MODULE_NAME}, '
                 f'found ids: {[module_id for module_id, _ in cm_v1_modules]}'
             )
         if len(cm_v2_modules) != 1:

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -6,8 +6,7 @@ from src.constants import CURATED_V1_TYPE, CURATED_V2_TYPE, FAR_FUTURE_EPOCH, MI
 from src.modules.common.types import ChainConfig
 from src.providers.execution.contracts.meta_registry import ExternalOperator, OperatorGroup, SubNodeOperator
 from src.services.exit_order_iterator import (
-    CuratedModuleNotFoundError,
-    ModulesWithSameTypeError,
+    InvalidCuratedModuleConfigError,
     NodeOperatorAlreadyGroupedError,
     NodeOperatorExpectedToBeInCMv1Error,
     NodeOperatorStats,
@@ -43,7 +42,7 @@ def iterator(web3):
     return it
 
 
-def make_staking_module(sm_id, threshold=10000):
+def make_staking_module(sm_id, threshold=10000, name="test"):
     return StakingModule(
         id=StakingModuleId(sm_id),
         staking_module_address="0x" + "1" * 40,
@@ -51,7 +50,7 @@ def make_staking_module(sm_id, threshold=10000):
         treasury_fee=0,
         stake_share_limit=0,
         status=0,
-        name="test",
+        name=name,
         last_deposit_at=0,
         last_deposit_block=0,
         exited_validators_count=0,
@@ -645,9 +644,9 @@ class TestNoRemainingForcedPredicate:
 @pytest.mark.unit
 class TestFetchCuratedModules:
     def test_fetch_curated_modules__both_found__returns_tuple(self, iterator):
-        sm1 = make_staking_module(1)
+        sm1 = make_staking_module(1, name="Curated")
         sm1.staking_module_address = "0x" + "a" * 40
-        sm2 = make_staking_module(2)
+        sm2 = make_staking_module(2, name="curated-onchain-v1")
         sm2.staking_module_address = "0x" + "b" * 40
         ms1 = StakingModuleStats(staking_module=sm1)
         ms2 = StakingModuleStats(staking_module=sm2)
@@ -670,7 +669,7 @@ class TestFetchCuratedModules:
         assert cm_v2[0] == sm2.id
 
     def test_fetch_curated_modules__missing_v2__raises_error(self, iterator):
-        sm1 = make_staking_module(1)
+        sm1 = make_staking_module(1, name="Curated")
         ms1 = StakingModuleStats(staking_module=sm1)
         iterator.module_stats = {sm1.id: ms1}
 
@@ -678,7 +677,7 @@ class TestFetchCuratedModules:
         mock_contract.get_type.return_value = CURATED_V1_TYPE
         iterator.w3.eth.contract = Mock(return_value=mock_contract)
 
-        with pytest.raises(CuratedModuleNotFoundError):
+        with pytest.raises(InvalidCuratedModuleConfigError):
             iterator._fetch_curated_modules()
 
     def test_fetch_curated_modules__missing_v1__raises_error(self, iterator):
@@ -690,7 +689,7 @@ class TestFetchCuratedModules:
         mock_contract.get_type.return_value = CURATED_V2_TYPE
         iterator.w3.eth.contract = Mock(return_value=mock_contract)
 
-        with pytest.raises(CuratedModuleNotFoundError):
+        with pytest.raises(InvalidCuratedModuleConfigError):
             iterator._fetch_curated_modules()
 
 
@@ -816,39 +815,88 @@ class TestOperatorGroupIsFulfilled:
 
 
 @pytest.mark.unit
-class TestModulesWithSameTypeError:
-    def test_fetch_curated_modules__duplicate_v1__raises_error(self, iterator):
-        sm1 = make_staking_module(1)
+class TestInvalidCuratedModuleConfigError:
+    def test_fetch_curated_modules__duplicate_curated_name__raises_error(self, iterator):
+        sm1 = make_staking_module(1, name="Curated")
         sm1.staking_module_address = "0x" + "a" * 40
-        sm2 = make_staking_module(2)
+        sm2 = make_staking_module(2, name="Curated")
         sm2.staking_module_address = "0x" + "b" * 40
+        sm3 = make_staking_module(3, name="curated-onchain-v1")
+        sm3.staking_module_address = "0x" + "c" * 40
         iterator.module_stats = {
             sm1.id: StakingModuleStats(staking_module=sm1),
             sm2.id: StakingModuleStats(staking_module=sm2),
+            sm3.id: StakingModuleStats(staking_module=sm3),
         }
 
-        mock_contract = Mock()
-        mock_contract.get_type.return_value = CURATED_V1_TYPE
-        iterator.w3.eth.contract = Mock(return_value=mock_contract)
+        mock_contract_v1 = Mock()
+        mock_contract_v1.get_type.return_value = CURATED_V1_TYPE
+        mock_contract_v2 = Mock()
+        mock_contract_v2.get_type.return_value = CURATED_V2_TYPE
+        contracts_by_addr = {
+            sm1.staking_module_address: mock_contract_v1,
+            sm2.staking_module_address: mock_contract_v1,
+            sm3.staking_module_address: mock_contract_v2,
+        }
+        iterator.w3.eth.contract = Mock(side_effect=lambda **kw: contracts_by_addr[kw['address']])
 
-        with pytest.raises(ModulesWithSameTypeError, match="v1"):
+        with pytest.raises(InvalidCuratedModuleConfigError, match="Curated"):
             iterator._fetch_curated_modules()
 
-    def test_fetch_curated_modules__duplicate_v2__raises_error(self, iterator):
-        sm1 = make_staking_module(1)
+    def test_fetch_curated_modules__simple_dvt_is_ignored_for_v1_selection(self, iterator):
+        sm1 = make_staking_module(1, name="Curated")
         sm1.staking_module_address = "0x" + "a" * 40
-        sm2 = make_staking_module(2)
+        sm2 = make_staking_module(2, name="SimpleDVT")
         sm2.staking_module_address = "0x" + "b" * 40
+        sm3 = make_staking_module(3, name="curated-onchain-v1")
+        sm3.staking_module_address = "0x" + "c" * 40
         iterator.module_stats = {
             sm1.id: StakingModuleStats(staking_module=sm1),
             sm2.id: StakingModuleStats(staking_module=sm2),
+            sm3.id: StakingModuleStats(staking_module=sm3),
         }
 
-        mock_contract = Mock()
-        mock_contract.get_type.return_value = CURATED_V2_TYPE
-        iterator.w3.eth.contract = Mock(return_value=mock_contract)
+        mock_contract_v1 = Mock()
+        mock_contract_v1.get_type.return_value = CURATED_V1_TYPE
+        mock_contract_v2 = Mock()
+        mock_contract_v2.get_type.return_value = CURATED_V2_TYPE
+        contracts_by_addr = {
+            sm1.staking_module_address: mock_contract_v1,
+            sm2.staking_module_address: mock_contract_v1,
+            sm3.staking_module_address: mock_contract_v2,
+        }
+        iterator.w3.eth.contract = Mock(side_effect=lambda **kw: contracts_by_addr[kw['address']])
 
-        with pytest.raises(ModulesWithSameTypeError, match="v2"):
+        cm_v1, cm_v2 = iterator._fetch_curated_modules()
+
+        assert cm_v1[0] == sm1.id
+        assert cm_v2[0] == sm3.id
+
+    def test_fetch_curated_modules__duplicate_v2__raises_error(self, iterator):
+        sm1 = make_staking_module(1, name="Curated")
+        sm1.staking_module_address = "0x" + "a" * 40
+        sm2 = make_staking_module(2, name="curated-onchain-v1")
+        sm2.staking_module_address = "0x" + "b" * 40
+        sm3 = make_staking_module(3, name="curated-onchain-v1")
+        sm3.staking_module_address = "0x" + "c" * 40
+        iterator.module_stats = {
+            sm1.id: StakingModuleStats(staking_module=sm1),
+            sm2.id: StakingModuleStats(staking_module=sm2),
+            sm3.id: StakingModuleStats(staking_module=sm3),
+        }
+
+        mock_contract_v1 = Mock()
+        mock_contract_v1.get_type.return_value = CURATED_V1_TYPE
+        mock_contract_v2 = Mock()
+        mock_contract_v2.get_type.return_value = CURATED_V2_TYPE
+        contracts_by_addr = {
+            sm1.staking_module_address: mock_contract_v1,
+            sm2.staking_module_address: mock_contract_v2,
+            sm3.staking_module_address: mock_contract_v2,
+        }
+        iterator.w3.eth.contract = Mock(side_effect=lambda **kw: contracts_by_addr[kw['address']])
+
+        with pytest.raises(InvalidCuratedModuleConfigError, match="curated module v2"):
             iterator._fetch_curated_modules()
 
 

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from src.constants import (
-    CURATED_MODULE_NAME,
+    CURATED_V1_MODULE_NAME,
     CURATED_V1_TYPE,
     CURATED_V2_MODULE_NAME,
     CURATED_V2_TYPE,
@@ -651,7 +651,7 @@ class TestNoRemainingForcedPredicate:
 @pytest.mark.unit
 class TestFetchCuratedModules:
     def test_fetch_curated_modules__both_found__returns_tuple(self, iterator):
-        sm1 = make_staking_module(1, name=CURATED_MODULE_NAME)
+        sm1 = make_staking_module(1, name=CURATED_V1_MODULE_NAME)
         sm1.staking_module_address = "0x" + "a" * 40
         sm2 = make_staking_module(2, name=CURATED_V2_MODULE_NAME)
         sm2.staking_module_address = "0x" + "b" * 40
@@ -676,7 +676,7 @@ class TestFetchCuratedModules:
         assert cm_v2[0] == sm2.id
 
     def test_fetch_curated_modules__missing_v2__raises_error(self, iterator):
-        sm1 = make_staking_module(1, name=CURATED_MODULE_NAME)
+        sm1 = make_staking_module(1, name=CURATED_V1_MODULE_NAME)
         ms1 = StakingModuleStats(staking_module=sm1)
         iterator.module_stats = {sm1.id: ms1}
 
@@ -824,9 +824,9 @@ class TestOperatorGroupIsFulfilled:
 @pytest.mark.unit
 class TestInvalidCuratedModuleConfigError:
     def test_fetch_curated_modules__duplicate_curated_name__raises_error(self, iterator):
-        sm1 = make_staking_module(1, name=CURATED_MODULE_NAME)
+        sm1 = make_staking_module(1, name=CURATED_V1_MODULE_NAME)
         sm1.staking_module_address = "0x" + "a" * 40
-        sm2 = make_staking_module(2, name=CURATED_MODULE_NAME)
+        sm2 = make_staking_module(2, name=CURATED_V1_MODULE_NAME)
         sm2.staking_module_address = "0x" + "b" * 40
         sm3 = make_staking_module(3, name=CURATED_V2_MODULE_NAME)
         sm3.staking_module_address = "0x" + "c" * 40
@@ -847,11 +847,11 @@ class TestInvalidCuratedModuleConfigError:
         }
         iterator.w3.eth.contract = Mock(side_effect=lambda **kw: contracts_by_addr[kw['address']])
 
-        with pytest.raises(InvalidCuratedModuleConfigError, match="Curated"):
+        with pytest.raises(InvalidCuratedModuleConfigError, match="curated-onchain-v1"):
             iterator._fetch_curated_modules()
 
     def test_fetch_curated_modules__simple_dvt_present__returns_curated_as_v1(self, iterator):
-        sm1 = make_staking_module(1, name=CURATED_MODULE_NAME)
+        sm1 = make_staking_module(1, name=CURATED_V1_MODULE_NAME)
         sm1.staking_module_address = "0x" + "a" * 40
         sm2 = make_staking_module(2, name="SimpleDVT")
         sm2.staking_module_address = "0x" + "b" * 40
@@ -880,7 +880,7 @@ class TestInvalidCuratedModuleConfigError:
         assert cm_v2[0] == sm3.id
 
     def test_fetch_curated_modules__duplicate_v2__raises_error(self, iterator):
-        sm1 = make_staking_module(1, name=CURATED_MODULE_NAME)
+        sm1 = make_staking_module(1, name=CURATED_V1_MODULE_NAME)
         sm1.staking_module_address = "0x" + "a" * 40
         sm2 = make_staking_module(2, name=CURATED_V2_MODULE_NAME)
         sm2.staking_module_address = "0x" + "b" * 40

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -2,7 +2,14 @@ from unittest.mock import Mock
 
 import pytest
 
-from src.constants import CURATED_V1_TYPE, CURATED_V2_TYPE, FAR_FUTURE_EPOCH, MIN_ACTIVATION_BALANCE
+from src.constants import (
+    CURATED_MODULE_NAME,
+    CURATED_V1_TYPE,
+    CURATED_V2_MODULE_NAME,
+    CURATED_V2_TYPE,
+    FAR_FUTURE_EPOCH,
+    MIN_ACTIVATION_BALANCE,
+)
 from src.modules.common.types import ChainConfig
 from src.providers.execution.contracts.meta_registry import ExternalOperator, OperatorGroup, SubNodeOperator
 from src.services.exit_order_iterator import (
@@ -644,9 +651,9 @@ class TestNoRemainingForcedPredicate:
 @pytest.mark.unit
 class TestFetchCuratedModules:
     def test_fetch_curated_modules__both_found__returns_tuple(self, iterator):
-        sm1 = make_staking_module(1, name="Curated")
+        sm1 = make_staking_module(1, name=CURATED_MODULE_NAME)
         sm1.staking_module_address = "0x" + "a" * 40
-        sm2 = make_staking_module(2, name="curated-onchain-v1")
+        sm2 = make_staking_module(2, name=CURATED_V2_MODULE_NAME)
         sm2.staking_module_address = "0x" + "b" * 40
         ms1 = StakingModuleStats(staking_module=sm1)
         ms2 = StakingModuleStats(staking_module=sm2)
@@ -669,7 +676,7 @@ class TestFetchCuratedModules:
         assert cm_v2[0] == sm2.id
 
     def test_fetch_curated_modules__missing_v2__raises_error(self, iterator):
-        sm1 = make_staking_module(1, name="Curated")
+        sm1 = make_staking_module(1, name=CURATED_MODULE_NAME)
         ms1 = StakingModuleStats(staking_module=sm1)
         iterator.module_stats = {sm1.id: ms1}
 
@@ -681,7 +688,7 @@ class TestFetchCuratedModules:
             iterator._fetch_curated_modules()
 
     def test_fetch_curated_modules__missing_v1__raises_error(self, iterator):
-        sm1 = make_staking_module(1)
+        sm1 = make_staking_module(1, name=CURATED_V2_MODULE_NAME)
         ms1 = StakingModuleStats(staking_module=sm1)
         iterator.module_stats = {sm1.id: ms1}
 
@@ -817,11 +824,11 @@ class TestOperatorGroupIsFulfilled:
 @pytest.mark.unit
 class TestInvalidCuratedModuleConfigError:
     def test_fetch_curated_modules__duplicate_curated_name__raises_error(self, iterator):
-        sm1 = make_staking_module(1, name="Curated")
+        sm1 = make_staking_module(1, name=CURATED_MODULE_NAME)
         sm1.staking_module_address = "0x" + "a" * 40
-        sm2 = make_staking_module(2, name="Curated")
+        sm2 = make_staking_module(2, name=CURATED_MODULE_NAME)
         sm2.staking_module_address = "0x" + "b" * 40
-        sm3 = make_staking_module(3, name="curated-onchain-v1")
+        sm3 = make_staking_module(3, name=CURATED_V2_MODULE_NAME)
         sm3.staking_module_address = "0x" + "c" * 40
         iterator.module_stats = {
             sm1.id: StakingModuleStats(staking_module=sm1),
@@ -844,11 +851,11 @@ class TestInvalidCuratedModuleConfigError:
             iterator._fetch_curated_modules()
 
     def test_fetch_curated_modules__simple_dvt_is_ignored_for_v1_selection(self, iterator):
-        sm1 = make_staking_module(1, name="Curated")
+        sm1 = make_staking_module(1, name=CURATED_MODULE_NAME)
         sm1.staking_module_address = "0x" + "a" * 40
         sm2 = make_staking_module(2, name="SimpleDVT")
         sm2.staking_module_address = "0x" + "b" * 40
-        sm3 = make_staking_module(3, name="curated-onchain-v1")
+        sm3 = make_staking_module(3, name=CURATED_V2_MODULE_NAME)
         sm3.staking_module_address = "0x" + "c" * 40
         iterator.module_stats = {
             sm1.id: StakingModuleStats(staking_module=sm1),
@@ -873,11 +880,11 @@ class TestInvalidCuratedModuleConfigError:
         assert cm_v2[0] == sm3.id
 
     def test_fetch_curated_modules__duplicate_v2__raises_error(self, iterator):
-        sm1 = make_staking_module(1, name="Curated")
+        sm1 = make_staking_module(1, name=CURATED_MODULE_NAME)
         sm1.staking_module_address = "0x" + "a" * 40
-        sm2 = make_staking_module(2, name="curated-onchain-v1")
+        sm2 = make_staking_module(2, name=CURATED_V2_MODULE_NAME)
         sm2.staking_module_address = "0x" + "b" * 40
-        sm3 = make_staking_module(3, name="curated-onchain-v1")
+        sm3 = make_staking_module(3, name=CURATED_V2_MODULE_NAME)
         sm3.staking_module_address = "0x" + "c" * 40
         iterator.module_stats = {
             sm1.id: StakingModuleStats(staking_module=sm1),

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -850,7 +850,7 @@ class TestInvalidCuratedModuleConfigError:
         with pytest.raises(InvalidCuratedModuleConfigError, match="Curated"):
             iterator._fetch_curated_modules()
 
-    def test_fetch_curated_modules__simple_dvt_is_ignored_for_v1_selection(self, iterator):
+    def test_fetch_curated_modules__simple_dvt_present__returns_curated_as_v1(self, iterator):
         sm1 = make_staking_module(1, name=CURATED_MODULE_NAME)
         sm1.staking_module_address = "0x" + "a" * 40
         sm2 = make_staking_module(2, name="SimpleDVT")


### PR DESCRIPTION
## Description

Modules types is not unique, sdvt has the same type as cmv1, which leads to errors. So, we added checking by names as well.

## Related Issue/Task
- Related task: orc-686
- Epic: srv3

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [x] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
