### PR TITLE
feat(orc-121): add get_blockstamp_by_state to utils

### DIFF
--- a/src/modules/common/daemon_module.py
+++ b/src/modules/common/daemon_module.py
@@ -3,7 +3,6 @@ import signal
 import time
 from abc import ABC, abstractmethod
 from contextlib import AbstractContextManager
-from dataclasses import asdict
 
 from timeout_decorator import timeout
 
@@ -12,14 +11,12 @@ from src.metrics.healthcheck_server import pulse
 from src.metrics.prometheus.basic import (
     CYCLE_COUNT,
     LAST_CYCLE_TIMESTAMP,
-    ORACLE_BLOCK_NUMBER,
-    ORACLE_SLOT_NUMBER,
     CycleResult,
 )
 from src.modules.common.types import ModuleExecuteDelay
 from src.providers.consensus.client import ConsensusClient
-from src.types import BlockRoot, BlockStamp, SlotNumber
-from src.utils.blockstamp import build_blockstamp
+from src.types import BlockStamp, SlotNumber
+from src.utils.blockstamp import get_blockstamp_by_state
 
 
 logger = logging.getLogger(__name__)
@@ -94,13 +91,7 @@ class DaemonModule(ABC):
 
     def _receive_last_finalized_slot(self) -> BlockStamp:
         """Gets last finalized BlockStamp"""
-        block_root = BlockRoot(self.cc.get_block_root('finalized').root)
-        block_details = self.cc.get_block_details(block_root)
-        bs = build_blockstamp(block_details)
-        logger.info({'msg': 'Fetch last finalized BlockStamp.', 'value': asdict(bs)})
-        ORACLE_SLOT_NUMBER.labels('finalized').set(bs.slot_number)
-        ORACLE_BLOCK_NUMBER.labels('finalized').set(bs.block_number)
-        return bs
+        return get_blockstamp_by_state(self.cc, 'finalized')
 
     def run_cycle(self, last_finalized_blockstamp: BlockStamp):
         """Base logic for daemon module cycle execution"""

--- a/src/modules/oracles/common/consensus.py
+++ b/src/modules/oracles/common/consensus.py
@@ -8,11 +8,7 @@ from hexbytes import HexBytes
 from web3.exceptions import ContractCustomError
 
 from src import variables
-from src.metrics.prometheus.basic import (
-    ACCOUNT_BALANCE,
-    ORACLE_BLOCK_NUMBER,
-    ORACLE_SLOT_NUMBER,
-)
+from src.metrics.prometheus.basic import ACCOUNT_BALANCE
 from src.metrics.prometheus.business import (
     FRAME_CURRENT_REF_SLOT,
     FRAME_DEADLINE_SLOT,
@@ -34,7 +30,7 @@ from src.modules.oracles.common.exceptions import (
 from src.providers.execution.contracts.base_oracle import BaseOracleContract
 from src.providers.execution.contracts.hash_consensus import HashConsensusContract
 from src.types import BlockStamp, FrameNumber, ReferenceBlockStamp, SlotNumber
-from src.utils.blockstamp import build_blockstamp
+from src.utils.blockstamp import get_blockstamp_by_state
 from src.utils.cache import global_lru_cache as lru_cache
 from src.utils.slot import get_reference_blockstamp
 from src.utils.web3converter import Web3Converter
@@ -476,13 +472,7 @@ class ConsensusModule[W3: Web3Base](ABC):
         self.w3.transaction.check_and_send_transaction(tx, variables.ACCOUNT)
 
     def _get_latest_blockstamp(self) -> BlockStamp:
-        root = self.w3.cc.get_block_root('head').root
-        block_details = self.w3.cc.get_block_details(root)
-        bs = build_blockstamp(block_details)
-        logger.debug({'msg': 'Fetch latest blockstamp.', 'value': bs})
-        ORACLE_SLOT_NUMBER.labels('head').set(bs.slot_number)
-        ORACLE_BLOCK_NUMBER.labels('head').set(bs.block_number)
-        return bs
+        return get_blockstamp_by_state(self.w3.cc, 'head')
 
     @lru_cache(maxsize=1)
     def _get_slot_delay_before_data_submit(self, blockstamp: BlockStamp) -> int:

--- a/src/utils/blockstamp.py
+++ b/src/utils/blockstamp.py
@@ -1,7 +1,15 @@
+import logging
+from dataclasses import asdict
+
 from eth_utils.hexadecimal import add_0x_prefix
 
+from src.metrics.prometheus.basic import ORACLE_BLOCK_NUMBER, ORACLE_SLOT_NUMBER
+from src.providers.consensus.client import ConsensusClient, LiteralState
 from src.providers.consensus.types import BlockDetailsResponse
 from src.types import BlockStamp, EpochNumber, ReferenceBlockStamp, SlotNumber
+
+
+logger = logging.getLogger(__name__)
 
 
 def build_reference_blockstamp(
@@ -18,6 +26,17 @@ def build_reference_blockstamp(
 
 def build_blockstamp(slot_details: BlockDetailsResponse):
     return BlockStamp(**_build_blockstamp_data(slot_details))
+
+
+def get_blockstamp_by_state(cc: ConsensusClient, state: LiteralState) -> BlockStamp:
+    """Fetch the block for the given chain state and build a BlockStamp from it."""
+    block_root = cc.get_block_root(state).root
+    block_details = cc.get_block_details(block_root)
+    bs = build_blockstamp(block_details)
+    logger.info({'msg': f'Fetch {state} blockstamp.', 'value': asdict(bs)})
+    ORACLE_SLOT_NUMBER.labels(state).set(bs.slot_number)
+    ORACLE_BLOCK_NUMBER.labels(state).set(bs.block_number)
+    return bs
 
 
 def _build_blockstamp_data(

--- a/tests/modules/submodules/consensus/test_consensus.py
+++ b/tests/modules/submodules/consensus/test_consensus.py
@@ -371,11 +371,9 @@ def test_no_report_contract(web3, impl: type[ConsensusModule]):
 
 @pytest.mark.unit
 def test_check_contract_config(consensus: ConsensusModule, monkeypatch: pytest.MonkeyPatch):
-    consensus.w3.cc.get_block_root = Mock(return_value=Mock(root=""))
-    consensus.w3.cc.get_block_details = Mock()
     bs = ReferenceBlockStampFactory.build()
     with monkeypatch.context() as m:
-        m.setattr(consensus_module, "build_blockstamp", Mock(return_value=bs))
+        m.setattr(consensus_module, "get_blockstamp_by_state", Mock(return_value=bs))
         chain_config = cast(ChainConfig, ChainConfigFactory.build())
         consensus.get_chain_config = Mock(return_value=chain_config)
         bc_spec = cast(BeaconSpecResponse, BeaconSpecResponseFactory.build())

--- a/tests/utils/test_blockstamp.py
+++ b/tests/utils/test_blockstamp.py
@@ -1,0 +1,42 @@
+from unittest.mock import Mock
+
+import pytest
+from eth_utils import add_0x_prefix
+
+from src.types import BlockStamp
+from src.utils.blockstamp import get_blockstamp_by_state
+from tests.factory.configs import BlockDetailsResponseFactory
+
+
+@pytest.mark.unit
+class TestGetBlockstampByState:
+    @pytest.fixture
+    def block_details(self):
+        return BlockDetailsResponseFactory.build()
+
+    @pytest.fixture
+    def cc(self, block_details):
+        return Mock(get_block_details=Mock(return_value=block_details))
+
+    def test_get_blockstamp_by_state__finalized__returns_blockstamp(self, cc, block_details):
+        # Act
+        bs = get_blockstamp_by_state(cc, 'finalized')
+
+        # Assert
+        cc.get_block_root.assert_called_once_with('finalized')
+        cc.get_block_details.assert_called_once_with(cc.get_block_root.return_value.root)
+        execution_payload = block_details.message.body.execution_payload
+        assert bs == BlockStamp(
+            state_root=block_details.message.state_root,
+            slot_number=block_details.message.slot,
+            block_hash=add_0x_prefix(execution_payload.block_hash),
+            block_number=execution_payload.block_number,
+            block_timestamp=execution_payload.timestamp,
+        )
+
+    def test_get_blockstamp_by_state__head__requests_head_block(self, cc):
+        # Act
+        get_blockstamp_by_state(cc, 'head')
+
+        # Assert
+        cc.get_block_root.assert_called_once_with('head')


### PR DESCRIPTION
## Description
This pull request refactors how blockstamp data is retrieved and metrics are updated throughout the codebase. The main improvement is the introduction of a new utility function, `get_blockstamp_by_state`, which centralizes the logic for fetching blockstamps and updating Prometheus metrics. This change reduces code duplication and streamlines metric reporting for consensus states.

## Related Issue/Task
- Related task: #[task number] (e.g., #123)
- Epic: [epic name or link, if applicable]

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [x] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
