### PR TITLE
fix: no strike when slashing and no threshold

### DIFF
--- a/src/modules/oracles/staking_modules/common/distribution.py
+++ b/src/modules/oracles/staking_modules/common/distribution.py
@@ -262,7 +262,8 @@ class Distribution:
             # It means that validator was active during the frame and got slashed and didn't meet the exit
             # epoch, so we should not count such validator for operator's share.
             log_validator.slashed = True
-            return ValidatorDutiesOutcome(participation_share=0, rebate_share=0, strikes=1)
+            strikes = 1 if threshold > 0 else 0
+            return ValidatorDutiesOutcome(participation_share=0, rebate_share=0, strikes=strikes)
 
         performance = perf_coeffs.calc_performance(duties)
 

--- a/tests/modules/csm/test_csm_distribution.py
+++ b/tests/modules/csm/test_csm_distribution.py
@@ -1314,6 +1314,17 @@ def test_get_module_validators_raises_for_key_module_address_mismatch():
             1,
             ValidatorDutiesOutcome(participation_share=0, rebate_share=0, strikes=1),
         ),
+        (
+            ValidatorDuties(
+                attestation=DutyAccumulator(assigned=1, included=1),
+                proposal=DutyAccumulator(assigned=1, included=1),
+                sync=DutyAccumulator(assigned=1, included=1),
+            ),
+            True,
+            0,
+            1,
+            ValidatorDutiesOutcome(participation_share=0, rebate_share=0, strikes=0),
+        ),
     ],
 )
 @pytest.mark.unit


### PR DESCRIPTION
## Description
We should not strike validator when threshold is zero

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
