### PR TITLE
feat: call get latest data to record metric updates

### DIFF
--- a/src/modules/oracles/common/consensus.py
+++ b/src/modules/oracles/common/consensus.py
@@ -230,14 +230,13 @@ class ConsensusModule[W3: Web3Base](ABC):
         Returns:
             Non-missed reference slot blockstamp in case the contract is reportable.
         """
-        latest_blockstamp = self._get_latest_blockstamp()
+        latest_blockstamp, member_info = self._get_latest_data()
 
         # Check if the contract is currently reportable
         if not self.is_contract_reportable(latest_blockstamp):
             logger.info({'msg': 'Contract is not reportable.'})
             return None
 
-        member_info = self.get_member_info(latest_blockstamp)
         logger.info({'msg': 'Fetch member info.', 'value': member_info})
 
         # Check if the current slot is higher than the member slot

--- a/tests/modules/submodules/consensus/test_consensus.py
+++ b/tests/modules/submodules/consensus/test_consensus.py
@@ -299,8 +299,8 @@ def test_incompatible_contract_version(consensus):
 @pytest.mark.unit
 def test_get_blockstamp_for_report_contract_is_not_reportable(consensus: ConsensusModule, caplog):
     bs = ReferenceBlockStampFactory.build()
-    consensus._get_latest_blockstamp = Mock(return_value=bs)
-    consensus._check_contract_versions = Mock(return_value=True)
+    member_info = MemberInfoFactory.build()
+    consensus._get_latest_data = Mock(return_value=(bs, member_info))
     consensus.is_contract_reportable = Mock(return_value=False)
 
     consensus.get_blockstamp_for_report(bs)


### PR DESCRIPTION
* Replaces the separate call to `self._get_latest_blockstamp()` with a combined call to `self._get_latest_data()`, which now returns both `latest_blockstamp` and `member_info` in `get_blockstamp_for_report`. (`src/modules/oracles/common/consensus.py`)