### PR TITLE
feat: Support Glamsterdam block structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG SOURCE_DATE_EPOCH
 RUN apt-get update && apt-get install -y --no-install-recommends -qq \
     libffi-dev=3.4.8-2 \
     g++=4:14.2.0-1 \
-    curl=8.14.1-2+deb13u2 \
+    curl=8.14.1-2+deb13u3 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /var/cache/* \

--- a/src/modules/checks/suites/conftest.py
+++ b/src/modules/checks/suites/conftest.py
@@ -10,8 +10,7 @@ from src import variables
 from src.modules.oracles.common.runtime import build_staking_module_web3
 from src.types import BlockRoot, EpochNumber, OracleModuleName, SlotNumber
 from src.utils.api import opsgenie_api
-from src.utils.blockstamp import build_blockstamp
-from src.utils.slot import get_reference_blockstamp
+from src.utils.blockstamp import BlockstampBuilder
 from src.web3py.contract_tweak import tweak_w3_contracts
 from src.web3py.extensions import (
     ConsensusClientModule,
@@ -108,10 +107,8 @@ def blockstamp(web3, finalized_blockstamp, request):
     cc_config = web3.cc.get_config_spec()
     slots_per_frame = epochs_per_frame * cc_config.SLOTS_PER_EPOCH
     last_report_ref_slot = SlotNumber(finalized_blockstamp.slot_number - slots_per_frame)
-
-    return get_reference_blockstamp(
-        web3.cc,
-        last_report_ref_slot,
+    return BlockstampBuilder(web3.cc, web3.eth).get_non_missed_reference_blockstamp(
+        ref_slot=last_report_ref_slot,
         ref_epoch=EpochNumber(last_report_ref_slot // cc_config.SLOTS_PER_EPOCH),
         last_finalized_slot_number=finalized_blockstamp.slot_number,
     )
@@ -121,13 +118,12 @@ def blockstamp(web3, finalized_blockstamp, request):
 def finalized_blockstamp(web3):
     block_root = BlockRoot(web3.cc.get_block_root('finalized').root)
     block_details = web3.cc.get_block_details(block_root)
-    bs = build_blockstamp(block_details)
     cc_config = web3.cc.get_config_spec()
-    return get_reference_blockstamp(
-        web3.cc,
-        bs.slot_number,
-        ref_epoch=EpochNumber(bs.slot_number // cc_config.SLOTS_PER_EPOCH),
-        last_finalized_slot_number=bs.slot_number,
+    block_details_slot_number = block_details.message.slot
+    return BlockstampBuilder(web3.cc, web3.eth).get_non_missed_reference_blockstamp(
+        ref_slot=block_details_slot_number,
+        ref_epoch=EpochNumber(block_details_slot_number // cc_config.SLOTS_PER_EPOCH),
+        last_finalized_slot_number=block_details_slot_number,
     )
 
 

--- a/src/modules/common/daemon_module.py
+++ b/src/modules/common/daemon_module.py
@@ -7,7 +7,6 @@ from dataclasses import asdict
 
 from timeout_decorator import timeout
 
-from providers.consensus.types import BlockDetailsResponse
 from src import variables
 from src.metrics.healthcheck_server import pulse
 from src.metrics.prometheus.basic import (
@@ -18,6 +17,7 @@ from src.metrics.prometheus.basic import (
 )
 from src.modules.common.types import ModuleExecuteDelay
 from src.providers.consensus.client import ConsensusClient
+from src.providers.consensus.types import BlockDetailsResponse
 from src.types import BlockRoot, SlotNumber
 
 

--- a/src/modules/common/daemon_module.py
+++ b/src/modules/common/daemon_module.py
@@ -7,19 +7,18 @@ from dataclasses import asdict
 
 from timeout_decorator import timeout
 
+from providers.consensus.types import BlockDetailsResponse
 from src import variables
 from src.metrics.healthcheck_server import pulse
 from src.metrics.prometheus.basic import (
     CYCLE_COUNT,
     LAST_CYCLE_TIMESTAMP,
-    ORACLE_BLOCK_NUMBER,
     ORACLE_SLOT_NUMBER,
     CycleResult,
 )
 from src.modules.common.types import ModuleExecuteDelay
 from src.providers.consensus.client import ConsensusClient
-from src.types import BlockRoot, BlockStamp, SlotNumber
-from src.utils.blockstamp import build_blockstamp
+from src.types import BlockRoot, SlotNumber
 
 
 logger = logging.getLogger(__name__)
@@ -61,9 +60,9 @@ class DaemonModule(ABC):
         cycle_result = CycleResult.ERROR
         try:
             with self.exception_handler():
-                blockstamp = self._receive_last_finalized_slot()
+                block_details = self._receive_last_finalized_block()
 
-                if blockstamp.slot_number <= self._slot_threshold:
+                if block_details.message.slot <= self._slot_threshold:
                     logger.info(
                         {
                             'msg': 'Skipping the report. Waiting for new finalized slot.',
@@ -73,7 +72,7 @@ class DaemonModule(ABC):
                     cycle_result = CycleResult.SUCCESS
                     return
 
-                self.run_cycle(blockstamp)
+                self.run_cycle(block_details)
                 cycle_result = CycleResult.SUCCESS
         finally:
             CYCLE_COUNT.labels(result=cycle_result.value).inc()
@@ -92,26 +91,24 @@ class DaemonModule(ABC):
         logger.info({'msg': f'Cycle end. Sleeping for {variables.CYCLE_SLEEP_IN_SECONDS} seconds.'})
         time.sleep(variables.CYCLE_SLEEP_IN_SECONDS)
 
-    def _receive_last_finalized_slot(self) -> BlockStamp:
+    def _receive_last_finalized_block(self) -> BlockDetailsResponse:
         """Gets last finalized BlockStamp"""
         block_root = BlockRoot(self.cc.get_block_root('finalized').root)
         block_details = self.cc.get_block_details(block_root)
-        bs = build_blockstamp(block_details)
-        logger.info({'msg': 'Fetch last finalized BlockStamp.', 'value': asdict(bs)})
-        ORACLE_SLOT_NUMBER.labels('finalized').set(bs.slot_number)
-        ORACLE_BLOCK_NUMBER.labels('finalized').set(bs.block_number)
-        return bs
+        logger.info({'msg': 'Fetch last finalized block details.', 'value': asdict(block_details)})
+        ORACLE_SLOT_NUMBER.labels('finalized').set(block_details.message.slot)
+        return block_details
 
-    def run_cycle(self, last_finalized_blockstamp: BlockStamp):
+    def run_cycle(self, last_finalized_block: BlockDetailsResponse):
         """Base logic for daemon module cycle execution"""
-        logger.info({'msg': 'Execute module.', 'value': last_finalized_blockstamp})
-        result = self.execute_module(last_finalized_blockstamp)
+        logger.info({'msg': 'Execute module.', 'value': last_finalized_block})
+        result = self.execute_module(last_finalized_block)
         pulse()
         if result is ModuleExecuteDelay.NEXT_FINALIZED_EPOCH:
-            self._slot_threshold = last_finalized_blockstamp.slot_number
+            self._slot_threshold = last_finalized_block.message.slot
 
     @abstractmethod
-    def execute_module(self, last_finalized_blockstamp: BlockStamp) -> ModuleExecuteDelay:
+    def execute_module(self, last_finalized_block: BlockDetailsResponse) -> ModuleExecuteDelay:
         """Executes module business logic for a given blockstamp"""
 
     @property

--- a/src/modules/oracles/accounting/accounting.py
+++ b/src/modules/oracles/accounting/accounting.py
@@ -6,7 +6,6 @@ from hexbytes import HexBytes
 from web3.exceptions import ContractCustomError
 from web3.types import Wei
 
-from providers.consensus.types import BlockDetailsResponse
 from src import variables
 from src.constants import SHARE_RATE_PRECISION_E27
 from src.metrics.prometheus.accounting import (
@@ -34,6 +33,7 @@ from src.modules.oracles.common.consensus import (
     InitialEpochIsYetToArriveRevert,
 )
 from src.modules.oracles.common.oracle_module import OracleModule
+from src.providers.consensus.types import BlockDetailsResponse
 from src.providers.execution.contracts.accounting_oracle import AccountingOracleContract
 from src.services.bunker import BunkerService
 from src.services.staking_vaults import StakingVaultsService

--- a/src/modules/oracles/accounting/accounting.py
+++ b/src/modules/oracles/accounting/accounting.py
@@ -6,6 +6,7 @@ from hexbytes import HexBytes
 from web3.exceptions import ContractCustomError
 from web3.types import Wei
 
+from providers.consensus.types import BlockDetailsResponse
 from src import variables
 from src.constants import SHARE_RATE_PRECISION_E27
 from src.metrics.prometheus.accounting import (
@@ -87,11 +88,12 @@ class Accounting(OracleModule[Web3]):
     def is_contracts_addresses_changed(self) -> bool:
         return self.w3.lido_contracts.has_contract_address_changed()
 
-    def execute_module(self, last_finalized_blockstamp: BlockStamp) -> ModuleExecuteDelay:
+    def execute_module(self, last_finalized_block: BlockDetailsResponse) -> ModuleExecuteDelay:
         """
         Execute the accounting module's reporting cycle.
         Includes reporting of the main data and the extra data.
         """
+        last_finalized_blockstamp = self._blockstamp_builder.build_blockstamp(last_finalized_block)
         report_blockstamp = self.get_blockstamp_for_report(last_finalized_blockstamp)
 
         if not report_blockstamp or not self._check_compatibility(report_blockstamp):
@@ -329,7 +331,7 @@ class Accounting(OracleModule[Web3]):
         )
         logger.info({'msg': 'Calculate shares rate.', 'value': share_rate})
 
-        withdrawal_service = Withdrawal(self.w3, blockstamp, chain_config, frame_config)
+        withdrawal_service = Withdrawal(self.w3, self._blockstamp_builder, blockstamp, chain_config, frame_config)
         batches = withdrawal_service.get_finalization_batches(
             is_bunker,
             share_rate,

--- a/src/modules/oracles/common/consensus.py
+++ b/src/modules/oracles/common/consensus.py
@@ -38,7 +38,7 @@ from src.utils.cache import global_lru_cache as lru_cache
 from src.utils.web3converter import Web3Converter
 from src.web3py.extensions.telemetry_data_bus import TelemetryEventId
 from src.web3py.types import Web3, Web3Base
-from utils.blockstamp import BlockstampBuilder
+from src.utils.blockstamp import BlockstampBuilder
 
 
 logger = logging.getLogger(__name__)

--- a/src/modules/oracles/common/consensus.py
+++ b/src/modules/oracles/common/consensus.py
@@ -34,12 +34,11 @@ from src.modules.oracles.common.exceptions import (
 from src.providers.execution.contracts.base_oracle import BaseOracleContract
 from src.providers.execution.contracts.hash_consensus import HashConsensusContract
 from src.types import BlockStamp, FrameNumber, ReferenceBlockStamp, SlotNumber
-from src.utils.blockstamp import build_blockstamp
 from src.utils.cache import global_lru_cache as lru_cache
-from src.utils.slot import get_reference_blockstamp
 from src.utils.web3converter import Web3Converter
 from src.web3py.extensions.telemetry_data_bus import TelemetryEventId
 from src.web3py.types import Web3, Web3Base
+from utils.blockstamp import BlockstampBuilder
 
 
 logger = logging.getLogger(__name__)
@@ -70,6 +69,7 @@ class ConsensusModule[W3: Web3Base](ABC):
     def __init__(self, w3: W3, **kwargs):
         super().__init__(**kwargs)
         self.w3 = w3
+        self._blockstamp_builder = BlockstampBuilder(w3.cc, w3.eth)
         self._last_sent_report_hash: HexBytes | None = None
 
         if getattr(self, "report_contract", None) is None:
@@ -252,8 +252,7 @@ class ConsensusModule[W3: Web3Base](ABC):
 
         converter = self._get_web3_converter(last_finalized_blockstamp)
 
-        bs = get_reference_blockstamp(
-            cc=self.w3.cc,
+        bs = self._blockstamp_builder.get_non_missed_reference_blockstamp(
             ref_slot=member_info.current_frame_ref_slot,
             ref_epoch=converter.get_epoch_by_slot(member_info.current_frame_ref_slot),
             last_finalized_slot_number=last_finalized_blockstamp.slot_number,
@@ -479,7 +478,7 @@ class ConsensusModule[W3: Web3Base](ABC):
     def _get_latest_blockstamp(self) -> BlockStamp:
         root = self.w3.cc.get_block_root('head').root
         block_details = self.w3.cc.get_block_details(root)
-        bs = build_blockstamp(block_details)
+        bs = self._blockstamp_builder.build_blockstamp(block_details)
         logger.debug({'msg': 'Fetch latest blockstamp.', 'value': bs})
         ORACLE_SLOT_NUMBER.labels('head').set(bs.slot_number)
         ORACLE_BLOCK_NUMBER.labels('head').set(bs.block_number)

--- a/src/modules/oracles/common/consensus.py
+++ b/src/modules/oracles/common/consensus.py
@@ -34,11 +34,11 @@ from src.modules.oracles.common.exceptions import (
 from src.providers.execution.contracts.base_oracle import BaseOracleContract
 from src.providers.execution.contracts.hash_consensus import HashConsensusContract
 from src.types import BlockStamp, FrameNumber, ReferenceBlockStamp, SlotNumber
+from src.utils.blockstamp import BlockstampBuilder
 from src.utils.cache import global_lru_cache as lru_cache
 from src.utils.web3converter import Web3Converter
 from src.web3py.extensions.telemetry_data_bus import TelemetryEventId
 from src.web3py.types import Web3, Web3Base
-from src.utils.blockstamp import BlockstampBuilder
 
 
 logger = logging.getLogger(__name__)

--- a/src/modules/oracles/common/oracle_module.py
+++ b/src/modules/oracles/common/oracle_module.py
@@ -10,7 +10,6 @@ from timeout_decorator import TimeoutError as DecoratorTimeoutError
 from web3.exceptions import Web3Exception
 from web3_multi_provider import NoActiveProviderError
 
-from providers.consensus.types import BlockDetailsResponse
 from src.modules.common.daemon_module import DaemonModule
 from src.modules.oracles.common.consensus import ConsensusModule
 from src.modules.oracles.common.exceptions import (
@@ -19,6 +18,7 @@ from src.modules.oracles.common.exceptions import (
     IsNotMemberException,
 )
 from src.providers.consensus.client import ConsensusClient
+from src.providers.consensus.types import BlockDetailsResponse
 from src.providers.http_provider import NotOkResponse
 from src.providers.ipfs import IPFSError
 from src.providers.keys.client import KAPIInconsistentData, KeysOutdatedException

--- a/src/modules/oracles/common/oracle_module.py
+++ b/src/modules/oracles/common/oracle_module.py
@@ -10,6 +10,7 @@ from timeout_decorator import TimeoutError as DecoratorTimeoutError
 from web3.exceptions import Web3Exception
 from web3_multi_provider import NoActiveProviderError
 
+from providers.consensus.types import BlockDetailsResponse
 from src.modules.common.daemon_module import DaemonModule
 from src.modules.oracles.common.consensus import ConsensusModule
 from src.modules.oracles.common.exceptions import (
@@ -21,7 +22,6 @@ from src.providers.consensus.client import ConsensusClient
 from src.providers.http_provider import NotOkResponse
 from src.providers.ipfs import IPFSError
 from src.providers.keys.client import KAPIInconsistentData, KeysOutdatedException
-from src.types import BlockStamp
 from src.utils.cache import clear_global_cache
 from src.utils.slot import InconsistentData, NoSlotsAvailable, SlotNotFinalized
 from src.web3py.extensions.lido_validators import CountOfKeysDiffersException
@@ -51,10 +51,10 @@ class OracleModule[W3: Web3Base](DaemonModule, ConsensusModule[W3], ABC):
         """Consensus client from w3"""
         return self.w3.cc
 
-    def run_cycle(self, last_finalized_blockstamp: BlockStamp):
+    def run_cycle(self, last_finalized_block: BlockDetailsResponse):
         """Override to add Oracle-specific logic before execution"""
         self.refresh_contracts_if_address_change()
-        super().run_cycle(last_finalized_blockstamp)
+        super().run_cycle(last_finalized_block)
 
     @contextmanager
     def exception_handler(self) -> Iterator[None]:  # noqa: C901

--- a/src/modules/oracles/staking_modules/base.py
+++ b/src/modules/oracles/staking_modules/base.py
@@ -9,7 +9,6 @@ from itertools import batched
 from eth_typing import HexAddress
 from hexbytes import HexBytes
 
-from providers.consensus.types import BlockDetailsResponse
 from src import variables
 from src.constants import UINT64_MAX
 from src.metrics.prometheus.business import CONTRACT_ON_PAUSE
@@ -28,6 +27,7 @@ from src.modules.oracles.staking_modules.common.log import Logs
 from src.modules.oracles.staking_modules.common.state import DutyAccumulator, State
 from src.modules.oracles.staking_modules.common.tree import RewardsTree, StrikesTree, Tree
 from src.modules.oracles.staking_modules.common.types import ReportData, RewardsShares, StrikesList, StrikesValidator
+from src.providers.consensus.types import BlockDetailsResponse
 from src.providers.execution.contracts.cs_fee_oracle import CSFeeOracleContract
 from src.providers.execution.exceptions import InconsistentData
 from src.providers.ipfs import CID

--- a/src/modules/oracles/staking_modules/base.py
+++ b/src/modules/oracles/staking_modules/base.py
@@ -9,6 +9,7 @@ from itertools import batched
 from eth_typing import HexAddress
 from hexbytes import HexBytes
 
+from providers.consensus.types import BlockDetailsResponse
 from src import variables
 from src.constants import UINT64_MAX
 from src.metrics.prometheus.business import CONTRACT_ON_PAUSE
@@ -118,7 +119,8 @@ class SMPerformanceOracle(OracleModule[Web3StakingModule]):
     def is_contracts_addresses_changed(self) -> bool:
         return self.w3.staking_module.has_contract_address_changed()
 
-    def execute_module(self, last_finalized_blockstamp: BlockStamp) -> ModuleExecuteDelay:
+    def execute_module(self, last_finalized_block: BlockDetailsResponse) -> ModuleExecuteDelay:
+        last_finalized_blockstamp = self._blockstamp_builder.build_blockstamp(last_finalized_block)
         if not self._check_compatibility(last_finalized_blockstamp):
             return ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
 
@@ -278,7 +280,8 @@ class SMPerformanceOracle(OracleModule[Web3StakingModule]):
 
     @duration_meter()
     def _fulfill_state(self):  # noqa: C901
-        finalized_blockstamp = self._receive_last_finalized_slot()
+        finalized_block = self._receive_last_finalized_block()
+        finalized_blockstamp = self._blockstamp_builder.build_blockstamp(finalized_block)
         validators = self.w3.cc.get_validators(finalized_blockstamp)
 
         batch_size = variables.PERFORMANCE_COLLECTOR_EPOCHS_BATCH_SIZE

--- a/src/modules/oracles/staking_modules/common/distribution.py
+++ b/src/modules/oracles/staking_modules/common/distribution.py
@@ -28,7 +28,7 @@ from src.types import (
     StakingModuleAddress,
     ValidatorIndex,
 )
-from src.utils.slot import get_reference_blockstamp
+from src.utils.blockstamp import BlockstampBuilder
 from src.utils.web3converter import Web3Converter
 from src.web3py.extensions.lido_validators import LidoValidator
 from src.web3py.types import Web3StakingModule
@@ -60,6 +60,7 @@ class Distribution:
 
     def __init__(self, w3: Web3StakingModule, converter: Web3Converter, state: State):
         self.w3 = w3
+        self._blockstamp_builder = BlockstampBuilder(w3.cc, w3.eth)
         self.converter = converter
         self.state = state
 
@@ -123,8 +124,7 @@ class Distribution:
     def _get_ref_blockstamp_for_frame(
         self, blockstamp: ReferenceBlockStamp, frame_ref_epoch: EpochNumber
     ) -> ReferenceBlockStamp:
-        return get_reference_blockstamp(
-            cc=self.w3.cc,
+        return self._blockstamp_builder.get_non_missed_reference_blockstamp(
             ref_slot=self.converter.get_epoch_last_slot(frame_ref_epoch),
             ref_epoch=frame_ref_epoch,
             last_finalized_slot_number=blockstamp.slot_number,

--- a/src/modules/sidecars/performance/collector/checkpoint.py
+++ b/src/modules/sidecars/performance/collector/checkpoint.py
@@ -21,9 +21,8 @@ from src.modules.common.types import ZERO_HASH
 from src.modules.sidecars.performance.common.db import DutiesDB
 from src.modules.sidecars.performance.common.types import AttDutyMisses, ProposalDuty, SyncDuty
 from src.providers.consensus.client import ConsensusClient
-from src.providers.consensus.types import BlockAttestation, SyncAggregate, SyncCommittee
-from src.types import BlockRoot, BlockStamp, CommitteeIndex, EpochNumber, SlotNumber, ValidatorIndex
-from src.utils.blockstamp import build_blockstamp
+from src.providers.consensus.types import BlockAttestation, BlockDetailsResponse, SyncAggregate, SyncCommittee
+from src.types import BlockRoot, CommitteeIndex, EpochNumber, SlotNumber, ValidatorIndex
 from src.utils.range import sequence
 from src.utils.slot import get_prev_non_missed_slot
 from src.utils.timeit import timeit
@@ -120,19 +119,18 @@ class FrameCheckpointProcessor:
     converter: ChainConverter
 
     db: DutiesDB
-    finalized_blockstamp: BlockStamp
 
     def __init__(
         self,
         cc: ConsensusClient,
         db: DutiesDB,
         converter: ChainConverter,
-        finalized_blockstamp: BlockStamp,
+        last_finalized_block: BlockDetailsResponse,
     ):
         self.cc = cc
         self.converter = converter
         self.db = db
-        self.finalized_blockstamp = finalized_blockstamp
+        self.last_finalized_block = last_finalized_block
         self._metrics_lock = Lock()
         self._last_metrics_refresh = 0.0
 
@@ -329,7 +327,9 @@ class FrameCheckpointProcessor:
     def _prepare_attestation_duties(self, epoch: EpochNumber) -> tuple[AttestationCommittees, AttDutyMisses]:
         committees: AttestationCommittees = {}
         att_misses: AttDutyMisses = set()
-        for committee in self.cc.get_attestation_committees(self.finalized_blockstamp, epoch):
+        for committee in self.cc.get_attestation_committees(
+            (self.last_finalized_block.message.state_root, self.last_finalized_block.message.slot), epoch
+        ):
             committees[(committee.slot, committee.index)] = committee.validators
             att_misses.update(committee.validators)
         return committees, att_misses
@@ -372,12 +372,10 @@ class FrameCheckpointProcessor:
         from_epoch = EpochNumber(epoch - epoch % EPOCHS_PER_SYNC_COMMITTEE_PERIOD)
         to_epoch = EpochNumber(from_epoch + EPOCHS_PER_SYNC_COMMITTEE_PERIOD - 1)
         logger.info({"msg": f"Preparing cached Sync Committee for [{from_epoch};{to_epoch}] chain epochs"})
-        state_blockstamp = build_blockstamp(
-            get_prev_non_missed_slot(
-                self.cc, self.converter.get_epoch_first_slot(epoch), self.finalized_blockstamp.slot_number
-            )
+        state_slot = get_prev_non_missed_slot(
+            self.cc, self.converter.get_epoch_first_slot(epoch), self.last_finalized_block.message.slot
         )
-        sync_committee = self.cc.get_sync_committee(state_blockstamp, epoch)
+        sync_committee = self.cc.get_sync_committee((state_slot.message.state_root, state_slot.message.slot), epoch)
         SYNC_COMMITTEES_CACHE[sync_committee_period] = sync_committee
         return sync_committee
 
@@ -417,7 +415,7 @@ class FrameCheckpointProcessor:
                 dependent_slot = SlotNumber(int(dependent_slot - 1))
         except SlotOutOfRootsRange:
             dependent_non_missed_slot = get_prev_non_missed_slot(
-                self.cc, dependent_slot, self.finalized_blockstamp.slot_number
+                self.cc, dependent_slot, self.last_finalized_block.message.slot
             ).message.slot
             dependent_root = self.cc.get_block_root(dependent_non_missed_slot).root
             logger.debug(

--- a/src/modules/sidecars/performance/collector/collector.py
+++ b/src/modules/sidecars/performance/collector/collector.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from timeout_decorator import TimeoutError as DecoratorTimeoutError
 
-from providers.consensus.types import BlockDetailsResponse
 from src import variables
 from src.metrics.prometheus.performance_collector import (
     PERFORMANCE_COLLECTOR_DB_DEMAND_COUNT,
@@ -21,6 +20,7 @@ from src.modules.sidecars.performance.collector.checkpoint import (
 )
 from src.modules.sidecars.performance.common.db import DutiesDB
 from src.providers.consensus.client import ConsensusClient
+from src.providers.consensus.types import BlockDetailsResponse
 from src.providers.http_provider import NotOkResponse
 from src.types import EpochNumber
 from src.utils.slot import InconsistentData, NoSlotsAvailable, SlotNotFinalized

--- a/src/modules/sidecars/performance/collector/collector.py
+++ b/src/modules/sidecars/performance/collector/collector.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from timeout_decorator import TimeoutError as DecoratorTimeoutError
 
+from providers.consensus.types import BlockDetailsResponse
 from src import variables
 from src.metrics.prometheus.performance_collector import (
     PERFORMANCE_COLLECTOR_DB_DEMAND_COUNT,
@@ -21,7 +22,7 @@ from src.modules.sidecars.performance.collector.checkpoint import (
 from src.modules.sidecars.performance.common.db import DutiesDB
 from src.providers.consensus.client import ConsensusClient
 from src.providers.http_provider import NotOkResponse
-from src.types import BlockStamp, EpochNumber
+from src.types import EpochNumber
 from src.utils.slot import InconsistentData, NoSlotsAvailable, SlotNotFinalized
 from src.utils.web3converter import ChainConverter
 
@@ -81,14 +82,14 @@ class PerformanceCollector(DaemonModule):
         )
         return ChainConverter(chain_cfg)
 
-    def execute_module(self, last_finalized_blockstamp: BlockStamp) -> ModuleExecuteDelay:
+    def execute_module(self, last_finalized_block: BlockDetailsResponse) -> ModuleExecuteDelay:
         converter = self._build_converter()
 
         # NOTE: Finalized slot is the first slot of justifying epoch, so we need to take the previous. But if the first
         # slot of the justifying epoch is empty, blockstamp.slot_number will point to the slot where the last finalized
         # block was created. As a result, finalized_epoch in this case will be less than the actual number of the last
         # finalized epoch. As a result we can have a delay in frame finalization.
-        finalized_epoch = EpochNumber(converter.get_epoch_by_slot(last_finalized_blockstamp.slot_number) - 1)
+        finalized_epoch = EpochNumber(converter.get_epoch_by_slot(last_finalized_block.message.slot) - 1)
 
         self._update_demand_metrics()
 
@@ -107,7 +108,7 @@ class PerformanceCollector(DaemonModule):
             self.cc,
             self.db,
             converter,
-            last_finalized_blockstamp,
+            last_finalized_block,
         )
 
         checkpoint_count = 0

--- a/src/providers/consensus/client.py
+++ b/src/providers/consensus/client.py
@@ -41,6 +41,8 @@ logger = logging.getLogger(__name__)
 
 LiteralState = Literal['head', 'genesis', 'finalized', 'justified']
 
+type StateRootSlotNumber = tuple[StateRoot, SlotNumber]
+
 
 class ConsensusClientError(NotOkResponse):
     pass
@@ -163,16 +165,21 @@ class ConsensusClient(HTTPProvider):
     @list_of_dataclasses(SlotAttestationCommittee.from_response)
     def get_attestation_committees(
         self,
-        blockstamp: BlockStamp,
+        state_root_slot_number: tuple[StateRoot, SlotNumber] | BlockStamp,
         epoch: EpochNumber | None = None,
         committee_index: int | None = None,
         slot: SlotNumber | None = None,
     ) -> list[SlotAttestationCommittee]:
         """Spec: https://ethereum.github.io/beacon-APIs/#/Beacon/getEpochCommittees"""
+        if isinstance(state_root_slot_number, BlockStamp):
+            state_root = state_root_slot_number.state_root
+            slot_number = state_root_slot_number.slot_number
+        else:
+            state_root, slot_number = state_root_slot_number
         try:
             data, _ = self._get(
                 self.API_GET_ATTESTATION_COMMITTEES,
-                path_params=(blockstamp.state_root,),
+                path_params=(state_root,),
                 query_params={'epoch': epoch, 'index': committee_index, 'slot': slot},
                 force_raise=self.__raise_on_prysm_error,
                 validate_response=data_is_list,
@@ -180,7 +187,7 @@ class ConsensusClient(HTTPProvider):
         except NotOkResponse as error:
             if self.PRYSM_STATE_NOT_FOUND_ERROR in error.text:
                 data = self._get_attestation_committees_with_prysm(
-                    blockstamp,
+                    state_root_slot_number,
                     epoch,
                     committee_index,
                     slot,
@@ -189,12 +196,19 @@ class ConsensusClient(HTTPProvider):
                 raise error
         return cast(list[SlotAttestationCommittee], data)
 
-    def get_sync_committee(self, blockstamp: BlockStamp, epoch: EpochNumber) -> SyncCommittee:
+    def get_sync_committee(
+        self, state_root_slot_number: StateRootSlotNumber | BlockStamp, epoch: EpochNumber
+    ) -> SyncCommittee:
         """Spec: https://ethereum.github.io/beacon-APIs/#/Beacon/getEpochSyncCommittees"""
+        if isinstance(state_root_slot_number, BlockStamp):
+            state_root = state_root_slot_number.state_root
+            slot_number = state_root_slot_number.slot_number
+        else:
+            state_root, slot_number = state_root_slot_number
         try:
             data, _ = self._get(
                 self.API_GET_SYNC_COMMITTEE,
-                path_params=(blockstamp.state_root,),
+                path_params=(state_root,),
                 query_params={'epoch': epoch},
                 force_raise=self.__raise_on_prysm_error,
                 validate_response=data_is_dict,
@@ -202,7 +216,7 @@ class ConsensusClient(HTTPProvider):
         except NotOkResponse as error:
             if self.PRYSM_STATE_NOT_FOUND_ERROR in error.text:
                 data = self._get_sync_committee_with_prysm(
-                    blockstamp,
+                    slot_number,
                     epoch,
                 )
             else:
@@ -241,8 +255,8 @@ class ConsensusClient(HTTPProvider):
         )
         return data
 
-    def get_validators(self, blockstamp: BlockStamp) -> list[Validator]:
-        return self.get_state_view(blockstamp).indexed_validators
+    def get_validators(self, state_root_slot_number: StateRootSlotNumber | BlockStamp) -> list[Validator]:
+        return self.get_state_view(state_root_slot_number).indexed_validators
 
     def get_validators_no_cache(self, blockstamp: BlockStamp) -> list[Validator]:
         return self.get_state_view_no_cache(blockstamp).indexed_validators
@@ -250,26 +264,31 @@ class ConsensusClient(HTTPProvider):
     PRYSM_STATE_NOT_FOUND_ERROR = 'State not found'
 
     @lru_cache(maxsize=1)
-    def get_state_view(self, blockstamp: BlockStamp) -> BeaconStateView:
-        return self.get_state_view_no_cache(blockstamp)
+    def get_state_view(self, state_root_slot_number: StateRootSlotNumber | BlockStamp) -> BeaconStateView:
+        return self.get_state_view_no_cache(state_root_slot_number)
 
-    def get_state_view_no_cache(self, blockstamp: BlockStamp) -> BeaconStateView:
+    def get_state_view_no_cache(self, state_root_slot_number: StateRootSlotNumber | BlockStamp) -> BeaconStateView:
         """Spec: https://ethereum.github.io/beacon-APIs/#/Debug/getStateV2"""
+        if isinstance(state_root_slot_number, BlockStamp):
+            state_root = state_root_slot_number.state_root
+            slot_number = state_root_slot_number.slot_number
+        else:
+            state_root, slot_number = state_root_slot_number
 
         logger.info(
             {
                 'msg': 'Getting state...',
                 'url': self.API_GET_STATE,
-                'slot_number': blockstamp.slot_number,
-                'state_root': blockstamp.state_root,
+                'slot_number': slot_number,
+                'state_root': state_root,
             }
         )
         try:
-            data = self._get_state_by_state_id(blockstamp.state_root)
+            data = self._get_state_by_state_id(state_root)
         except NotOkResponse as error:
             # Avoid Prysm issue with state root - https://github.com/prysmaticlabs/prysm/issues/12053
             if self.PRYSM_STATE_NOT_FOUND_ERROR in error.text:
-                data = self._get_state_by_state_id(blockstamp.slot_number)
+                data = self._get_state_by_state_id(slot_number)
             else:
                 raise
 
@@ -317,16 +336,20 @@ class ConsensusClient(HTTPProvider):
 
     def _get_attestation_committees_with_prysm(
         self,
-        blockstamp: BlockStamp,
+        state_root_slot_number: tuple[StateRoot, SlotNumber] | BlockStamp,
         epoch: EpochNumber | None = None,
         index: int | None = None,
         slot: SlotNumber | None = None,
     ) -> list[dict]:
         # Avoid Prysm issue with state root - https://github.com/prysmaticlabs/prysm/issues/12053
         # Trying to get committees by slot number
+        if isinstance(state_root_slot_number, BlockStamp):
+            slot_number = state_root_slot_number.slot_number
+        else:
+            _, slot_number = state_root_slot_number
         data, _ = self._get(
             self.API_GET_ATTESTATION_COMMITTEES,
-            path_params=(blockstamp.slot_number,),
+            path_params=(slot_number,),
             query_params={'epoch': epoch, 'index': index, 'slot': slot},
             validate_response=data_is_list,
         )
@@ -334,14 +357,14 @@ class ConsensusClient(HTTPProvider):
 
     def _get_sync_committee_with_prysm(
         self,
-        blockstamp: BlockStamp,
+        slot_number: SlotNumber,
         epoch: EpochNumber,
     ) -> list[dict]:
         # Avoid Prysm issue with state root - https://github.com/prysmaticlabs/prysm/issues/12053
         # Trying to get committees by slot number
         data, _ = self._get(
             self.API_GET_SYNC_COMMITTEE,
-            path_params=(blockstamp.slot_number,),
+            path_params=(slot_number,),
             query_params={'epoch': epoch},
             validate_response=data_is_dict,
         )

--- a/src/providers/consensus/types.py
+++ b/src/providers/consensus/types.py
@@ -29,6 +29,7 @@ class BeaconSpecResponse(Nested, FromResponse):
     SLOTS_PER_HISTORICAL_ROOT: int
     SLOT_DURATION_MS: int = 0
     SECONDS_PER_SLOT: int = 0
+    EPBS_FORK_EPOCH: EpochNumber = EpochNumber(2**64 - 1)  # EIP-7732; name TBD per final Gloas spec
 
     class NeitherSlotDurationFieldPresent(Exception):
         pass
@@ -130,6 +131,16 @@ class ExecutionPayload(Nested, FromResponse):
 
 
 @dataclass
+class SignedExecutionPayloadBid(Nested, FromResponse):
+    """EIP-7732: builder's commitment to the EL block for this slot."""
+    block_hash: BlockHash
+    builder_index: ValidatorIndex
+    slot: SlotNumber
+    parent_block_hash: BlockHash
+    bid_value: Gwei
+
+
+@dataclass
 class Checkpoint(Nested):
     epoch: EpochNumber
     root: BlockRoot
@@ -164,9 +175,21 @@ class SyncAggregate(FromResponse):
 
 @dataclass
 class BeaconBlockBody(Nested, FromResponse):
-    execution_payload: ExecutionPayload
     attestations: list[BlockAttestationResponse]
     sync_aggregate: SyncAggregate
+    # EIP-7732: execution_payload is absent post-fork; signed_execution_payload_bid is absent pre-fork
+    execution_payload: ExecutionPayload | None = None
+    signed_execution_payload_bid: SignedExecutionPayloadBid | None = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        # Handle Optional nested types that Nested.__post_init__ can't detect via UnionType
+        if isinstance(self.execution_payload, dict):
+            self.execution_payload = ExecutionPayload.from_response(**self.execution_payload)
+        if isinstance(self.signed_execution_payload_bid, dict):
+            self.signed_execution_payload_bid = SignedExecutionPayloadBid.from_response(
+                **self.signed_execution_payload_bid
+            )
 
 
 @dataclass
@@ -266,6 +289,10 @@ class BeaconStateView(Nested, FromResponse):
     pending_deposits: list[PendingDeposit] = field(default_factory=list)
     pending_partial_withdrawals: list[PendingPartialWithdrawal] = field(default_factory=list)
     pending_consolidations: list[PendingConsolidation] = field(default_factory=list)
+
+    # EIP-7732: hash of the last *revealed* EL block (= slot N-1 when CL is at slot N).
+    # Absent pre-fork, defaults to empty string.
+    latest_block_hash: BlockHash = field(default_factory=lambda: BlockHash(HexStr('')))  # type: ignore[arg-type]
 
     @cached_property
     def indexed_validators(self) -> list[Validator]:

--- a/src/providers/consensus/types.py
+++ b/src/providers/consensus/types.py
@@ -29,7 +29,6 @@ class BeaconSpecResponse(Nested, FromResponse):
     SLOTS_PER_HISTORICAL_ROOT: int
     SLOT_DURATION_MS: int = 0
     SECONDS_PER_SLOT: int = 0
-    EPBS_FORK_EPOCH: EpochNumber = EpochNumber(2**64 - 1)  # EIP-7732; name TBD per final Gloas spec
 
     class NeitherSlotDurationFieldPresent(Exception):
         pass

--- a/src/services/bunker_cases/abnormal_cl_rebase.py
+++ b/src/services/bunker_cases/abnormal_cl_rebase.py
@@ -14,12 +14,12 @@ from src.providers.keys.types import LidoKey
 from src.services.bunker_cases.types import BunkerConfig
 from src.types import BlockNumber, BlockStamp, EpochNumber, Gwei, ReferenceBlockStamp, SlotNumber
 from src.utils.events import get_events_in_range
-from src.utils.slot import get_blockstamp, get_reference_blockstamp
 from src.utils.types import hex_str_to_bytes
 from src.utils.units import wei_to_gwei
 from src.utils.validator_state import calculate_active_effective_balance_sum
 from src.web3py.extensions.lido_validators import LidoValidator, LidoValidatorsProvider
 from src.web3py.types import Web3
+from utils.blockstamp import BlockstampBuilder
 
 
 logger = logging.getLogger(__name__)
@@ -34,6 +34,7 @@ class AbnormalClRebase:
 
     def __init__(self, w3: Web3, c_conf: ChainConfig, b_conf: BunkerConfig):
         self.w3 = w3
+        self._blockstamp_builder = BlockstampBuilder(self.w3.cc, self.w3.eth)
         self.c_conf = c_conf
         self.b_conf = b_conf
 
@@ -150,11 +151,11 @@ class AbnormalClRebase:
 
         AbnormalClRebase.validate_slot_distance(distant_slot, nearest_slot, ref_blockstamp.slot_number)
 
-        nearest_blockstamp = get_blockstamp(
-            self.w3.cc, nearest_slot, last_finalized_slot_number=ref_blockstamp.slot_number
+        nearest_blockstamp = self._blockstamp_builder.get_non_missed_blockstamp(
+            nearest_slot, last_finalized_slot_number=ref_blockstamp.slot_number
         )
-        distant_blockstamp = get_blockstamp(
-            self.w3.cc, distant_slot, last_finalized_slot_number=ref_blockstamp.slot_number
+        distant_blockstamp = self._blockstamp_builder.get_non_missed_blockstamp(
+            distant_slot, last_finalized_slot_number=ref_blockstamp.slot_number
         )
 
         return nearest_blockstamp, distant_blockstamp
@@ -354,8 +355,7 @@ class AbnormalClRebase:
     def _get_last_report_reference_blockstamp(self, ref_blockstamp: ReferenceBlockStamp) -> ReferenceBlockStamp:
         """Get blockstamp of last report"""
         last_report_ref_slot = self.w3.lido_contracts.get_accounting_last_processing_ref_slot(ref_blockstamp)
-        return get_reference_blockstamp(
-            self.w3.cc,
+        return self._blockstamp_builder.get_non_missed_reference_blockstamp(
             last_report_ref_slot,
             ref_epoch=EpochNumber(last_report_ref_slot // self.c_conf.slots_per_epoch),
             last_finalized_slot_number=ref_blockstamp.slot_number,

--- a/src/services/bunker_cases/abnormal_cl_rebase.py
+++ b/src/services/bunker_cases/abnormal_cl_rebase.py
@@ -13,13 +13,13 @@ from src.providers.consensus.types import Validator
 from src.providers.keys.types import LidoKey
 from src.services.bunker_cases.types import BunkerConfig
 from src.types import BlockNumber, BlockStamp, EpochNumber, Gwei, ReferenceBlockStamp, SlotNumber
+from src.utils.blockstamp import BlockstampBuilder
 from src.utils.events import get_events_in_range
 from src.utils.types import hex_str_to_bytes
 from src.utils.units import wei_to_gwei
 from src.utils.validator_state import calculate_active_effective_balance_sum
 from src.web3py.extensions.lido_validators import LidoValidator, LidoValidatorsProvider
 from src.web3py.types import Web3
-from utils.blockstamp import BlockstampBuilder
 
 
 logger = logging.getLogger(__name__)

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -7,10 +7,10 @@ from src.constants import EPOCHS_PER_SLASHINGS_VECTOR, MIN_VALIDATOR_WITHDRAWABI
 from src.metrics.prometheus.duration_meter import duration_meter
 from src.modules.oracles.common.consensus import ChainConfig, FrameConfig
 from src.types import EpochNumber, FrameNumber, ReferenceBlockStamp, SlotNumber
-from src.utils.slot import get_blockstamp
 from src.utils.web3converter import Web3Converter
 from src.web3py.extensions.lido_validators import Validator
 from src.web3py.types import Web3
+from utils.blockstamp import BlockstampBuilder
 
 
 class WrongExitPeriod(Exception):
@@ -36,12 +36,18 @@ class SafeBorder(Web3Converter):
     blockstamp: ReferenceBlockStamp
 
     def __init__(
-        self, w3: Web3, blockstamp: ReferenceBlockStamp, chain_config: ChainConfig, frame_config: FrameConfig
+        self, 
+        w3: Web3,
+        blockstamp_builder: BlockstampBuilder,
+        blockstamp: ReferenceBlockStamp,
+        chain_config: ChainConfig,
+        frame_config: FrameConfig
     ) -> None:
         super().__init__(chain_config, frame_config)
 
         self.w3 = w3
         self.lido_contracts = w3.lido_contracts
+        self._blockstamp_builder = blockstamp_builder
 
         self.blockstamp = blockstamp
 
@@ -243,7 +249,10 @@ class SafeBorder(Web3Converter):
         return self.get_epoch_by_timestamp(last_finalized_request_data.timestamp)
 
     def _get_blockstamp(self, last_slot_in_frame: SlotNumber):
-        return get_blockstamp(self.w3.cc, last_slot_in_frame, self.blockstamp.ref_slot)
+        return self._blockstamp_builder.get_non_missed_blockstamp(
+            last_slot_in_frame,
+            self.blockstamp.ref_slot
+        )
 
     def round_epoch_by_frame(self, epoch: EpochNumber) -> EpochNumber:
         return EpochNumber(

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -7,10 +7,10 @@ from src.constants import EPOCHS_PER_SLASHINGS_VECTOR, MIN_VALIDATOR_WITHDRAWABI
 from src.metrics.prometheus.duration_meter import duration_meter
 from src.modules.oracles.common.consensus import ChainConfig, FrameConfig
 from src.types import EpochNumber, FrameNumber, ReferenceBlockStamp, SlotNumber
+from src.utils.blockstamp import BlockstampBuilder
 from src.utils.web3converter import Web3Converter
 from src.web3py.extensions.lido_validators import Validator
 from src.web3py.types import Web3
-from utils.blockstamp import BlockstampBuilder
 
 
 class WrongExitPeriod(Exception):

--- a/src/services/staking_vaults.py
+++ b/src/services/staking_vaults.py
@@ -50,10 +50,10 @@ from src.providers.ipfs import CID
 from src.types import FrameNumber, Gwei, ReferenceBlockStamp, SlotNumber
 from src.utils.apr import get_steth_by_shares
 from src.utils.block import get_block_timestamps
+from src.utils.blockstamp import BlockstampBuilder
 from src.utils.units import gwei_to_wei
 from src.utils.validator_state import has_far_future_activation_eligibility_epoch
 from src.web3py.types import Web3
-from utils.blockstamp import BlockstampBuilder
 
 
 logger = logging.getLogger(__name__)

--- a/src/services/staking_vaults.py
+++ b/src/services/staking_vaults.py
@@ -50,10 +50,10 @@ from src.providers.ipfs import CID
 from src.types import FrameNumber, Gwei, ReferenceBlockStamp, SlotNumber
 from src.utils.apr import get_steth_by_shares
 from src.utils.block import get_block_timestamps
-from src.utils.slot import get_blockstamp
 from src.utils.units import gwei_to_wei
 from src.utils.validator_state import has_far_future_activation_eligibility_epoch
 from src.web3py.types import Web3
+from utils.blockstamp import BlockstampBuilder
 
 
 logger = logging.getLogger(__name__)
@@ -66,6 +66,7 @@ class StakingVaultsService:
 
     def __init__(self, w3: Web3) -> None:
         self.w3 = w3
+        self._blockstamp_builder = BlockstampBuilder(self.w3.cc, self.w3.eth)
 
     def get_vaults(self, block_identifier: BlockIdentifier = 'latest') -> VaultsMap:
         vaults = self.w3.lido_contracts.lazy_oracle.get_all_vaults(block_identifier=block_identifier)
@@ -825,8 +826,7 @@ class StakingVaultsService:
             ) * chain_config.slots_per_epoch - 1
             from_ref_slot = SlotNumber(max(potential_prev_ref_slot, 0))
 
-        prev_report_block_number = get_blockstamp(
-            cc=self.w3.cc,
+        prev_report_block_number = self._blockstamp_builder.get_non_missed_blockstamp(
             slot=from_ref_slot,
             last_finalized_slot_number=blockstamp.slot_number,
         ).block_number

--- a/src/services/withdrawal.py
+++ b/src/services/withdrawal.py
@@ -7,6 +7,7 @@ from src.services.safe_border import SafeBorder
 from src.types import FinalizationBatches, ReferenceBlockStamp
 from src.variables import FINALIZATION_BATCH_MAX_REQUEST_COUNT
 from src.web3py.types import Web3
+from utils.blockstamp import BlockstampBuilder
 
 
 class Withdrawal:
@@ -20,12 +21,13 @@ class Withdrawal:
     def __init__(
         self,
         w3: Web3,
+        blockstamp_builder: BlockstampBuilder,
         blockstamp: ReferenceBlockStamp,
         chain_config: ChainConfig,
         frame_config: FrameConfig,
     ) -> None:
         self.w3 = w3
-        self.safe_border_service = SafeBorder(self.w3, blockstamp, chain_config, frame_config)
+        self.safe_border_service = SafeBorder(self.w3, blockstamp_builder, blockstamp, chain_config, frame_config)
 
         self.chain_config = chain_config
         self.frame_config = frame_config

--- a/src/services/withdrawal.py
+++ b/src/services/withdrawal.py
@@ -5,9 +5,9 @@ from src.modules.oracles.accounting.types import BatchState
 from src.modules.oracles.common.consensus import ChainConfig, FrameConfig
 from src.services.safe_border import SafeBorder
 from src.types import FinalizationBatches, ReferenceBlockStamp
+from src.utils.blockstamp import BlockstampBuilder
 from src.variables import FINALIZATION_BATCH_MAX_REQUEST_COUNT
 from src.web3py.types import Web3
-from utils.blockstamp import BlockstampBuilder
 
 
 class Withdrawal:

--- a/src/utils/blockstamp.py
+++ b/src/utils/blockstamp.py
@@ -1,34 +1,115 @@
+import logging
+
+from eth_typing import BlockNumber
 from eth_utils.hexadecimal import add_0x_prefix
+from web3.eth import Eth
+from web3.types import Timestamp
 
+from src.providers.consensus.client import ConsensusClient
 from src.providers.consensus.types import BlockDetailsResponse
-from src.types import BlockStamp, EpochNumber, ReferenceBlockStamp, SlotNumber
+from src.types import BlockHash, BlockStamp, EpochNumber, ReferenceBlockStamp, SlotNumber
+from utils.slot import get_prev_non_missed_slot
 
 
-def build_reference_blockstamp(
-    slot_details: BlockDetailsResponse,
-    ref_slot: SlotNumber,
-    ref_epoch: EpochNumber,
-) -> ReferenceBlockStamp:
-    return ReferenceBlockStamp(
-        **_build_blockstamp_data(slot_details),
-        ref_slot=ref_slot,
-        ref_epoch=ref_epoch,
+logger = logging.getLogger(__name__)
+
+
+def build_blockstamp(slot_details: BlockDetailsResponse) -> BlockStamp:
+    """Build blockstamp from pre-ePBS block details (execution_payload must be present)."""
+    execution_payload = slot_details.message.body.execution_payload
+    assert execution_payload is not None, "execution_payload required; use BlockstampBuilder for post-ePBS slots"
+    return BlockStamp(
+        slot_number=slot_details.message.slot,
+        state_root=slot_details.message.state_root,
+        block_number=execution_payload.block_number,
+        block_hash=BlockHash(add_0x_prefix(execution_payload.block_hash)),
+        block_timestamp=execution_payload.timestamp,
     )
 
 
-def build_blockstamp(slot_details: BlockDetailsResponse):
-    return BlockStamp(**_build_blockstamp_data(slot_details))
+class BlockstampBuilder:
+
+    def __init__(self, cc: ConsensusClient, w3_eth: Eth):
+        self.cc = cc
+        self.w3_eth = w3_eth
+
+    def get_non_missed_blockstamp(
+        self,
+        slot: SlotNumber,
+        last_finalized_slot_number: SlotNumber,
+    ):
+        """Get first non-missed slot header and generates blockstamp for it"""
+        logger.info({'msg': f'Get Blockstamp for slot: {slot}'})
+        existed_slot = get_prev_non_missed_slot(self.cc, slot, last_finalized_slot_number)
+        logger.info({'msg': f'Resolved to slot: {existed_slot.message.slot}'})
+        return self.build_blockstamp(existed_slot)
 
 
-def _build_blockstamp_data(
-    slot_details: BlockDetailsResponse,
-) -> dict:
-    execution_payload = slot_details.message.body.execution_payload
+    def get_non_missed_reference_blockstamp(
+        self,
+        ref_slot: SlotNumber,
+        last_finalized_slot_number: SlotNumber,
+        ref_epoch: EpochNumber,
+    ) -> ReferenceBlockStamp:
+        """Get first non-missed slot header and generates reference blockstamp for it"""
+        logger.info({'msg': f'Get Reference Blockstamp for ref slot: {ref_slot}'})
+        existed_slot = get_prev_non_missed_slot(self.cc, ref_slot, last_finalized_slot_number)
+        logger.info({'msg': f'Resolved to slot: {existed_slot.message.slot}'})
+        return self._build_reference_blockstamp(existed_slot, ref_slot, ref_epoch)
 
-    return {
-        "slot_number": slot_details.message.slot,
-        "state_root": slot_details.message.state_root,
-        "block_number": execution_payload.block_number,
-        "block_hash": add_0x_prefix(execution_payload.block_hash),
-        "block_timestamp": execution_payload.timestamp,
-    }
+    def _build_reference_blockstamp(
+        self,
+        slot_details: BlockDetailsResponse,
+        ref_slot: SlotNumber,
+        ref_epoch: EpochNumber,
+    ) -> ReferenceBlockStamp:
+        return ReferenceBlockStamp(
+            **self._build_blockstamp_data(slot_details),
+            ref_slot=ref_slot,
+            ref_epoch=ref_epoch,
+        )
+
+    def build_blockstamp(
+        self,
+        slot_details: BlockDetailsResponse,
+    ) -> BlockStamp:
+        return BlockStamp(**self._build_blockstamp_data(slot_details))
+    
+    def _build_blockstamp_data(
+        self,
+        slot_details: BlockDetailsResponse,
+    ) -> dict:
+        execution_payload = slot_details.message.body.execution_payload
+
+        if execution_payload is not None:
+            return {
+                "slot_number": slot_details.message.slot,
+                "state_root": slot_details.message.state_root,
+                "block_number": execution_payload.block_number,
+                "block_hash": add_0x_prefix(execution_payload.block_hash),
+                "block_timestamp": execution_payload.timestamp,
+            }
+
+        # Post-ePBS path: execution_payload absent — use state.latest_block_hash.
+        # state.latest_block_hash = last *revealed* EL block (slot N-1 when CL is at slot N).
+        # This guarantees deposit symmetry: its deposit_requests are already in pending_deposits.
+        state = self.cc.get_state_view(
+            (slot_details.message.state_root, slot_details.message.slot)
+        )
+        el_hash = state.latest_block_hash
+        el_block = self.w3_eth.get_block(el_hash)
+
+        logger.info({
+            'msg': 'Post-ePBS blockstamp: execution_payload absent, resolved via state.latest_block_hash',
+            'slot': slot_details.message.slot,
+            'el_hash': el_hash,
+            'el_block_number': el_block['number'],  # type: ignore[typeddict-item]
+        })
+
+        return {
+            "slot_number": slot_details.message.slot,
+            "state_root": slot_details.message.state_root,
+            "block_number": BlockNumber(el_block["number"]),  # type: ignore[typeddict-item]
+            "block_hash": add_0x_prefix(el_hash),
+            "block_timestamp": Timestamp(el_block["timestamp"]),  # type: ignore[typeddict-item]
+        }

--- a/src/utils/blockstamp.py
+++ b/src/utils/blockstamp.py
@@ -8,7 +8,7 @@ from web3.types import Timestamp
 from src.providers.consensus.client import ConsensusClient
 from src.providers.consensus.types import BlockDetailsResponse
 from src.types import BlockHash, BlockStamp, EpochNumber, ReferenceBlockStamp, SlotNumber
-from utils.slot import get_prev_non_missed_slot
+from src.utils.slot import get_prev_non_missed_slot
 
 
 logger = logging.getLogger(__name__)

--- a/src/utils/slot.py
+++ b/src/utils/slot.py
@@ -5,8 +5,7 @@ from src.providers.consensus.client import ConsensusClient
 from src.providers.consensus.types import BlockDetailsResponse, BlockHeaderFullResponse
 from src.providers.execution.exceptions import InconsistentData
 from src.providers.http_provider import NotOkResponse
-from src.types import EpochNumber, ReferenceBlockStamp, SlotNumber
-from src.utils.blockstamp import build_blockstamp, build_reference_blockstamp
+from src.types import SlotNumber
 
 
 logger = logging.getLogger(__name__)
@@ -113,31 +112,6 @@ def get_prev_non_missed_slot(
 
     _check_block_header(parent_header)
     return cc.get_block_details(parent_header.data.root)
-
-
-def get_blockstamp(
-    cc: ConsensusClient,
-    slot: SlotNumber,
-    last_finalized_slot_number: SlotNumber,
-):
-    """Get first non-missed slot header and generates blockstamp for it"""
-    logger.info({'msg': f'Get Blockstamp for slot: {slot}'})
-    existed_slot = get_prev_non_missed_slot(cc, slot, last_finalized_slot_number)
-    logger.info({'msg': f'Resolved to slot: {existed_slot.message.slot}'})
-    return build_blockstamp(existed_slot)
-
-
-def get_reference_blockstamp(
-    cc: ConsensusClient,
-    ref_slot: SlotNumber,
-    last_finalized_slot_number: SlotNumber,
-    ref_epoch: EpochNumber,
-) -> ReferenceBlockStamp:
-    """Get first non-missed slot header and generates reference blockstamp for it"""
-    logger.info({'msg': f'Get Reference Blockstamp for ref slot: {ref_slot}'})
-    existed_slot = get_prev_non_missed_slot(cc, ref_slot, last_finalized_slot_number)
-    logger.info({'msg': f'Resolved to slot: {existed_slot.message.slot}'})
-    return build_reference_blockstamp(existed_slot, ref_slot, ref_epoch)
 
 
 def _check_block_header(block_header: BlockHeaderFullResponse):

--- a/tests/factory/configs.py
+++ b/tests/factory/configs.py
@@ -6,10 +6,15 @@ from src.providers.consensus.types import (
     BlockAttestationResponse,
     BlockDetailsResponse,
     Checkpoint,
+    ExecutionPayload,
     SlotAttestationCommittee,
 )
 from src.services.bunker_cases.types import BunkerConfig
+from src.types import BlockHash, BlockNumber, Timestamp
 from tests.factory.web3_factory import Web3DataclassFactory
+
+
+_ZERO_BLOCK_HASH: BlockHash = BlockHash("0x" + "00" * 32)  # type: ignore[arg-type]
 
 
 class ChainConfigFactory(Web3DataclassFactory[ChainConfig]):
@@ -68,5 +73,12 @@ class BlockDetailsResponseFactory(Web3DataclassFactory[BlockDetailsResponse]):
     @classmethod
     def build(cls, **kwargs) -> BlockDetailsResponse:
         instance = super().build(**kwargs)
-        instance.message.body.execution_payload.block_hash = "0x0000000000000000000000000000000000000000"
+        if instance.message.body.execution_payload is None:
+            instance.message.body.execution_payload = ExecutionPayload(
+                parent_hash=_ZERO_BLOCK_HASH,
+                block_number=BlockNumber(0),
+                timestamp=Timestamp(0),
+                block_hash=_ZERO_BLOCK_HASH,
+            )
+        instance.message.body.execution_payload.block_hash = _ZERO_BLOCK_HASH
         return instance

--- a/tests/main/test_main_cycle_smoke.py
+++ b/tests/main/test_main_cycle_smoke.py
@@ -26,7 +26,9 @@ class TestIntegrationMainCycleSmoke:
         variables.CYCLE_SLEEP_IN_SECONDS = 0
 
         # Use last finalized instead of head slot for avoiding calls with non-existent block at the moment of cycle
-        ConsensusModule._get_latest_blockstamp = lambda self: cast(DaemonModule, self)._receive_last_finalized_block()
+        ConsensusModule._get_latest_blockstamp = lambda self: self._blockstamp_builder.build_blockstamp(
+            cast(DaemonModule, self)._receive_last_finalized_block()
+        )
 
         if module_name is OracleModuleName.CSM:
             variables.PERFORMANCE_COLLECTOR_URI = ["http://localhost:9020"]

--- a/tests/main/test_main_cycle_smoke.py
+++ b/tests/main/test_main_cycle_smoke.py
@@ -26,7 +26,7 @@ class TestIntegrationMainCycleSmoke:
         variables.CYCLE_SLEEP_IN_SECONDS = 0
 
         # Use last finalized instead of head slot for avoiding calls with non-existent block at the moment of cycle
-        ConsensusModule._get_latest_blockstamp = lambda self: cast(DaemonModule, self)._receive_last_finalized_slot()
+        ConsensusModule._get_latest_blockstamp = lambda self: cast(DaemonModule, self)._receive_last_finalized_block()
 
         if module_name is OracleModuleName.CSM:
             variables.PERFORMANCE_COLLECTOR_URI = ["http://localhost:9020"]

--- a/tests/modules/accounting/bunker/conftest.py
+++ b/tests/modules/accounting/bunker/conftest.py
@@ -75,8 +75,8 @@ def mock_get_used_lido_keys(abnormal_case):
 
 
 @pytest.fixture
-def mock_get_blockstamp(monkeypatch):
-    def _get_blockstamp(_, ref_slot, last_finalized_slot_number):
+def mock_get_blockstamp(abnormal_case):
+    def _get_blockstamp(ref_slot, last_finalized_slot_number):
         slots = {
             0: simple_blockstamp(0),
             10: simple_blockstamp(10),
@@ -89,7 +89,7 @@ def mock_get_blockstamp(monkeypatch):
         }
         return slots[ref_slot]
 
-    def _get_reference_blockstamp(_, ref_slot, last_finalized_slot_number, ref_epoch):
+    def _get_reference_blockstamp(ref_slot, last_finalized_slot_number, ref_epoch):
         slots = {
             0: simple_ref_blockstamp(0),
             10: simple_ref_blockstamp(10),
@@ -102,12 +102,9 @@ def mock_get_blockstamp(monkeypatch):
         }
         return slots[ref_slot]
 
-    monkeypatch.setattr(
-        'src.services.bunker_cases.abnormal_cl_rebase.get_blockstamp', Mock(side_effect=_get_blockstamp)
-    )
-    monkeypatch.setattr(
-        'src.services.bunker_cases.abnormal_cl_rebase.get_reference_blockstamp',
-        Mock(side_effect=_get_reference_blockstamp),
+    abnormal_case._blockstamp_builder = Mock(  # type: ignore[attr-defined]
+        get_non_missed_blockstamp=Mock(side_effect=_get_blockstamp),
+        get_non_missed_reference_blockstamp=Mock(side_effect=_get_reference_blockstamp),
     )
 
 

--- a/tests/modules/accounting/staking_vault/test_fee_get_vaults.py
+++ b/tests/modules/accounting/staking_vault/test_fee_get_vaults.py
@@ -31,7 +31,7 @@ from tests.modules.accounting.staking_vault.conftest import (
 @pytest.mark.unit
 class TestGetVaultsFees:
     @pytest.fixture
-    def service(self, web3, monkeypatch):
+    def service(self, web3):
         web3.cc = MagicMock()
         web3.lido_contracts.vault_hub = MagicMock()
         web3.lido_contracts.accounting_oracle = MagicMock()
@@ -42,7 +42,7 @@ class TestGetVaultsFees:
 
         fake_blockstamp = MagicMock()
         fake_blockstamp.block_number = 0
-        monkeypatch.setattr("src.services.staking_vaults.get_blockstamp", MagicMock(return_value=fake_blockstamp))
+        svc._blockstamp_builder = MagicMock(get_non_missed_blockstamp=MagicMock(return_value=fake_blockstamp))  # type: ignore[attr-defined]
 
         return svc
 
@@ -111,7 +111,7 @@ class TestGetVaultsFees:
 
         assert fees[vault_adr].prev_fee == 0
 
-    def test_negative_ref_slot_on_first_report(self, service, monkeypatch):
+    def test_negative_ref_slot_on_first_report(self, service):
         # initial_epoch - frame_epoches <= 0
         vault_adr = VaultAddresses.VAULT_0
         vault = VaultInfoFactory.build(vault=vault_adr, liability_shares=0, max_liability_shares=0)
@@ -123,9 +123,10 @@ class TestGetVaultsFees:
 
         # Negative prev_slot -> events should be fetched from 0 block
         blockstamp = self.make_blockstamp(block=3 * 32 - 1, slot=3 * 32 - 1)
-        monkeypatch.setattr(
-            "src.services.staking_vaults.get_blockstamp",
-            lambda cc, slot, last_finalized_slot_number: BlockStampFactory.build(block_number=slot),
+        service._blockstamp_builder = MagicMock(  # type: ignore[attr-defined]
+            get_non_missed_blockstamp=MagicMock(
+                side_effect=lambda slot, last_finalized_slot_number: BlockStampFactory.build(block_number=slot)
+            )
         )
 
         service.get_vaults_fees(
@@ -161,7 +162,7 @@ class TestGetVaultsFees:
             block_timestamps={},
         )
 
-    def test_first_ref_slot_calculate_on_first_report(self, service, monkeypatch):
+    def test_first_ref_slot_calculate_on_first_report(self, service):
         # initial_epoch - frame_epoches > 0
         vault_adr = VaultAddresses.VAULT_0
         vault = VaultInfoFactory.build(vault=vault_adr, liability_shares=0, max_liability_shares=0)
@@ -171,9 +172,10 @@ class TestGetVaultsFees:
         service._get_vault_events_for_fees = MagicMock(return_value=({}, set()))
         service._calculate_vault_fee_components = MagicMock(return_value=(Decimal(0), Decimal(0), Decimal(0), 0))
 
-        monkeypatch.setattr(
-            "src.services.staking_vaults.get_blockstamp",
-            lambda cc, slot, last_finalized_slot_number: BlockStampFactory.build(block_number=slot),
+        service._blockstamp_builder = MagicMock(  # type: ignore[attr-defined]
+            get_non_missed_blockstamp=MagicMock(
+                side_effect=lambda slot, last_finalized_slot_number: BlockStampFactory.build(block_number=slot)
+            )
         )
 
         # First report -> events should be fetched from initial_epoch - frame_epoches

--- a/tests/modules/accounting/staking_vault/test_ifps_report.py
+++ b/tests/modules/accounting/staking_vault/test_ifps_report.py
@@ -5,7 +5,7 @@ from src.modules.oracles.accounting.types import StakingVaultIpfsReport
 from src.providers.ipfs import CIDv0
 from src.services.staking_vaults import StakingVaultsService
 from src.types import FrameNumber, SlotNumber
-from src.utils.slot import get_blockstamp
+from src.utils.blockstamp import BlockstampBuilder
 
 
 # =============================================================================
@@ -41,8 +41,8 @@ class TestIpfsReportSmoke:
 
         # Assert
         if last_processing_ref_slot:
-            ref_block = get_blockstamp(
-                web3_integration.cc, last_processing_ref_slot, SlotNumber(int(last_processing_ref_slot))
+            ref_block = BlockstampBuilder(web3_integration.cc, web3_integration.eth).get_non_missed_blockstamp(
+                last_processing_ref_slot, SlotNumber(int(last_processing_ref_slot))
             )
 
             assert tree.block_number == ref_block.block_number

--- a/tests/modules/accounting/test_accounting_module.py
+++ b/tests/modules/accounting/test_accounting_module.py
@@ -71,17 +71,19 @@ def frame_config() -> FrameConfig:
 
 @pytest.mark.unit
 def test_accounting_execute_module(accounting: Accounting, bs: BlockStamp):
+    accounting._blockstamp_builder = Mock(build_blockstamp=Mock(return_value=bs))  # type: ignore[attr-defined]
     accounting.get_blockstamp_for_report = Mock(return_value=None)
-    assert accounting.execute_module(last_finalized_blockstamp=bs) is ModuleExecuteDelay.NEXT_FINALIZED_EPOCH, (
+    assert accounting.execute_module(Mock()) is ModuleExecuteDelay.NEXT_FINALIZED_EPOCH, (
         "execute_module should wait for the next finalized epoch"
     )
     accounting.get_blockstamp_for_report.assert_called_once_with(bs)
 
+    accounting._blockstamp_builder = Mock(build_blockstamp=Mock(return_value=bs))  # type: ignore[attr-defined]
     accounting.get_blockstamp_for_report = Mock(return_value=bs)
     accounting.process_report = Mock(return_value=None)
     accounting.process_extra_data = Mock(return_value=None)
     accounting._check_compatibility = Mock(return_value=True)
-    assert accounting.execute_module(last_finalized_blockstamp=bs) is ModuleExecuteDelay.NEXT_SLOT, (
+    assert accounting.execute_module(Mock()) is ModuleExecuteDelay.NEXT_SLOT, (
         "execute_module should wait for the next slot"
     )
     accounting.get_blockstamp_for_report.assert_called_once_with(bs)
@@ -666,9 +668,10 @@ def test_is_contracts_addresses_changed(accounting: Accounting):
 
 @pytest.mark.unit
 def test_accounting_execute_module_compatibility_fails(accounting: Accounting, bs: BlockStamp):
+    accounting._blockstamp_builder = Mock(build_blockstamp=Mock(return_value=bs))  # type: ignore[attr-defined]
     accounting.get_blockstamp_for_report = Mock(return_value=bs)
     accounting._check_compatibility = Mock(return_value=False)
-    assert accounting.execute_module(last_finalized_blockstamp=bs) is ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
+    assert accounting.execute_module(Mock()) is ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
     accounting.get_blockstamp_for_report.assert_called_once_with(bs)
 
 

--- a/tests/modules/accounting/test_safe_border_integration.py
+++ b/tests/modules/accounting/test_safe_border_integration.py
@@ -34,7 +34,7 @@ def subject(
         return_value=finalization_max_negative_rebase_epoch_shift
     )
 
-    return SafeBorder(web3, past_blockstamp, ChainConfigFactory.build(), FrameConfigFactory.build())
+    return SafeBorder(web3, Mock(), past_blockstamp, ChainConfigFactory.build(), FrameConfigFactory.build())
 
 
 @pytest.mark.unit

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -66,7 +66,7 @@ def safe_border(
         return_value=OracleReportLimitsFactory.build()
     )
     web3.lido_contracts.oracle_daemon_config.finalization_max_negative_rebase_epoch_shift = Mock(return_value=100)
-    return SafeBorder(web3, past_blockstamp, chain_config, frame_config)
+    return SafeBorder(web3, Mock(), past_blockstamp, chain_config, frame_config)
 
 
 @pytest.mark.unit

--- a/tests/modules/accounting/test_withdrawal_unit.py
+++ b/tests/modules/accounting/test_withdrawal_unit.py
@@ -30,7 +30,7 @@ def subject(web3, past_blockstamp, chain_config, frame_config):
     web3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits = Mock(
         return_value=OracleReportLimitsFactory.build()
     )
-    return Withdrawal(web3, past_blockstamp, chain_config, frame_config)
+    return Withdrawal(web3, Mock(), past_blockstamp, chain_config, frame_config)
 
 
 @pytest.mark.unit

--- a/tests/modules/csm/test_csm_distribution.py
+++ b/tests/modules/csm/test_csm_distribution.py
@@ -309,6 +309,8 @@ def test_calculate_distribution(
     # Mocking the data from EL
     w3 = Mock(
         spec=Web3StakingModule,
+        cc=Mock(),
+        eth=Mock(),
         staking_module=Mock(spec=StakingModuleContracts, fee_distributor=Mock(spec=CSFeeDistributorContract)),
     )
     w3.staking_module.fee_distributor.shares_to_distribute = Mock(side_effect=shares_to_distribute)
@@ -338,6 +340,8 @@ def test_calculate_distribution_handles_invalid_distribution():
     # Mocking the data from EL
     w3 = Mock(
         spec=Web3StakingModule,
+        cc=Mock(),
+        eth=Mock(),
         staking_module=Mock(spec=StakingModuleContracts, fee_distributor=Mock(spec=CSFeeDistributorContract)),
     )
     w3.staking_module.fee_distributor.shares_to_distribute = Mock(return_value=500)
@@ -369,6 +373,8 @@ def test_calculate_distribution_handles_invalid_distribution_in_total():
     # Mocking the data from EL
     w3 = Mock(
         spec=Web3StakingModule,
+        cc=Mock(),
+        eth=Mock(),
         staking_module=Mock(spec=StakingModuleContracts, fee_distributor=Mock(spec=CSFeeDistributorContract)),
     )
     w3.staking_module.fee_distributor.shares_to_distribute = Mock(return_value=500)
@@ -1111,7 +1117,7 @@ def test_calculate_distribution_in_frame(
 ):
     log = FramePerfLog(blockstamp=..., frame=...)
     # Mocking the data from EL
-    w3 = Mock(spec=Web3StakingModule, staking_module=Mock(spec=StakingModuleContracts))
+    w3 = Mock(spec=Web3StakingModule, cc=Mock(), eth=Mock(), staking_module=Mock(spec=StakingModuleContracts))
     w3.staking_module.get_curve_params = mocked_curve_params
 
     frame = (EpochNumber(0), EpochNumber(31))
@@ -1191,6 +1197,7 @@ def test_get_module_validators_raises_for_operator_module_address_mismatch():
         staking_module=Mock(spec=StakingModuleContracts, module=Mock(address=module_address)),
         kac=Mock(),
         cc=Mock(),
+        eth=Mock(),
     )
     w3.kac.get_used_module_operators_keys.return_value = {
         "module": {"id": 1},
@@ -1221,6 +1228,7 @@ def test_get_module_validators_raises_for_key_module_address_mismatch():
         staking_module=Mock(spec=StakingModuleContracts, module=Mock(address=module_address)),
         kac=Mock(),
         cc=Mock(),
+        eth=Mock(),
     )
     w3.kac.get_used_module_operators_keys.return_value = {
         "module": {"id": 1},
@@ -1649,7 +1657,7 @@ def test_get_validator_duties_outcome_scales_by_effective_balance(multiplier: in
 
 @pytest.mark.unit
 def test_calculate_distribution_in_frame_assigns_keys_by_sorted_order():
-    w3 = Mock(spec=Web3StakingModule, staking_module=Mock())
+    w3 = Mock(spec=Web3StakingModule, cc=Mock(), eth=Mock(), staking_module=Mock())
     reward_share_data = Mock()
     reward_share_data.get_for = Mock(side_effect=lambda k: {1: 1.0, 2: 0.9, 3: 0.8, 4: 0.7, 5: 0.6, 6: 0.5}[k])
     w3.staking_module.get_curve_params = Mock(

--- a/tests/modules/csm/test_csm_module.py
+++ b/tests/modules/csm/test_csm_module.py
@@ -247,6 +247,7 @@ def test_current_frame_range(module: CSPerformanceOracle, mock_chain_config: NoR
 @pytest.mark.unit
 def test_execute_module_posts_new_demand(module: CSPerformanceOracle, mock_chain_config: NoReturn):
     blockstamp = ReferenceBlockStampFactory.build()
+    module._blockstamp_builder = Mock(build_blockstamp=Mock(return_value=blockstamp))  # type: ignore[attr-defined]
     module.state = Mock(migrate=Mock())
     module._check_compatibility = Mock(return_value=True)
     module._get_epochs_range_to_process = Mock(return_value=(10, 20))
@@ -257,7 +258,7 @@ def test_execute_module_posts_new_demand(module: CSPerformanceOracle, mock_chain
     module.w3.performance.get_epochs_demand = Mock(return_value=None)
     module.w3.performance.post_epochs_demand = Mock()
 
-    execute_delay = module.execute_module(blockstamp)
+    execute_delay = module.execute_module(Mock())
 
     assert execute_delay is ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
     module.state.init.assert_called_once_with(10, 20, 4)
@@ -269,6 +270,7 @@ def test_execute_module_posts_new_demand(module: CSPerformanceOracle, mock_chain
 @pytest.mark.unit
 def test_execute_module_skips_demand_post_when_demand_same(module: CSPerformanceOracle, mock_chain_config: NoReturn):
     blockstamp = ReferenceBlockStampFactory.build()
+    module._blockstamp_builder = Mock(build_blockstamp=Mock(return_value=blockstamp))  # type: ignore[attr-defined]
     module.state = Mock(migrate=Mock())
     module._check_compatibility = Mock(return_value=True)
     module._get_epochs_range_to_process = Mock(return_value=(10, 20))
@@ -282,7 +284,7 @@ def test_execute_module_skips_demand_post_when_demand_same(module: CSPerformance
     module.w3.performance.get_epochs_demand = Mock(return_value=demand_mock)
     module.w3.performance.post_epochs_demand = Mock()
 
-    execute_delay = module.execute_module(blockstamp)
+    execute_delay = module.execute_module(Mock())
 
     assert execute_delay is ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
     module.state.init.assert_called_once_with(10, 20, 4)
@@ -495,7 +497,8 @@ def test__collect_data_handles_range_availability(
 
 @pytest.mark.unit
 def test_fulfill_state_handles_epoch_data(module: CSPerformanceOracle):
-    module._receive_last_finalized_slot = Mock(return_value="finalized")
+    module._receive_last_finalized_block = Mock(return_value="finalized")
+    module._blockstamp_builder = Mock(build_blockstamp=Mock(side_effect=lambda x: x))  # type: ignore[attr-defined]
     validator_a = make_validator(0, activation_epoch=0, exit_epoch=10)
     validator_b = make_validator(1, activation_epoch=0, exit_epoch=10)
     module.w3 = Mock()
@@ -536,7 +539,7 @@ def test_fulfill_state_handles_epoch_data(module: CSPerformanceOracle):
 
     module._fulfill_state()
 
-    module._receive_last_finalized_slot.assert_called_once()
+    module._receive_last_finalized_block.assert_called_once()
     module.w3.cc.get_validators.assert_called_once_with("finalized")
 
     module.w3.performance.get_epochs_data.assert_called_once_with(0, 1)
@@ -568,7 +571,8 @@ def test_fulfill_state_handles_epoch_data(module: CSPerformanceOracle):
 @pytest.mark.unit
 def test_fulfill_state_raises_on_inactive_missed_attestation(module: CSPerformanceOracle):
     inactive_validator = make_validator(5, activation_epoch=10, exit_epoch=20)
-    module._receive_last_finalized_slot = Mock(return_value="finalized")
+    module._receive_last_finalized_block = Mock(return_value="finalized")
+    module._blockstamp_builder = Mock(build_blockstamp=Mock(side_effect=lambda x: x))  # type: ignore[attr-defined]
     module.w3 = Mock()
     module.w3.cc.get_validators = Mock(return_value=[inactive_validator])
     module.w3.performance.get_epochs_data = Mock(
@@ -603,7 +607,8 @@ def test_fulfill_state_raises_on_inactive_missed_attestation(module: CSPerforman
 
 @pytest.mark.unit
 def test_fulfill_state_raises_on_inconsistent_sync_misses(module: CSPerformanceOracle):
-    module._receive_last_finalized_slot = Mock(return_value="finalized")
+    module._receive_last_finalized_block = Mock(return_value="finalized")
+    module._blockstamp_builder = Mock(build_blockstamp=Mock(side_effect=lambda x: x))  # type: ignore[attr-defined]
     validator = make_validator(0, activation_epoch=0, exit_epoch=10)
     module.w3 = Mock()
     module.w3.cc.get_validators = Mock(return_value=[validator])
@@ -643,7 +648,8 @@ def test_fulfill_state_raises_on_inconsistent_sync_misses(module: CSPerformanceO
 
 @pytest.mark.unit
 def test_fulfill_state_skips_inactive_validators_across_epochs(module: CSPerformanceOracle):
-    module._receive_last_finalized_slot = Mock(return_value="finalized")
+    module._receive_last_finalized_block = Mock(return_value="finalized")
+    module._blockstamp_builder = Mock(build_blockstamp=Mock(side_effect=lambda x: x))  # type: ignore[attr-defined]
     active_all = make_validator(0, activation_epoch=0, exit_epoch=10)
     active_late = make_validator(1, activation_epoch=1, exit_epoch=10)
     exit_early = make_validator(2, activation_epoch=0, exit_epoch=1)
@@ -1129,7 +1135,8 @@ def test_execute_module_not_collected(module: CSPerformanceOracle):
     module._prepare_to_collect = Mock()
 
     last_finalized_blockstamp = Mock(slot_number=100500)
-    execute_delay = module.execute_module(last_finalized_blockstamp=last_finalized_blockstamp)
+    module._blockstamp_builder = Mock(build_blockstamp=Mock(return_value=last_finalized_blockstamp))  # type: ignore[attr-defined]
+    execute_delay = module.execute_module(Mock())
 
     module._prepare_to_collect.assert_called_once_with(last_finalized_blockstamp)
     assert execute_delay is ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
@@ -1140,8 +1147,9 @@ def test_execute_module_skips_collecting_if_not_compatible(module: CSPerformance
     module._check_compatibility = Mock(return_value=False)
     module._collect_data = Mock(return_value=False)
     module._prepare_to_collect = Mock()
+    module._blockstamp_builder = Mock(build_blockstamp=Mock(return_value=Mock(slot_number=100500)))  # type: ignore[attr-defined]
 
-    execute_delay = module.execute_module(last_finalized_blockstamp=Mock(slot_number=100500))
+    execute_delay = module.execute_module(Mock())
 
     assert execute_delay is ModuleExecuteDelay.NEXT_FINALIZED_EPOCH
     module._prepare_to_collect.assert_not_called()
@@ -1156,7 +1164,8 @@ def test_execute_module_no_report_blockstamp(module: CSPerformanceOracle):
     module._prepare_to_collect = Mock()
 
     last_finalized_blockstamp = Mock(slot_number=100500)
-    execute_delay = module.execute_module(last_finalized_blockstamp=last_finalized_blockstamp)
+    module._blockstamp_builder = Mock(build_blockstamp=Mock(return_value=last_finalized_blockstamp))  # type: ignore[attr-defined]
+    execute_delay = module.execute_module(Mock())
 
     module._prepare_to_collect.assert_called_once_with(last_finalized_blockstamp)
     module._collect_data.assert_not_called()
@@ -1172,7 +1181,8 @@ def test_execute_module_processed(module: CSPerformanceOracle):
     module._prepare_to_collect = Mock()
 
     last_finalized_blockstamp = Mock(slot_number=100500)
-    execute_delay = module.execute_module(last_finalized_blockstamp=last_finalized_blockstamp)
+    module._blockstamp_builder = Mock(build_blockstamp=Mock(return_value=last_finalized_blockstamp))  # type: ignore[attr-defined]
+    execute_delay = module.execute_module(Mock())
 
     module._prepare_to_collect.assert_called_once_with(last_finalized_blockstamp)
     assert execute_delay is ModuleExecuteDelay.NEXT_SLOT

--- a/tests/modules/sidecars/performance/collector/test_checkpoint.py
+++ b/tests/modules/sidecars/performance/collector/test_checkpoint.py
@@ -322,7 +322,7 @@ class TestAttestations:
     def test_checkpoints_processor_prepare_committees(
         self, mock_get_attestation_committees, processor: FrameCheckpointProcessor
     ):
-        raw = processor.cc.get_attestation_committees(processor.finalized_blockstamp, 0)
+        raw = processor.cc.get_attestation_committees(processor.last_finalized_block, 0)
         committees, misses = processor._prepare_attestation_duties(0)
 
         assert len(committees) == 2048

--- a/tests/modules/submodules/consensus/test_consensus.py
+++ b/tests/modules/submodules/consensus/test_consensus.py
@@ -9,7 +9,6 @@ from web3.exceptions import ContractCustomError
 
 from src import variables
 from src.modules.common.types import ChainConfig
-from src.modules.oracles.common import consensus as consensus_module
 from src.modules.oracles.common.consensus import ZERO_HASH, ConsensusModule, IsNotMemberException, MemberInfo
 from src.modules.oracles.common.exceptions import ContractVersionMismatch, IncompatibleOracleVersion
 from src.providers.consensus.types import BeaconSpecResponse
@@ -300,7 +299,6 @@ def test_incompatible_contract_version(consensus):
 def test_get_blockstamp_for_report_contract_is_not_reportable(consensus: ConsensusModule, caplog):
     bs = ReferenceBlockStampFactory.build()
     consensus._get_latest_blockstamp = Mock(return_value=bs)
-    consensus._check_contract_versions = Mock(return_value=True)
     consensus.is_contract_reportable = Mock(return_value=False)
 
     consensus.get_blockstamp_for_report(bs)
@@ -374,28 +372,27 @@ def test_check_contract_config(consensus: ConsensusModule, monkeypatch: pytest.M
     consensus.w3.cc.get_block_root = Mock(return_value=Mock(root=""))
     consensus.w3.cc.get_block_details = Mock()
     bs = ReferenceBlockStampFactory.build()
-    with monkeypatch.context() as m:
-        m.setattr(consensus_module, "build_blockstamp", Mock(return_value=bs))
-        chain_config = cast(ChainConfig, ChainConfigFactory.build())
-        consensus.get_chain_config = Mock(return_value=chain_config)
-        bc_spec = cast(BeaconSpecResponse, BeaconSpecResponseFactory.build())
-        consensus.w3.cc.get_config_spec = Mock(return_value=bc_spec)
-        consensus.w3.cc.get_genesis = Mock(return_value=Mock(genesis_time=chain_config.genesis_time))
+    consensus._blockstamp_builder = Mock(build_blockstamp=Mock(return_value=bs))  # type: ignore[attr-defined]
+    chain_config = cast(ChainConfig, ChainConfigFactory.build())
+    consensus.get_chain_config = Mock(return_value=chain_config)
+    bc_spec = cast(BeaconSpecResponse, BeaconSpecResponseFactory.build())
+    consensus.w3.cc.get_config_spec = Mock(return_value=bc_spec)
+    consensus.w3.cc.get_genesis = Mock(return_value=Mock(genesis_time=chain_config.genesis_time))
 
+    consensus.check_contract_configs()
+
+    # broken path
+    chain_config = cast(
+        ChainConfig,
+        ChainConfigFactory.build(
+            seconds_per_slot=14,
+            slots_per_epoch=2,
+            genesis_time=1,
+        ),
+    )
+    consensus.get_chain_config = Mock(return_value=chain_config)
+    with pytest.raises(ValueError):
         consensus.check_contract_configs()
-
-        # broken path
-        chain_config = cast(
-            ChainConfig,
-            ChainConfigFactory.build(
-                seconds_per_slot=14,
-                slots_per_epoch=2,
-                genesis_time=1,
-            ),
-        )
-        consensus.get_chain_config = Mock(return_value=chain_config)
-        with pytest.raises(ValueError):
-            consensus.check_contract_configs()
 
 
 @pytest.mark.unit

--- a/tests/modules/submodules/test_oracle_module.py
+++ b/tests/modules/submodules/test_oracle_module.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import responses
-from eth_utils import add_0x_prefix
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from timeout_decorator import TimeoutError as DecoratorTimeoutError
 from web3_multi_provider.multi_http_provider import NoActiveProviderError
@@ -26,9 +25,7 @@ from src.modules.oracles.common.exceptions import (
 from src.modules.oracles.common.oracle_module import OracleModule
 from src.providers.http_provider import NotOkResponse
 from src.providers.keys.client import KeysOutdatedException
-from src.types import BlockStamp
 from src.utils.slot import InconsistentData, NoSlotsAvailable, SlotNotFinalized
-from tests.factory.blockstamp import ReferenceBlockStampFactory
 from tests.factory.configs import BlockDetailsResponseFactory
 
 
@@ -77,27 +74,20 @@ def oracle(web3):
 
 
 @pytest.mark.unit
-def test_receive_last_finalized_slot(oracle):
+def test_receive_last_finalized_block(oracle):
     block_details = BlockDetailsResponseFactory.build()
-    execution_payload = block_details.message.body.execution_payload
     oracle.w3.cc.get_block_details.return_value = block_details
 
-    slot = oracle._receive_last_finalized_slot()
+    result = oracle._receive_last_finalized_block()
 
-    assert slot == BlockStamp(
-        state_root=block_details.message.state_root,
-        slot_number=block_details.message.slot,
-        block_hash=add_0x_prefix(execution_payload.block_hash),
-        block_number=execution_payload.block_number,
-        block_timestamp=execution_payload.timestamp,
-    )
+    assert result == block_details
 
 
 @pytest.mark.unit
 @responses.activate
 def test_cycle_handler_run_once_per_slot(oracle, web3):
     oracle.is_contracts_addresses_changed = Mock()
-    oracle._receive_last_finalized_slot = Mock(return_value=ReferenceBlockStampFactory.build(slot_number=1))
+    oracle._receive_last_finalized_block = Mock(return_value=MagicMock(message=MagicMock(slot=1)))
     responses.get('http://localhost:8000/pulse/', status=HTTPStatus.OK)
 
     oracle.cycle_handler()
@@ -108,7 +98,7 @@ def test_cycle_handler_run_once_per_slot(oracle, web3):
     assert oracle.call_count == 1
     assert oracle.is_contracts_addresses_changed.call_count == 1
 
-    oracle._receive_last_finalized_slot = Mock(return_value=ReferenceBlockStampFactory.build(slot_number=2))
+    oracle._receive_last_finalized_block = Mock(return_value=MagicMock(message=MagicMock(slot=2)))
     oracle.cycle_handler()
     assert oracle.call_count == 2
     assert oracle.is_contracts_addresses_changed.call_count == 2
@@ -150,13 +140,13 @@ def test_run_as_daemon(oracle):
 def test_cycle_no_fail_on_retryable_error(oracle: OracleModule, ex: Exception):
     oracle.w3.lido_contracts = MagicMock()
     with (
-        patch.object(oracle, "_receive_last_finalized_slot", return_value=MagicMock(slot_number=1111111)),
+        patch.object(oracle, "_receive_last_finalized_block", return_value=MagicMock(message=MagicMock(slot=1111111))),
         patch.object(oracle.w3.lido_contracts, "has_contract_address_changed", return_value=False),
         patch.object(oracle, "execute_module", side_effect=ex),
     ):
         oracle._cycle()
     # test node availability
-    with patch.object(oracle, "_receive_last_finalized_slot", side_effect=ex):
+    with patch.object(oracle, "_receive_last_finalized_block", side_effect=ex):
         oracle._cycle()
 
 
@@ -172,7 +162,7 @@ def test_cycle_no_fail_on_retryable_error(oracle: OracleModule, ex: Exception):
 def test_run_cycle_fails_on_critical_exceptions(oracle: OracleModule, ex: Exception):
     oracle.w3.lido_contracts = MagicMock()
     with (
-        patch.object(oracle, "_receive_last_finalized_slot", return_value=MagicMock(slot_number=1111111)),
+        patch.object(oracle, "_receive_last_finalized_block", return_value=MagicMock(message=MagicMock(slot=1111111))),
         patch.object(oracle.w3.lido_contracts, "has_contract_address_changed", return_value=False),
         patch.object(oracle, "execute_module", side_effect=ex),
         pytest.raises(type(ex), match="Fake exception"),
@@ -180,7 +170,7 @@ def test_run_cycle_fails_on_critical_exceptions(oracle: OracleModule, ex: Except
         oracle._cycle()
     # test node availability
     with (
-        patch.object(oracle, "_receive_last_finalized_slot", side_effect=ex),
+        patch.object(oracle, "_receive_last_finalized_block", side_effect=ex),
         pytest.raises(type(ex), match="Fake exception"),
     ):
         oracle._cycle()
@@ -206,7 +196,7 @@ def test_cycle__successful_execution__records_success_metric(oracle: OracleModul
 
     with (
         patch("src.modules.common.daemon_module.pulse"),
-        patch.object(oracle, "_receive_last_finalized_slot", return_value=MagicMock(slot_number=1111111)),
+        patch.object(oracle, "_receive_last_finalized_block", return_value=MagicMock(message=MagicMock(slot=1111111))),
         patch.object(oracle, "execute_module", return_value=ModuleExecuteDelay.NEXT_FINALIZED_EPOCH),
     ):
         oracle._cycle()
@@ -220,7 +210,7 @@ def test_cycle__retryable_error__records_error_metric(oracle: OracleModule):
     before = CYCLE_COUNT.labels(result=CycleResult.ERROR.value)._value.get()
 
     with (
-        patch.object(oracle, "_receive_last_finalized_slot", return_value=MagicMock(slot_number=1111111)),
+        patch.object(oracle, "_receive_last_finalized_block", return_value=MagicMock(message=MagicMock(slot=1111111))),
         patch.object(oracle, "execute_module", side_effect=RequestsConnectionError("Fake")),
     ):
         oracle._cycle()
@@ -235,7 +225,7 @@ def test_cycle__slot_below_threshold__records_success_metric(oracle: OracleModul
     success_before = CYCLE_COUNT.labels(result=CycleResult.SUCCESS.value)._value.get()
     error_before = CYCLE_COUNT.labels(result=CycleResult.ERROR.value)._value.get()
 
-    with patch.object(oracle, "_receive_last_finalized_slot", return_value=MagicMock(slot_number=1)):
+    with patch.object(oracle, "_receive_last_finalized_block", return_value=MagicMock(message=MagicMock(slot=1))):
         oracle._cycle()
 
     assert CYCLE_COUNT.labels(result=CycleResult.SUCCESS.value)._value.get() == success_before + 1

--- a/tests/services/test_safe_border.py
+++ b/tests/services/test_safe_border.py
@@ -25,6 +25,7 @@ def test_get_safe_border_epoch(
     SafeBorder._retrieve_constants = Mock()
     sb = SafeBorder(
         w3=Mock(),
+        blockstamp_builder=Mock(),
         blockstamp=Mock(),
         chain_config=Mock(),
         frame_config=Mock(),
@@ -49,7 +50,7 @@ def test_get_safe_border_epoch(
 def test_get_bunker_start_or_last_successful_report_epoch(
     get_bunker_timestamp, slots_per_epoch, last_processing_ref_slot, initial_epoch, expected
 ):
-    SafeBorder._retrieve_constants = Mock
+    SafeBorder._retrieve_constants = Mock()
     SafeBorder._get_negative_rebase_border_epoch = Mock()
     SafeBorder._get_associated_slashings_border_epoch = Mock()
     SafeBorder._get_default_requests_border_epoch = Mock()
@@ -57,11 +58,15 @@ def test_get_bunker_start_or_last_successful_report_epoch(
     web3Mock = Mock()
     web3Mock.lido_contracts.get_accounting_last_processing_ref_slot = Mock(return_value=last_processing_ref_slot)
 
-    chain_config = Mock
+    chain_config = Mock()
     chain_config.slots_per_epoch = slots_per_epoch
-    chain_config.initial_epoch = initial_epoch
 
-    sb = SafeBorder(w3=web3Mock, blockstamp=Mock, chain_config=chain_config, frame_config=Mock)
+    frame_config = Mock()
+    frame_config.initial_epoch = initial_epoch
+
+    sb = SafeBorder(
+        w3=web3Mock, blockstamp_builder=Mock(), blockstamp=Mock(), chain_config=chain_config, frame_config=frame_config
+    )
 
     actual = sb._get_bunker_start_or_last_successful_report_epoch()
 
@@ -139,7 +144,13 @@ def test_find_earliest_slashed_epoch_rounded_to_frame(
     web3Mock = Mock()
     web3Mock.lido_contracts = Mock()
 
-    sb = SafeBorder(w3=web3Mock, blockstamp=blockstamp, chain_config=chain_config, frame_config=frame_config)
+    sb = SafeBorder(
+        w3=web3Mock,
+        blockstamp_builder=Mock(),
+        blockstamp=blockstamp,
+        chain_config=chain_config,
+        frame_config=frame_config,
+    )
 
     actual = sb._find_earliest_slashed_epoch_rounded_to_frame(validators)
 


### PR DESCRIPTION
# Support Glamsterdam (EIP-7732 / ePBS) block structure

## Context

  EIP-7732 (ePBS) separates the Consensus Layer block from the Execution Layer block. A builder commits to an EL block via `signed_execution_payload_bid` in the CL block, but may withhold the EL reveal. This introduces a new empty slot state — a CL block exists, but no EL block was revealed for it.

  This PR restructures how the oracle builds its execution-layer reference point(`BlockStamp`), making the codebase ready to handle both pre- and post-fork block structures.

  ---
 ## The problem

  Before EIP-7732, BlockStamp was built directly from `execution_payload` embedded in the CL block body. After the fork, `execution_payload` is absent — the EL block is no longer inline. The oracle must fetch EL data via a different path.

  The critical invariant we maintain: the EL block referenced by `blockstamp.block_hash` must be the same block whose `deposit_requests` are already reflected in `pending_deposits` on the CL state. This ensures CL/EL balance consistency with no correction for deposit asymmetry.

  The chosen reference point is `state.latest_block_hash` — the hash of the last revealed EL block. Per the Gloas spec, when the CL processes slot N, `state.latest_block_hash` equals the EL block hash of slot N−1 (updated by `process_parent_execution_payload`). Its `deposit_requests` have already been processed by `apply_parent_execution_payload`, so they are in `pending_deposits`. Full symmetry.

  This is preferable to using `signed_execution_payload_bid.message.block_hash`(slot N's EL hash), whose `deposit_requests` are not yet on the CL and whose ETH is not yet in the withdrawal vault.

  ---
 ## Changes

  1. New EIP-7732 types (src/providers/consensus/types.py)

  - `execution_payload: ExecutionPayload | None = None` — Optional in BeaconBlockBody; absent on post-fork slots
  - `signed_execution_payload_bid: SignedExecutionPayloadBid | None = None` — builder's EL commitment; absent pre-fork
  - `latest_block_hash: BlockHash` — new field in BeaconStateView; hash of last revealed EL block; defaults to empty string pre-fork

  2. BlockstampBuilder class (src/utils/blockstamp.py)

  Replaces the free functions `get_blockstamp / get_reference_blockstamp` in `slot.py` with a class that holds ConsensusClient and Eth together. This is the hook point for the post-ePBS path:

  - Pre-fork: builds BlockStamp from `execution_payload` as before
  - Post-fork (when `execution_payload is None`): fetches `state.latest_block_hash` via a beacon state request, then retrieves the EL block from the execution client

  Pre-fork:  CL block → `execution_payload → BlockStamp`
  Post-fork: CL block → `state.latest_block_hash → EL client → BlockStamp`

  3. `execute_module` receives BlockDetailsResponse, not BlockStamp (`src/modules/common/daemon_module.py`)

  `DaemonModule.execute_module` previously received a pre-built BlockStamp. Each module now receives the raw BlockDetailsResponse and calls `_blockstamp_builder.build_blockstamp()` as its first step. This is necessary because the pre/post-fork branching logic belongs in the builder, and the builder needs access to the EL client — which isn't available in `DaemonModule._receive_last_finalized_block`.

  4. Generalized beacon API methods (src/providers/consensus/client.py)

  get_attestation_committees, get_sync_committee, get_state_view, and get_validators now accept `tuple[StateRoot, SlotNumber] | BlockStamp` instead of requiring a full BlockStamp. This is required because during post-fork BlockStamp construction, the oracle needs to call get_state_view before it has built a BlockStamp.
