### PR TITLE
fix: external validator weight calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Claude Code local settings
 .claude/
+.ai
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/services/exit_order_iterator.py
+++ b/src/services/exit_order_iterator.py
@@ -371,7 +371,7 @@ class ValidatorExitIterator:
 
         for gid in external_gids:
             self.node_operators_stats[gid].total_stake += internal_balance / len(external_gids)
-            self.node_operators_stats[gid].weight += internal_weight / len(external_gids)
+            self.node_operators_stats[gid].weight = internal_weight / len(external_gids)
 
         self.module_stats[cm_v1_id].total_stake += internal_balance
         self.module_stats[cm_v2_id].total_stake += external_balance

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -416,13 +416,11 @@ class TestProcessGroup:
             node_operator=no_ext1,
             module_stats=ms_v1,
             predictable_balance=Gwei(50 * 10**9),
-            weight=1.0,
         )
         nos_ext2 = NodeOperatorStats(
             node_operator=no_ext2,
             module_stats=ms_v1,
             predictable_balance=Gwei(30 * 10**9),
-            weight=2.0,
         )
         iterator.module_stats = {sm_v2.id: ms_v2, sm_v1.id: ms_v1}
         iterator.node_operators_stats = {
@@ -456,8 +454,8 @@ class TestProcessGroup:
         assert nos_ext1.total_stake == Gwei(150 * 10**9)
         assert nos_ext2.total_stake == Gwei(150 * 10**9)
         # internal_weight = 4.0 + 6.0 = 10.0, split equally among 2 externals = 5.0 each
-        assert nos_ext1.weight == 1.0 + 5.0
-        assert nos_ext2.weight == 2.0 + 5.0
+        assert nos_ext1.weight == 5.0
+        assert nos_ext2.weight == 5.0
         # internal_balance added to cm_v1 total_stake
         assert ms_v1.total_stake == Gwei(300 * 10**9)
         # int1 gets external_balance * 4.0/10.0 = 80 * 0.4 = 32


### PR DESCRIPTION
* In `_process_group` in `exit_order_iterator.py`, the assignment for `weight` of external node operators is changed from incrementing (`+=`) to setting (`=`), ensuring each operator's weight is exactly the share of `internal_weight` divided among them.
