### PR TITLE
feat(orc-535): remove latest from default calls

### DIFF
--- a/src/modules/checks/suites/common.py
+++ b/src/modules/checks/suites/common.py
@@ -19,7 +19,7 @@ def skip_locator(web3):
 
 @pytest.fixture()
 def skip_csm(web3_cs_module):
-    contract_version = web3_cs_module.staking_module.oracle.get_contract_version()
+    contract_version = web3_cs_module.staking_module.oracle.get_contract_version('latest')
     if contract_version != CSPerformanceOracle.COMPATIBLE_CONTRACT_VERSION:
         pytest.skip(
             f'Staking module contract version {contract_version} is not compatible with CSM '
@@ -29,7 +29,7 @@ def skip_csm(web3_cs_module):
 
 @pytest.fixture()
 def skip_cm(web3_curated_module):
-    contract_version = web3_curated_module.staking_module.oracle.get_contract_version()
+    contract_version = web3_curated_module.staking_module.oracle.get_contract_version('latest')
     if contract_version != CMPerformanceOracle.COMPATIBLE_CONTRACT_VERSION:
         pytest.skip(
             f'Staking module contract version {contract_version} is not compatible with Curated Module '

--- a/src/providers/execution/contracts/accounting.py
+++ b/src/providers/execution/contracts/accounting.py
@@ -18,7 +18,7 @@ class AccountingContract(ContractInterface):
     def simulate_oracle_report(
         self,
         payload: ReportSimulationPayload,
-        block_identifier: BlockIdentifier = 'latest',
+        block_identifier: BlockIdentifier,
     ) -> ReportSimulationResults:
         """
         Simulates the effects of the `handleOracleReport` function without actually updating the contract state.

--- a/src/providers/execution/contracts/accounting_oracle.py
+++ b/src/providers/execution/contracts/accounting_oracle.py
@@ -16,7 +16,7 @@ class AccountingOracleContract(BaseOracleContract):
     abi_path = './assets/AccountingOracle.json'
 
     @lru_cache(maxsize=1)
-    def get_processing_state(self, block_identifier: BlockIdentifier = 'latest') -> AccountingProcessingState:
+    def get_processing_state(self, block_identifier: BlockIdentifier) -> AccountingProcessingState:
         """
         Returns data processing state for the current reporting frame.
         """

--- a/src/providers/execution/contracts/base_oracle.py
+++ b/src/providers/execution/contracts/base_oracle.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 class BaseOracleContract(ContractInterface):
     @lru_cache(maxsize=1)
-    def get_consensus_contract(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def get_consensus_contract(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         """
         Returns the address of the HashConsensus contract.
         """
@@ -30,7 +30,7 @@ class BaseOracleContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def submit_data_role(self, block_identifier: BlockIdentifier = 'latest') -> Hash32:
+    def submit_data_role(self, block_identifier: BlockIdentifier) -> Hash32:
         """
         An ACL role granting the permission to submit the data for a committee report.
         """
@@ -46,7 +46,7 @@ class BaseOracleContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def has_role(self, role: Hash32, address: ChecksumAddress, block_identifier: BlockIdentifier = 'latest') -> bool:
+    def has_role(self, role: Hash32, address: ChecksumAddress, block_identifier: BlockIdentifier) -> bool:
         """
         Returns `true` if `account` has been granted `role`.
         """
@@ -62,7 +62,7 @@ class BaseOracleContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def get_contract_version(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def get_contract_version(self, block_identifier: BlockIdentifier) -> int:
         """
         Returns the current contract version.
         """
@@ -78,7 +78,7 @@ class BaseOracleContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def get_consensus_version(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def get_consensus_version(self, block_identifier: BlockIdentifier) -> int:
         """
         Returns the current consensus version expected by the oracle contract.
         Consensus version must change every time consensus rules change, meaning that
@@ -116,7 +116,7 @@ class BaseOracleContract(ContractInterface):
         return tx
 
     @lru_cache(maxsize=1)
-    def get_last_processing_ref_slot(self, block_identifier: BlockIdentifier = 'latest') -> SlotNumber:
+    def get_last_processing_ref_slot(self, block_identifier: BlockIdentifier) -> SlotNumber:
         """
         Returns the last reference slot for which processing of the report was started.
         HashConsensus won't submit reports for any slot less than or equal to this slot.

--- a/src/providers/execution/contracts/burner.py
+++ b/src/providers/execution/contracts/burner.py
@@ -15,7 +15,7 @@ class BurnerContract(ContractInterface):
     abi_path = './assets/Burner.json'
 
     @lru_cache(maxsize=1)
-    def get_shares_requested_to_burn(self, block_identifier: BlockIdentifier = 'latest') -> SharesRequestedToBurn:
+    def get_shares_requested_to_burn(self, block_identifier: BlockIdentifier) -> SharesRequestedToBurn:
         """
         Returns the current amount of shares locked on the contract to be burnt.
         """

--- a/src/providers/execution/contracts/cs_accounting.py
+++ b/src/providers/execution/contracts/cs_accounting.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 class CSAccountingContract(ContractInterface):
     abi_path = "./assets/CSAccounting.json"
 
-    def fee_distributor(self, block_identifier: BlockIdentifier = "latest") -> ChecksumAddress:
+    def fee_distributor(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         """Returns the address of the CSFeeDistributor contract"""
 
         resp = self.functions.FEE_DISTRIBUTOR().call(block_identifier=block_identifier)
@@ -30,7 +30,7 @@ class CSAccountingContract(ContractInterface):
         return Web3.to_checksum_address(resp)
 
     @lru_cache()
-    def get_bond_curve_id(self, node_operator_id: NodeOperatorId, block_identifier: BlockIdentifier = "latest") -> int:
+    def get_bond_curve_id(self, node_operator_id: NodeOperatorId, block_identifier: BlockIdentifier) -> int:
         """Returns the curve ID"""
 
         resp = self.functions.getBondCurveId(node_operator_id).call(block_identifier=block_identifier)

--- a/src/providers/execution/contracts/cs_fee_distributor.py
+++ b/src/providers/execution/contracts/cs_fee_distributor.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class CSFeeDistributorContract(ContractInterface):
     abi_path = "./assets/CSFeeDistributor.json"
 
-    def oracle(self, block_identifier: BlockIdentifier = "latest") -> ChecksumAddress:
+    def oracle(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         """Returns the address of the CSFeeOracle contract"""
 
         resp = self.functions.ORACLE().call(block_identifier=block_identifier)
@@ -27,7 +27,7 @@ class CSFeeDistributorContract(ContractInterface):
         )
         return Web3.to_checksum_address(resp)
 
-    def shares_to_distribute(self, block_identifier: BlockIdentifier = "latest") -> Wei:
+    def shares_to_distribute(self, block_identifier: BlockIdentifier) -> Wei:
         """Returns the amount of shares that are pending to be distributed"""
 
         resp = self.functions.pendingSharesToDistribute().call(block_identifier=block_identifier)
@@ -40,7 +40,7 @@ class CSFeeDistributorContract(ContractInterface):
         )
         return resp
 
-    def tree_root(self, block_identifier: BlockIdentifier = "latest") -> HexBytes:
+    def tree_root(self, block_identifier: BlockIdentifier) -> HexBytes:
         """Root of the latest published Merkle tree"""
 
         resp = self.functions.treeRoot().call(block_identifier=block_identifier)
@@ -53,7 +53,7 @@ class CSFeeDistributorContract(ContractInterface):
         )
         return HexBytes(resp)
 
-    def tree_cid(self, block_identifier: BlockIdentifier = "latest") -> str:
+    def tree_cid(self, block_identifier: BlockIdentifier) -> str:
         """CID of the latest published Merkle tree"""
 
         resp = self.functions.treeCid().call(block_identifier=block_identifier)

--- a/src/providers/execution/contracts/cs_fee_oracle.py
+++ b/src/providers/execution/contracts/cs_fee_oracle.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class CSFeeOracleContract(BaseOracleContract):
     abi_path = "./assets/CSFeeOracle.json"
 
-    def is_paused(self, block_identifier: BlockIdentifier = "latest") -> bool:
+    def is_paused(self, block_identifier: BlockIdentifier) -> bool:
         """Returns whether the contract is paused"""
 
         resp = self.functions.isPaused().call(block_identifier=block_identifier)
@@ -26,7 +26,7 @@ class CSFeeOracleContract(BaseOracleContract):
         )
         return resp
 
-    def strikes(self, block_identifier: BlockIdentifier = "latest") -> ChecksumAddress:
+    def strikes(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         """Return the address of the CSStrikes contract"""
 
         resp = self.functions.STRIKES().call(block_identifier=block_identifier)

--- a/src/providers/execution/contracts/cs_module.py
+++ b/src/providers/execution/contracts/cs_module.py
@@ -17,7 +17,7 @@ class CSModuleContract(ContractInterface):
 
     MAX_OPERATORS_COUNT = UINT64_MAX
 
-    def accounting(self, block_identifier: BlockIdentifier = "latest") -> ChecksumAddress:
+    def accounting(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         """Returns the address of the CSAccounting contract"""
 
         resp = self.functions.ACCOUNTING().call(block_identifier=block_identifier)
@@ -30,7 +30,7 @@ class CSModuleContract(ContractInterface):
         )
         return Web3.to_checksum_address(resp)
 
-    def parameters_registry(self, block_identifier: BlockIdentifier = "latest") -> ChecksumAddress:
+    def parameters_registry(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         """Returns the address of the CSParametersRegistry contract"""
 
         resp = self.functions.PARAMETERS_REGISTRY().call(block_identifier=block_identifier)
@@ -43,7 +43,7 @@ class CSModuleContract(ContractInterface):
         )
         return Web3.to_checksum_address(resp)
 
-    def is_paused(self, block: BlockIdentifier = "latest") -> bool:
+    def is_paused(self, block: BlockIdentifier) -> bool:
         resp = self.functions.isPaused().call(block_identifier=block)
         logger.info(
             {

--- a/src/providers/execution/contracts/cs_parameters_registry.py
+++ b/src/providers/execution/contracts/cs_parameters_registry.py
@@ -80,7 +80,7 @@ class CSParametersRegistryContract(ContractInterface):
     def get_performance_coefficients(
         self,
         curve_id: int,
-        block_identifier: BlockIdentifier = "latest",
+        block_identifier: BlockIdentifier,
     ) -> PerformanceCoefficients:
         """Returns performance coefficients for given node operator"""
 
@@ -98,7 +98,7 @@ class CSParametersRegistryContract(ContractInterface):
     def get_reward_share_data(
         self,
         curve_id: int,
-        block_identifier: BlockIdentifier = "latest",
+        block_identifier: BlockIdentifier,
     ) -> KeyNumberValueIntervalList:
         """Returns reward share data for given node operator"""
 
@@ -116,7 +116,7 @@ class CSParametersRegistryContract(ContractInterface):
     def get_performance_leeway_data(
         self,
         curve_id: int,
-        block_identifier: BlockIdentifier = "latest",
+        block_identifier: BlockIdentifier,
     ) -> KeyNumberValueIntervalList:
         """Returns performance leeway data for given node operator"""
 
@@ -134,7 +134,7 @@ class CSParametersRegistryContract(ContractInterface):
     def get_strikes_params(
         self,
         curve_id: int,
-        block_identifier: BlockIdentifier = "latest",
+        block_identifier: BlockIdentifier,
     ) -> StrikesParams:
         """Returns strikes params for a given curve id"""
 

--- a/src/providers/execution/contracts/cs_strikes.py
+++ b/src/providers/execution/contracts/cs_strikes.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 class CSStrikesContract(ContractInterface):
     abi_path = "./assets/CSStrikes.json"
 
-    def tree_root(self, block_identifier: BlockIdentifier = "latest") -> HexBytes:
+    def tree_root(self, block_identifier: BlockIdentifier) -> HexBytes:
         """Root of the latest published Merkle tree"""
 
         resp = self.functions.treeRoot().call(block_identifier=block_identifier)
@@ -25,7 +25,7 @@ class CSStrikesContract(ContractInterface):
         )
         return HexBytes(resp)
 
-    def tree_cid(self, block_identifier: BlockIdentifier = "latest") -> str:
+    def tree_cid(self, block_identifier: BlockIdentifier) -> str:
         """CID of the latest published Merkle tree"""
 
         resp = self.functions.treeCid().call(block_identifier=block_identifier)

--- a/src/providers/execution/contracts/delegation_contract.py
+++ b/src/providers/execution/contracts/delegation_contract.py
@@ -38,7 +38,7 @@ class DelegationContract(ContractInterface):
         )
         return tx
 
-    def get_admin(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def get_admin(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         """Get current admin address"""
         response = self.functions.admin().call(block_identifier=block_identifier)
         logger.info(
@@ -46,7 +46,7 @@ class DelegationContract(ContractInterface):
         )
         return Web3.to_checksum_address(response)
 
-    def get_delegatee(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def get_delegatee(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         """Get current delegatee address"""
         response = self.functions.delegatee().call(block_identifier=block_identifier)
         logger.info(

--- a/src/providers/execution/contracts/exit_bus_oracle.py
+++ b/src/providers/execution/contracts/exit_bus_oracle.py
@@ -15,7 +15,7 @@ class ExitBusOracleContract(BaseOracleContract):
     abi_path = './assets/ValidatorsExitBusOracle.json'
 
     @lru_cache(maxsize=1)
-    def is_paused(self, block_identifier: BlockIdentifier = 'latest') -> bool:
+    def is_paused(self, block_identifier: BlockIdentifier) -> bool:
         """
         Returns whether the contract is paused.
         """
@@ -31,7 +31,7 @@ class ExitBusOracleContract(BaseOracleContract):
         return response
 
     @lru_cache(maxsize=1)
-    def get_processing_state(self, block_identifier: BlockIdentifier = 'latest') -> EjectorProcessingState:
+    def get_processing_state(self, block_identifier: BlockIdentifier) -> EjectorProcessingState:
         """
         Returns data processing state for the current reporting frame.
         """

--- a/src/providers/execution/contracts/hash_consensus.py
+++ b/src/providers/execution/contracts/hash_consensus.py
@@ -18,7 +18,7 @@ class HashConsensusContract(ContractInterface):
     abi_path = './assets/HashConsensus.json'
 
     @lru_cache(maxsize=1)
-    def get_members(self, block_identifier: BlockIdentifier = 'latest') -> tuple[list[ChecksumAddress], list[int]]:
+    def get_members(self, block_identifier: BlockIdentifier) -> tuple[list[ChecksumAddress], list[int]]:
         """
         Returns all current members, together with the last reference slot each member
         submitted a report for.
@@ -37,7 +37,7 @@ class HashConsensusContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def get_chain_config(self, block_identifier: BlockIdentifier = 'latest') -> ChainConfig:
+    def get_chain_config(self, block_identifier: BlockIdentifier) -> ChainConfig:
         """
         Returns the immutable chain parameters required to calculate epoch and slot
         given a timestamp.
@@ -57,7 +57,7 @@ class HashConsensusContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def get_current_frame(self, block_identifier: BlockIdentifier = 'latest') -> CurrentFrame:
+    def get_current_frame(self, block_identifier: BlockIdentifier) -> CurrentFrame:
         """
         Returns the current reporting frame.
 
@@ -84,7 +84,7 @@ class HashConsensusContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def get_initial_ref_slot(self, block_identifier: BlockIdentifier = 'latest') -> SlotNumber:
+    def get_initial_ref_slot(self, block_identifier: BlockIdentifier) -> SlotNumber:
         """
         Returns the earliest possible reference slot,
         i.e. the reference slot of the reporting frame with zero index.
@@ -103,7 +103,7 @@ class HashConsensusContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def get_frame_config(self, block_identifier: BlockIdentifier = 'latest') -> FrameConfig:
+    def get_frame_config(self, block_identifier: BlockIdentifier) -> FrameConfig:
         """
         Returns the time-related configuration.
 
@@ -126,9 +126,7 @@ class HashConsensusContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def get_consensus_state_for_member(
-        self, address: ChecksumAddress, block_identifier: BlockIdentifier = 'latest'
-    ) -> tuple:
+    def get_consensus_state_for_member(self, address: ChecksumAddress, block_identifier: BlockIdentifier) -> tuple:
         """
         Returns the extended information related to an oracle committee member with the
         given address and the current consensus state. Provides all the information needed for

--- a/src/providers/execution/contracts/lazy_oracle.py
+++ b/src/providers/execution/contracts/lazy_oracle.py
@@ -23,7 +23,7 @@ class LazyOracleContract(ContractInterface):
     abi_path = './assets/LazyOracle.json'
 
     @lru_cache(maxsize=1)
-    def get_vaults_count(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def get_vaults_count(self, block_identifier: BlockIdentifier) -> int:
         """
         Returns the number of vaults attached to the VaultHub.
         """
@@ -40,7 +40,7 @@ class LazyOracleContract(ContractInterface):
 
         return response
 
-    def get_latest_report_data(self, block_identifier: BlockIdentifier = 'latest') -> OnChainIpfsVaultReportData:
+    def get_latest_report_data(self, block_identifier: BlockIdentifier) -> OnChainIpfsVaultReportData:
         response = self.functions.latestReportData.call(block_identifier=block_identifier)
 
         logger.info(
@@ -55,7 +55,7 @@ class LazyOracleContract(ContractInterface):
         response = named_tuple_to_dataclass(response, OnChainIpfsVaultReportData)
         return response
 
-    def get_vaults(self, offset: int, limit: int, block_identifier: BlockIdentifier = 'latest') -> list[VaultInfo]:
+    def get_vaults(self, offset: int, limit: int, block_identifier: BlockIdentifier) -> list[VaultInfo]:
         """
         Returns the Vaults
         """
@@ -93,7 +93,7 @@ class LazyOracleContract(ContractInterface):
 
         return out
 
-    def get_all_vaults(self, block_identifier: BlockIdentifier = 'latest') -> list[VaultInfo]:
+    def get_all_vaults(self, block_identifier: BlockIdentifier) -> list[VaultInfo]:
         """
         Fetch all vaults using pagination via `get_vaults` in batches of `page_size`.
         """
@@ -119,7 +119,7 @@ class LazyOracleContract(ContractInterface):
         self,
         pubkeys: list[str],
         batch_size: int,
-        block_identifier: BlockIdentifier = 'latest',
+        block_identifier: BlockIdentifier,
     ) -> dict[str, ValidatorStatus]:
         """
         Fetch validator statuses for a list of pubkeys, batching requests for efficiency.

--- a/src/providers/execution/contracts/lido.py
+++ b/src/providers/execution/contracts/lido.py
@@ -15,7 +15,7 @@ class LidoContract(ContractInterface):
     abi_path = './assets/Lido.json'
 
     @lru_cache(maxsize=1)
-    def get_withdrawals_reserve(self, block_identifier: BlockIdentifier = 'latest') -> Wei:
+    def get_withdrawals_reserve(self, block_identifier: BlockIdentifier) -> Wei:
         """
         Return the amount of ETH reserved to satisfy withdrawals, in wei.
         """
@@ -32,7 +32,7 @@ class LidoContract(ContractInterface):
         return Wei(response)
 
     @lru_cache(maxsize=1)
-    def total_supply(self, block_identifier: BlockIdentifier = 'latest') -> Wei:
+    def total_supply(self, block_identifier: BlockIdentifier) -> Wei:
         """
         return the amount of tokens in existence.
 
@@ -52,7 +52,7 @@ class LidoContract(ContractInterface):
         return Wei(response)
 
     @lru_cache(maxsize=1)
-    def get_beacon_stat(self, block_identifier: BlockIdentifier = 'latest') -> BeaconStat:
+    def get_beacon_stat(self, block_identifier: BlockIdentifier) -> BeaconStat:
         """
         Returns the key values related to Consensus Layer side of the contract. It historically contains beacon
 

--- a/src/providers/execution/contracts/lido_locator.py
+++ b/src/providers/execution/contracts/lido_locator.py
@@ -14,7 +14,7 @@ class LidoLocatorContract(ContractInterface):
     abi_path = './assets/LidoLocator.json'
 
     @lru_cache(maxsize=1)
-    def lido(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def lido(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.lido().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -28,7 +28,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def accounting(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def accounting(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.accounting().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -42,7 +42,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def accounting_oracle(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def accounting_oracle(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.accountingOracle().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -56,7 +56,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def staking_router(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def staking_router(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.stakingRouter().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -70,7 +70,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def validator_exit_bus_oracle(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def validator_exit_bus_oracle(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.validatorsExitBusOracle().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -84,7 +84,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def withdrawal_queue(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def withdrawal_queue(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.withdrawalQueue().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -98,7 +98,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def oracle_report_sanity_checker(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def oracle_report_sanity_checker(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.oracleReportSanityChecker().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -112,7 +112,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def oracle_daemon_config(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def oracle_daemon_config(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.oracleDaemonConfig().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -126,7 +126,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def burner(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def burner(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.burner().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -140,7 +140,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def withdrawal_vault(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def withdrawal_vault(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.withdrawalVault().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -154,7 +154,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def el_rewards_vault(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def el_rewards_vault(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.elRewardsVault().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -168,7 +168,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def vault_hub(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def vault_hub(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.vaultHub().call(block_identifier=block_identifier)
 
         logger.debug(
@@ -182,7 +182,7 @@ class LidoLocatorContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def lazy_oracle(self, block_identifier: BlockIdentifier = 'latest') -> ChecksumAddress:
+    def lazy_oracle(self, block_identifier: BlockIdentifier) -> ChecksumAddress:
         response = self.functions.lazyOracle().call(block_identifier=block_identifier)
 
         logger.debug(

--- a/src/providers/execution/contracts/oracle_daemon_config.py
+++ b/src/providers/execution/contracts/oracle_daemon_config.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 class OracleDaemonConfigContract(ContractInterface):
     abi_path = './assets/OracleDaemonConfig.json'
 
-    def _get(self, param: str, block_identifier: BlockIdentifier = 'latest') -> int:
+    def _get(self, param: str, block_identifier: BlockIdentifier) -> int:
         response = Web3.to_int(self.functions.get(param).call(block_identifier=block_identifier))
 
         logger.info(
@@ -27,37 +27,37 @@ class OracleDaemonConfigContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def normalized_cl_reward_per_epoch(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def normalized_cl_reward_per_epoch(self, block_identifier: BlockIdentifier) -> int:
         return self._get('NORMALIZED_CL_REWARD_PER_EPOCH', block_identifier)
 
     @lru_cache(maxsize=1)
-    def normalized_cl_reward_mistake_rate_bp(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def normalized_cl_reward_mistake_rate_bp(self, block_identifier: BlockIdentifier) -> int:
         return self._get('NORMALIZED_CL_REWARD_MISTAKE_RATE_BP', block_identifier)
 
     @lru_cache(maxsize=1)
-    def rebase_check_nearest_epoch_distance(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def rebase_check_nearest_epoch_distance(self, block_identifier: BlockIdentifier) -> int:
         return self._get('REBASE_CHECK_NEAREST_EPOCH_DISTANCE', block_identifier)
 
     @lru_cache(maxsize=1)
-    def rebase_check_distant_epoch_distance(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def rebase_check_distant_epoch_distance(self, block_identifier: BlockIdentifier) -> int:
         return self._get('REBASE_CHECK_DISTANT_EPOCH_DISTANCE', block_identifier)
 
     @lru_cache(maxsize=1)
-    def prediction_duration_in_slots(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def prediction_duration_in_slots(self, block_identifier: BlockIdentifier) -> int:
         return self._get('PREDICTION_DURATION_IN_SLOTS', block_identifier)
 
     @lru_cache(maxsize=1)
-    def finalization_max_negative_rebase_epoch_shift(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def finalization_max_negative_rebase_epoch_shift(self, block_identifier: BlockIdentifier) -> int:
         return self._get('FINALIZATION_MAX_NEGATIVE_REBASE_EPOCH_SHIFT', block_identifier)
 
     @lru_cache(maxsize=1)
-    def exit_events_lookback_window_in_slots(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def exit_events_lookback_window_in_slots(self, block_identifier: BlockIdentifier) -> int:
         return self._get('EXIT_EVENTS_LOOKBACK_WINDOW_IN_SLOTS', block_identifier)
 
     @lru_cache(maxsize=1)
-    def slashing_reserve_we_left_shift(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def slashing_reserve_we_left_shift(self, block_identifier: BlockIdentifier) -> int:
         return self._get('SLASHING_RESERVE_WE_LEFT_SHIFT', block_identifier)
 
     @lru_cache(maxsize=1)
-    def slashing_reserve_we_right_shift(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def slashing_reserve_we_right_shift(self, block_identifier: BlockIdentifier) -> int:
         return self._get('SLASHING_RESERVE_WE_RIGHT_SHIFT', block_identifier)

--- a/src/providers/execution/contracts/oracle_report_sanity_checker.py
+++ b/src/providers/execution/contracts/oracle_report_sanity_checker.py
@@ -15,7 +15,7 @@ class OracleReportSanityCheckerContract(ContractInterface):
     abi_path = './assets/OracleReportSanityChecker.json'
 
     @lru_cache(maxsize=1)
-    def get_oracle_report_limits(self, block_identifier: BlockIdentifier = 'latest') -> OracleReportLimits:
+    def get_oracle_report_limits(self, block_identifier: BlockIdentifier) -> OracleReportLimits:
         """
         Returns the limits list for the Lido's oracle report sanity checks
         """

--- a/src/providers/execution/contracts/staking_router.py
+++ b/src/providers/execution/contracts/staking_router.py
@@ -17,7 +17,7 @@ class StakingRouterContract(ContractInterface):
     abi_path = './assets/StakingRouter.json'
 
     @lru_cache(maxsize=1)
-    def get_contract_version(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def get_contract_version(self, block_identifier: BlockIdentifier) -> int:
         response = self.functions.getContractVersion().call(block_identifier=block_identifier)
         logger.debug(
             {
@@ -30,7 +30,7 @@ class StakingRouterContract(ContractInterface):
         return response
 
     def get_all_node_operator_digests(
-        self, module: StakingModule, block_identifier: BlockIdentifier = 'latest'
+        self, module: StakingModule, block_identifier: BlockIdentifier
     ) -> list[NodeOperator]:
         """
         Returns node operator digests for each node operator in staking module

--- a/src/providers/execution/contracts/withdrawal_queue_nft.py
+++ b/src/providers/execution/contracts/withdrawal_queue_nft.py
@@ -15,7 +15,7 @@ class WithdrawalQueueNftContract(ContractInterface):
     abi_path = './assets/WithdrawalQueueERC721.json'
 
     @lru_cache(maxsize=1)
-    def unfinalized_steth(self, block_identifier: BlockIdentifier = 'latest') -> Wei:
+    def unfinalized_steth(self, block_identifier: BlockIdentifier) -> Wei:
         """
         Returns the amount of stETH in the queue yet to be finalized
         """
@@ -31,7 +31,7 @@ class WithdrawalQueueNftContract(ContractInterface):
         return Wei(response)
 
     @lru_cache(maxsize=1)
-    def bunker_mode_since_timestamp(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def bunker_mode_since_timestamp(self, block_identifier: BlockIdentifier) -> int:
         """
         Get bunker mode activation timestamp.
 
@@ -50,7 +50,7 @@ class WithdrawalQueueNftContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def get_last_finalized_request_id(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def get_last_finalized_request_id(self, block_identifier: BlockIdentifier) -> int:
         """
         id of the last finalized request
         NB! requests are indexed from 1, so it returns 0 if there is no finalized requests in the queue
@@ -68,9 +68,7 @@ class WithdrawalQueueNftContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def get_withdrawal_status(
-        self, request_id: int, block_identifier: BlockIdentifier = 'latest'
-    ) -> WithdrawalRequestStatus:
+    def get_withdrawal_status(self, request_id: int, block_identifier: BlockIdentifier) -> WithdrawalRequestStatus:
         """
         Returns status for requests with provided ids
         request_id: id of request to check status
@@ -89,7 +87,7 @@ class WithdrawalQueueNftContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def get_last_request_id(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def get_last_request_id(self, block_identifier: BlockIdentifier) -> int:
         """
         returns id of the last request
         NB! requests are indexed from 1, so it returns 0 if there is no requests in the queue
@@ -107,7 +105,7 @@ class WithdrawalQueueNftContract(ContractInterface):
         return response
 
     @lru_cache(maxsize=1)
-    def is_paused(self, block_identifier: BlockIdentifier = 'latest') -> bool:
+    def is_paused(self, block_identifier: BlockIdentifier) -> bool:
         """
         Returns whether the withdrawal queue is paused
         """
@@ -139,7 +137,7 @@ class WithdrawalQueueNftContract(ContractInterface):
         return Wei(response)
 
     @lru_cache(maxsize=1)
-    def max_batches_length(self, block_identifier: BlockIdentifier = 'latest') -> int:
+    def max_batches_length(self, block_identifier: BlockIdentifier) -> int:
         """
         maximal length of the batch array provided for prefinalization.
         """
@@ -161,7 +159,7 @@ class WithdrawalQueueNftContract(ContractInterface):
         timestamp: int,
         max_batch_request_count: int,
         batch_state: tuple,
-        block_identifier: BlockIdentifier = 'latest',
+        block_identifier: BlockIdentifier,
     ) -> BatchState:
         """
         Offchain view for the oracle daemon that calculates how many requests can be finalized within

--- a/src/services/safe_border.py
+++ b/src/services/safe_border.py
@@ -237,7 +237,7 @@ class SafeBorder(Web3Converter):
             return EpochNumber(0)
 
         last_finalized_request_data = self.w3.lido_contracts.withdrawal_queue_nft.get_withdrawal_status(
-            last_finalized_request_id
+            last_finalized_request_id, self.blockstamp.block_hash
         )
 
         return self.get_epoch_by_timestamp(last_finalized_request_data.timestamp)

--- a/src/services/staking_vaults.py
+++ b/src/services/staking_vaults.py
@@ -67,7 +67,7 @@ class StakingVaultsService:
     def __init__(self, w3: Web3) -> None:
         self.w3 = w3
 
-    def get_vaults(self, block_identifier: BlockIdentifier = 'latest') -> VaultsMap:
+    def get_vaults(self, block_identifier: BlockIdentifier) -> VaultsMap:
         vaults = self.w3.lido_contracts.lazy_oracle.get_all_vaults(block_identifier=block_identifier)
         return VaultsMap({v.vault: v for v in vaults})
 
@@ -76,7 +76,7 @@ class StakingVaultsService:
         vaults: VaultsMap,
         validators: list[Validator],
         pending_deposits: list[PendingDeposit],
-        block_identifier: BlockIdentifier = 'latest',
+        block_identifier: BlockIdentifier,
     ) -> VaultTotalValueMap:
         """
         Calculates the Total Value (TV) across all staking vaults connected to the protocol.

--- a/src/web3py/extensions/contracts.py
+++ b/src/web3py/extensions/contracts.py
@@ -80,7 +80,7 @@ class LidoContracts(Module):
         self.lido: LidoContract = cast(
             LidoContract,
             self.w3.eth.contract(
-                address=self.lido_locator.lido(),
+                address=self.lido_locator.lido('latest'),
                 ContractFactoryClass=LidoContract,
                 decode_tuples=True,
             ),
@@ -89,7 +89,7 @@ class LidoContracts(Module):
         self.accounting_oracle: AccountingOracleContract = cast(
             AccountingOracleContract,
             self.w3.eth.contract(
-                address=self.lido_locator.accounting_oracle(),
+                address=self.lido_locator.accounting_oracle('latest'),
                 ContractFactoryClass=AccountingOracleContract,
                 decode_tuples=True,
             ),
@@ -98,7 +98,7 @@ class LidoContracts(Module):
         self.validators_exit_bus_oracle: ExitBusOracleContract = cast(
             ExitBusOracleContract,
             self.w3.eth.contract(
-                address=self.lido_locator.validator_exit_bus_oracle(),
+                address=self.lido_locator.validator_exit_bus_oracle('latest'),
                 ContractFactoryClass=ExitBusOracleContract,
                 decode_tuples=True,
             ),
@@ -107,7 +107,7 @@ class LidoContracts(Module):
         self.withdrawal_queue_nft: WithdrawalQueueNftContract = cast(
             WithdrawalQueueNftContract,
             self.w3.eth.contract(
-                address=self.lido_locator.withdrawal_queue(),
+                address=self.lido_locator.withdrawal_queue('latest'),
                 ContractFactoryClass=WithdrawalQueueNftContract,
                 decode_tuples=True,
             ),
@@ -116,7 +116,7 @@ class LidoContracts(Module):
         self.oracle_report_sanity_checker: OracleReportSanityCheckerContract = cast(
             OracleReportSanityCheckerContract,
             self.w3.eth.contract(
-                address=self.lido_locator.oracle_report_sanity_checker(),
+                address=self.lido_locator.oracle_report_sanity_checker('latest'),
                 ContractFactoryClass=OracleReportSanityCheckerContract,
                 decode_tuples=True,
             ),
@@ -125,7 +125,7 @@ class LidoContracts(Module):
         self.oracle_daemon_config: OracleDaemonConfigContract = cast(
             OracleDaemonConfigContract,
             self.w3.eth.contract(
-                address=self.lido_locator.oracle_daemon_config(),
+                address=self.lido_locator.oracle_daemon_config('latest'),
                 ContractFactoryClass=OracleDaemonConfigContract,
                 decode_tuples=True,
             ),
@@ -134,7 +134,7 @@ class LidoContracts(Module):
         self.burner: BurnerContract = cast(
             BurnerContract,
             self.w3.eth.contract(
-                address=self.lido_locator.burner(),
+                address=self.lido_locator.burner('latest'),
                 ContractFactoryClass=BurnerContract,
                 decode_tuples=True,
             ),
@@ -143,7 +143,7 @@ class LidoContracts(Module):
         self.staking_router = cast(
             StakingRouterContract,
             self.w3.eth.contract(
-                address=self.lido_locator.staking_router(),
+                address=self.lido_locator.staking_router('latest'),
                 ContractFactoryClass=StakingRouterContract,
                 decode_tuples=True,
             ),
@@ -152,7 +152,7 @@ class LidoContracts(Module):
         self.accounting = cast(
             AccountingContract,
             self.w3.eth.contract(
-                address=self.lido_locator.accounting(),
+                address=self.lido_locator.accounting('latest'),
                 ContractFactoryClass=AccountingContract,
                 decode_tuples=True,
             ),
@@ -161,7 +161,7 @@ class LidoContracts(Module):
         self.lazy_oracle = cast(
             LazyOracleContract,
             self.w3.eth.contract(
-                address=self.lido_locator.lazy_oracle(),
+                address=self.lido_locator.lazy_oracle('latest'),
                 ContractFactoryClass=LazyOracleContract,
                 decode_tuples=True,
             ),
@@ -170,7 +170,7 @@ class LidoContracts(Module):
         self.vault_hub = cast(
             VaultHubContract,
             self.w3.eth.contract(
-                address=self.lido_locator.vault_hub(),
+                address=self.lido_locator.vault_hub('latest'),
                 ContractFactoryClass=VaultHubContract,
                 decode_tuples=True,
             ),

--- a/src/web3py/extensions/delegation.py
+++ b/src/web3py/extensions/delegation.py
@@ -82,7 +82,7 @@ class DelegationModule(Module):
             logger.warning({'msg': 'Skipping delegation validation - ACCOUNT is not set'})
             return
 
-        current_delegatee = self.delegation_contract.get_delegatee()
+        current_delegatee = self.delegation_contract.get_delegatee('latest')
         oracle_address = cast(ChecksumAddress, variables.ACCOUNT.address)
 
         if current_delegatee == '0x0000000000000000000000000000000000000000':
@@ -97,7 +97,7 @@ class DelegationModule(Module):
                 f"Admin must call assignDelegate({oracle_address})"
             )
 
-        admin_address = self.delegation_contract.get_admin()
+        admin_address = self.delegation_contract.get_admin('latest')
 
         logger.info(
             {

--- a/src/web3py/extensions/staking_module.py
+++ b/src/web3py/extensions/staking_module.py
@@ -100,7 +100,7 @@ class StakingModuleContracts(Module):
                 self.params = cast(
                     CSParametersRegistryContract,
                     self.w3.eth.contract(
-                        address=self.module.parameters_registry(),
+                        address=self.module.parameters_registry('latest'),
                         ContractFactoryClass=CSParametersRegistryContract,
                         decode_tuples=True,
                     ),
@@ -109,7 +109,7 @@ class StakingModuleContracts(Module):
                 self.accounting = cast(
                     CSAccountingContract,
                     self.w3.eth.contract(
-                        address=self.module.accounting(),
+                        address=self.module.accounting('latest'),
                         ContractFactoryClass=CSAccountingContract,
                         decode_tuples=True,
                     ),
@@ -118,7 +118,7 @@ class StakingModuleContracts(Module):
                 self.fee_distributor = cast(
                     CSFeeDistributorContract,
                     self.w3.eth.contract(
-                        address=self.accounting.fee_distributor(),
+                        address=self.accounting.fee_distributor('latest'),
                         ContractFactoryClass=CSFeeDistributorContract,
                         decode_tuples=True,
                     ),
@@ -127,7 +127,7 @@ class StakingModuleContracts(Module):
                 self.oracle = cast(
                     CSFeeOracleContract,
                     self.w3.eth.contract(
-                        address=self.fee_distributor.oracle(),
+                        address=self.fee_distributor.oracle('latest'),
                         ContractFactoryClass=CSFeeOracleContract,
                         decode_tuples=True,
                     ),
@@ -136,7 +136,7 @@ class StakingModuleContracts(Module):
                 self.strikes = cast(
                     CSStrikesContract,
                     self.w3.eth.contract(
-                        address=self.oracle.strikes(),
+                        address=self.oracle.strikes('latest'),
                         ContractFactoryClass=CSStrikesContract,
                         decode_tuples=True,
                     ),
@@ -160,11 +160,11 @@ class StakingModuleContracts(Module):
     def _get_contract_addresses(self) -> tuple[str, ...]:
         return (
             self.module.address,
-            self.module.accounting(),
-            self.module.parameters_registry(),
-            self.accounting.fee_distributor(),
-            self.fee_distributor.oracle(),
-            self.oracle.strikes(),
+            self.module.accounting('latest'),
+            self.module.parameters_registry('latest'),
+            self.accounting.fee_distributor('latest'),
+            self.fee_distributor.oracle('latest'),
+            self.oracle.strikes('latest'),
         )
 
     def has_contract_address_changed(self) -> bool:

--- a/tests/execution/contracts/test_contract_transformations.py
+++ b/tests/execution/contracts/test_contract_transformations.py
@@ -306,6 +306,7 @@ class TestLazyOracleGetVaults:
         assert v.max_liability_shares == 200
         assert v.reserve_ratio_bp == 1000
         assert v.pending_disconnect is False
+        contract.functions.batchVaultsInfo.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_withdrawal_credentials_converted_to_hex(self):
         contract = _mock_contract()
@@ -316,6 +317,7 @@ class TestLazyOracleGetVaults:
 
         assert result[0].withdrawal_credentials.startswith("0x")
         assert "ab" in result[0].withdrawal_credentials.lower()
+        contract.functions.batchVaultsInfo.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_empty_response(self):
         contract = _mock_contract()
@@ -324,6 +326,7 @@ class TestLazyOracleGetVaults:
         result = LazyOracleContract.get_vaults(contract, offset=0, limit=10, block_identifier="latest")
 
         assert result == []
+        contract.functions.batchVaultsInfo.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_passes_offset_and_limit(self):
         contract = _mock_contract()
@@ -332,6 +335,7 @@ class TestLazyOracleGetVaults:
         LazyOracleContract.get_vaults(contract, offset=50, limit=25, block_identifier="latest")
 
         contract.functions.batchVaultsInfo.assert_called_once_with(50, 25)
+        contract.functions.batchVaultsInfo.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -351,6 +355,7 @@ class TestLazyOracleGetAllVaults:
         result = LazyOracleContract.get_all_vaults(contract, block_identifier="latest")
 
         assert result == []
+        contract.get_vaults_count.assert_called_once_with("latest")
         contract.get_vaults.assert_not_called()
 
     def test_single_page(self, monkeypatch):
@@ -363,6 +368,7 @@ class TestLazyOracleGetAllVaults:
         result = LazyOracleContract.get_all_vaults(contract, block_identifier="latest")
 
         assert len(result) == 2
+        contract.get_vaults_count.assert_called_once_with("latest")
         contract.get_vaults.assert_called_once_with(block_identifier="latest", offset=0, limit=100)
 
     def test_multiple_pages(self, monkeypatch):
@@ -378,6 +384,7 @@ class TestLazyOracleGetAllVaults:
 
         assert len(result) == 3
         assert contract.get_vaults.call_count == 2
+        contract.get_vaults_count.assert_called_once_with("latest")
         contract.get_vaults.assert_any_call(block_identifier="latest", offset=0, limit=2)
         contract.get_vaults.assert_any_call(block_identifier="latest", offset=2, limit=2)
 
@@ -390,6 +397,8 @@ class TestLazyOracleGetAllVaults:
         result = LazyOracleContract.get_all_vaults(contract, block_identifier="latest")
 
         assert result == []
+        contract.get_vaults_count.assert_called_once_with("latest")
+        contract.get_vaults.assert_called_once_with(block_identifier="latest", offset=0, limit=100)
 
 
 # ---------------------------------------------------------------------------
@@ -428,6 +437,7 @@ class TestLazyOracleGetValidatorStatuses:
 
         assert pk in result
         assert result[pk].stage == ValidatorStage.ACTIVATED
+        contract.functions.batchValidatorStatuses.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_multiple_batches(self):
         contract = _mock_contract()
@@ -442,6 +452,7 @@ class TestLazyOracleGetValidatorStatuses:
 
         assert len(result) == 3
         assert contract.functions.batchValidatorStatuses.call_count == 2
+        contract.functions.batchValidatorStatuses.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_result_keyed_by_0x_pubkey(self):
         contract = _mock_contract()
@@ -454,6 +465,7 @@ class TestLazyOracleGetValidatorStatuses:
 
         key = next(iter(result))
         assert key.startswith("0x")
+        contract.functions.batchValidatorStatuses.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -482,6 +494,7 @@ class TestStakingRouterGetAllNodeOperatorDigests:
 
         assert len(result) == 2
         assert contract.functions.getNodeOperatorDigests.call_count == 1
+        contract.functions.getNodeOperatorDigests.return_value.call.assert_called_with(block_identifier="latest")
 
     @patch("src.providers.execution.contracts.staking_router.NodeOperator.from_response")
     def test_multiple_pages(self, mock_from_response, monkeypatch):
@@ -501,6 +514,7 @@ class TestStakingRouterGetAllNodeOperatorDigests:
 
         assert len(result) == 3
         assert contract.functions.getNodeOperatorDigests.call_count == 2
+        contract.functions.getNodeOperatorDigests.return_value.call.assert_called_with(block_identifier="latest")
 
     @patch("src.providers.execution.contracts.staking_router.NodeOperator.from_response")
     def test_empty_first_response(self, mock_from_response, monkeypatch):
@@ -513,6 +527,7 @@ class TestStakingRouterGetAllNodeOperatorDigests:
         )
 
         assert result == []
+        contract.functions.getNodeOperatorDigests.return_value.call.assert_called_with(block_identifier="latest")
 
     @patch("src.providers.execution.contracts.staking_router.NodeOperator.from_response")
     def test_uses_correct_offsets(self, mock_from_response, monkeypatch):
@@ -527,6 +542,7 @@ class TestStakingRouterGetAllNodeOperatorDigests:
 
         contract.functions.getNodeOperatorDigests.assert_any_call(3, 0, 2)
         contract.functions.getNodeOperatorDigests.assert_any_call(3, 2, 2)
+        contract.functions.getNodeOperatorDigests.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -947,6 +963,7 @@ class TestAccountingSimulateOracleReport:
         AccountingContract.simulate_oracle_report(contract, payload, block_identifier="latest")
 
         contract.functions.simulateOracleReport.assert_called_once_with(payload.as_tuple())
+        contract.functions.simulateOracleReport.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_returns_report_simulation_results(self):
         contract = _mock_contract()
@@ -959,6 +976,7 @@ class TestAccountingSimulateOracleReport:
         assert result.withdrawals_vault_transfer == 1
         assert result.el_rewards_vault_transfer == 2
         assert result.post_total_pooled_ether == 14
+        contract.functions.simulateOracleReport.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -981,6 +999,7 @@ class TestWithdrawalQueueCalculateFinalizationBatches:
             timestamp=1000,
             max_batch_request_count=100,
             batch_state=(5000, False, [], 0),
+            block_identifier="latest",
         )
 
         assert isinstance(result, BatchState)
@@ -988,6 +1007,7 @@ class TestWithdrawalQueueCalculateFinalizationBatches:
         assert result.finished is False
         assert result.batches == [10, 20]
         assert result.batches_length == 2
+        contract.functions.calculateFinalizationBatches.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_passes_all_args_to_contract(self):
         contract = _mock_contract()
@@ -1004,6 +1024,7 @@ class TestWithdrawalQueueCalculateFinalizationBatches:
         )
 
         contract.functions.calculateFinalizationBatches.assert_called_once_with(123, 456, 50, (0, True, [], 0))
+        contract.functions.calculateFinalizationBatches.return_value.call.assert_called_with(block_identifier=999)
 
 
 # ===========================================================================
@@ -1089,6 +1110,7 @@ def test_lido_locator_pass_throughs(method, fn_attr):
     getattr(contract.functions, fn_attr).return_value.call.return_value = _ADDR
     result = getattr(LidoLocatorContract, method)(contract, block_identifier="latest")
     assert result == _ADDR
+    getattr(contract.functions, fn_attr).return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -1104,6 +1126,7 @@ class TestHashConsensusContract:
         contract.functions.getMembers.return_value.call.return_value = expected
         result = HashConsensusContract.get_members(contract, block_identifier="latest")
         assert result == expected
+        contract.functions.getMembers.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_chain_config(self):
         contract = _mock_contract()
@@ -1113,6 +1136,7 @@ class TestHashConsensusContract:
         assert result.slots_per_epoch == 32
         assert result.seconds_per_slot == 12
         assert result.genesis_time == 1000
+        contract.functions.getChainConfig.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_current_frame(self):
         contract = _mock_contract()
@@ -1121,12 +1145,14 @@ class TestHashConsensusContract:
         assert isinstance(result, CurrentFrame)
         assert result.ref_slot == 500
         assert result.report_processing_deadline_slot == 600
+        contract.functions.getCurrentFrame.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_initial_ref_slot(self):
         contract = _mock_contract()
         contract.functions.getInitialRefSlot.return_value.call.return_value = 42
         result = HashConsensusContract.get_initial_ref_slot(contract, block_identifier="latest")
         assert result == 42
+        contract.functions.getInitialRefSlot.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_frame_config(self):
         contract = _mock_contract()
@@ -1135,6 +1161,7 @@ class TestHashConsensusContract:
         assert isinstance(result, FrameConfig)
         assert result.initial_epoch == 1
         assert result.epochs_per_frame == 45
+        contract.functions.getFrameConfig.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_consensus_state_for_member(self):
         contract = _mock_contract()
@@ -1144,6 +1171,7 @@ class TestHashConsensusContract:
             contract, address=ChecksumAddress(_ADDR), block_identifier="latest"
         )
         assert result == expected
+        contract.functions.getConsensusStateForMember.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_submit_report(self):
         contract = _mock_contract()
@@ -1165,12 +1193,14 @@ class TestLidoContract:
         contract.functions.getWithdrawalsReserve.return_value.call.return_value = 1000
         result = LidoContract.get_withdrawals_reserve(contract, block_identifier="latest")
         assert result == 1000
+        contract.functions.getWithdrawalsReserve.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_total_supply(self):
         contract = _mock_contract()
         contract.functions.totalSupply.return_value.call.return_value = 5000
         result = LidoContract.total_supply(contract, block_identifier="latest")
         assert result == 5000
+        contract.functions.totalSupply.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_beacon_stat(self):
         contract = _mock_contract()
@@ -1179,6 +1209,7 @@ class TestLidoContract:
         assert isinstance(result, BeaconStat)
         assert result.deposited_validators == 100
         assert result.beacon_validators == 90
+        contract.functions.getBeaconStat.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_deposits_reserve_target(self):
         contract = _mock_contract()
@@ -1203,6 +1234,7 @@ class TestBurnerContract:
         assert isinstance(result, SharesRequestedToBurn)
         assert result.cover_shares == 100
         assert result.non_cover_shares == 200
+        contract.functions.getSharesRequestedToBurn.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -1220,6 +1252,7 @@ class TestOracleReportSanityCheckerContract:
         assert isinstance(result, OracleReportLimits)
         assert result.exited_eth_amount_per_day_limit == 1
         assert result.exited_validator_eth_amount_limit == 15
+        contract.functions.getOracleReportLimits.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -1234,18 +1267,21 @@ class TestWithdrawalQueueNftContractPassThroughs:
         contract.functions.unfinalizedStETH.return_value.call.return_value = 500
         result = WithdrawalQueueNftContract.unfinalized_steth(contract, block_identifier="latest")
         assert result == 500
+        contract.functions.unfinalizedStETH.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_bunker_mode_since_timestamp(self):
         contract = _mock_contract()
         contract.functions.bunkerModeSinceTimestamp.return_value.call.return_value = 9999
         result = WithdrawalQueueNftContract.bunker_mode_since_timestamp(contract, block_identifier="latest")
         assert result == 9999
+        contract.functions.bunkerModeSinceTimestamp.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_last_finalized_request_id(self):
         contract = _mock_contract()
         contract.functions.getLastFinalizedRequestId.return_value.call.return_value = 7
         result = WithdrawalQueueNftContract.get_last_finalized_request_id(contract, block_identifier="latest")
         assert result == 7
+        contract.functions.getLastFinalizedRequestId.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_withdrawal_status(self):
         contract = _mock_contract()
@@ -1255,24 +1291,28 @@ class TestWithdrawalQueueNftContractPassThroughs:
         assert isinstance(result, WithdrawalRequestStatus)
         assert result.amount_of_st_eth == 100
         assert result.amount_of_shares == 50
+        contract.functions.getWithdrawalStatus.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_last_request_id(self):
         contract = _mock_contract()
         contract.functions.getLastRequestId.return_value.call.return_value = 42
         result = WithdrawalQueueNftContract.get_last_request_id(contract, block_identifier="latest")
         assert result == 42
+        contract.functions.getLastRequestId.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_is_paused(self):
         contract = _mock_contract()
         contract.functions.isPaused.return_value.call.return_value = True
         result = WithdrawalQueueNftContract.is_paused(contract, block_identifier="latest")
         assert result is True
+        contract.functions.isPaused.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_max_batches_length(self):
         contract = _mock_contract()
         contract.functions.MAX_BATCHES_LENGTH.return_value.call.return_value = 36
         result = WithdrawalQueueNftContract.max_batches_length(contract, block_identifier="latest")
         assert result == 36
+        contract.functions.MAX_BATCHES_LENGTH.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -1287,30 +1327,35 @@ class TestBaseOracleContract:
         contract.functions.getConsensusContract.return_value.call.return_value = _ADDR
         result = BaseOracleContract.get_consensus_contract(contract, block_identifier="latest")
         assert result == _ADDR
+        contract.functions.getConsensusContract.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_submit_data_role(self):
         contract = _mock_contract()
         contract.functions.SUBMIT_DATA_ROLE.return_value.call.return_value = _ROLE
         result = BaseOracleContract.submit_data_role(contract, block_identifier="latest")
         assert result == _ROLE
+        contract.functions.SUBMIT_DATA_ROLE.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_has_role(self):
         contract = _mock_contract()
         contract.functions.hasRole.return_value.call.return_value = True
         result = BaseOracleContract.has_role(contract, _ROLE, _ADDR, block_identifier="latest")
         assert result is True
+        contract.functions.hasRole.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_contract_version(self):
         contract = _mock_contract()
         contract.functions.getContractVersion.return_value.call.return_value = 3
         result = BaseOracleContract.get_contract_version(contract, block_identifier="latest")
         assert result == 3
+        contract.functions.getContractVersion.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_consensus_version(self):
         contract = _mock_contract()
         contract.functions.getConsensusVersion.return_value.call.return_value = 2
         result = BaseOracleContract.get_consensus_version(contract, block_identifier="latest")
         assert result == 2
+        contract.functions.getConsensusVersion.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_submit_report_data(self):
         contract = _mock_contract()
@@ -1324,6 +1369,7 @@ class TestBaseOracleContract:
         contract.functions.getLastProcessingRefSlot.return_value.call.return_value = 999
         result = BaseOracleContract.get_last_processing_ref_slot(contract, block_identifier="latest")
         assert result == 999
+        contract.functions.getLastProcessingRefSlot.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -1340,6 +1386,7 @@ class TestAccountingOracleContract:
         result = AccountingOracleContract.get_processing_state(contract, block_identifier="latest")
         assert isinstance(result, AccountingProcessingState)
         assert result.current_frame_ref_slot == 1
+        contract.functions.getProcessingState.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_submit_report_extra_data_empty(self):
         contract = _mock_contract()
@@ -1438,18 +1485,21 @@ class TestCSFeeDistributorContract:
         contract.functions.pendingSharesToDistribute.return_value.call.return_value = 999
         result = CSFeeDistributorContract.shares_to_distribute(contract, block_identifier="latest")
         assert result == 999
+        contract.functions.pendingSharesToDistribute.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_tree_root(self):
         contract = _mock_contract()
         contract.functions.treeRoot.return_value.call.return_value = b"\xaa" * 32
         result = CSFeeDistributorContract.tree_root(contract, block_identifier="latest")
         assert result == HexBytes(b"\xaa" * 32)
+        contract.functions.treeRoot.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_tree_cid(self):
         contract = _mock_contract()
         contract.functions.treeCid.return_value.call.return_value = "QmTest"
         result = CSFeeDistributorContract.tree_cid(contract, block_identifier="latest")
         assert result == "QmTest"
+        contract.functions.treeCid.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_oracle_returns_checksum_address(self):
         contract = _mock_contract()
@@ -1457,6 +1507,7 @@ class TestCSFeeDistributorContract:
         result = CSFeeDistributorContract.oracle(contract, block_identifier="latest")
         assert result.startswith("0x")
         assert len(result) == 42
+        contract.functions.ORACLE.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -1471,12 +1522,14 @@ class TestCSAccountingContract:
         contract.functions.FEE_DISTRIBUTOR.return_value.call.return_value = "0x" + "cd" * 20
         result = CSAccountingContract.fee_distributor(contract, block_identifier="latest")
         assert result.startswith("0x")
+        contract.functions.FEE_DISTRIBUTOR.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_get_bond_curve_id(self):
         contract = _mock_contract()
         contract.functions.getBondCurveId.return_value.call.return_value = 5
         result = CSAccountingContract.get_bond_curve_id(contract, NodeOperatorId(1), block_identifier="latest")
         assert result == 5
+        contract.functions.getBondCurveId.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -1491,12 +1544,14 @@ class TestCSFeeOracleContract:
         contract.functions.isPaused.return_value.call.return_value = False
         result = CSFeeOracleContract.is_paused(contract, block_identifier="latest")
         assert result is False
+        contract.functions.isPaused.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_strikes(self):
         contract = _mock_contract()
         contract.functions.STRIKES.return_value.call.return_value = "0x" + "ef" * 20
         result = CSFeeOracleContract.strikes(contract, block_identifier="latest")
         assert result.startswith("0x")
+        contract.functions.STRIKES.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -1511,18 +1566,21 @@ class TestCSModuleContract:
         contract.functions.ACCOUNTING.return_value.call.return_value = "0x" + "11" * 20
         result = CSModuleContract.accounting(contract, block_identifier="latest")
         assert result.startswith("0x")
+        contract.functions.ACCOUNTING.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_parameters_registry(self):
         contract = _mock_contract()
         contract.functions.PARAMETERS_REGISTRY.return_value.call.return_value = "0x" + "22" * 20
         result = CSModuleContract.parameters_registry(contract, block_identifier="latest")
         assert result.startswith("0x")
+        contract.functions.PARAMETERS_REGISTRY.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_is_paused(self):
         contract = _mock_contract()
         contract.functions.isPaused.return_value.call.return_value = True
         result = CSModuleContract.is_paused(contract, block="latest")
         assert result is True
+        contract.functions.isPaused.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------
@@ -1537,12 +1595,14 @@ class TestCSStrikesContract:
         contract.functions.treeRoot.return_value.call.return_value = b"\xbb" * 32
         result = CSStrikesContract.tree_root(contract, block_identifier="latest")
         assert result == HexBytes(b"\xbb" * 32)
+        contract.functions.treeRoot.return_value.call.assert_called_with(block_identifier="latest")
 
     def test_tree_cid(self):
         contract = _mock_contract()
         contract.functions.treeCid.return_value.call.return_value = "QmStrikes"
         result = CSStrikesContract.tree_cid(contract, block_identifier="latest")
         assert result == "QmStrikes"
+        contract.functions.treeCid.return_value.call.assert_called_with(block_identifier="latest")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/fork/test_lido_oracle_cycle.py
+++ b/tests/fork/test_lido_oracle_cycle.py
@@ -58,14 +58,14 @@ def missed_initial_frame(frame_config: FrameConfig):
 )
 def test_lido_module_report(module, set_oracle_members, running_finalized_slots, account_from):
     # Skip if consensus version is different
-    current_consensus_version = module.report_contract.get_consensus_version()
+    current_consensus_version = module.report_contract.get_consensus_version('latest')
     if current_consensus_version != module.COMPATIBLE_CONSENSUS_VERSION:
         pytest.skip(
             f"Consensus version {current_consensus_version} does not match expected "
             f"{module.COMPATIBLE_CONSENSUS_VERSION}"
         )
 
-    assert module.report_contract.get_last_processing_ref_slot() == 0, "Last processing ref slot should be 0"
+    assert module.report_contract.get_last_processing_ref_slot('latest') == 0, "Last processing ref slot should be 0"
     members = set_oracle_members(count=2)
 
     report_frame = None
@@ -79,7 +79,7 @@ def test_lido_module_report(module, set_oracle_members, running_finalized_slots,
             module._receive_last_finalized_slot()  # pylint: disable=protected-access
         )
 
-    last_processing_after_report = module.report_contract.get_last_processing_ref_slot()
+    last_processing_after_report = module.report_contract.get_last_processing_ref_slot('latest')
     assert last_processing_after_report == report_frame.ref_slot, (
         "Last processing ref slot should equal to report ref slot"
     )

--- a/tests/fork/test_staking_module_oracle_cycle.py
+++ b/tests/fork/test_staking_module_oracle_cycle.py
@@ -168,27 +168,27 @@ def test_staking_module_module_report(
     frame_index_as_processed,
     account_from,
 ):
-    current_contract_version = module.report_contract.get_contract_version()
+    current_contract_version = module.report_contract.get_contract_version('latest')
     if current_contract_version != module.COMPATIBLE_CONTRACT_VERSION:
         pytest.skip(
             f"Contract version {current_contract_version} does not match expected {module.COMPATIBLE_CONTRACT_VERSION}"
         )
 
-    current_consensus_version = module.report_contract.get_consensus_version()
+    current_consensus_version = module.report_contract.get_consensus_version('latest')
     if current_consensus_version != module.COMPATIBLE_CONSENSUS_VERSION:
         pytest.skip(
             f"Consensus version {current_consensus_version} does not match expected "
             f"{module.COMPATIBLE_CONSENSUS_VERSION}"
         )
 
-    assert module.report_contract.get_last_processing_ref_slot() == 0, "Last processing ref slot should be 0"
+    assert module.report_contract.get_last_processing_ref_slot('latest') == 0, "Last processing ref slot should be 0"
     if frame_index_as_processed is not None:
         process_frame_index(frame_index_as_processed)
 
     members = set_oracle_members(count=2)
 
     report_frame = None
-    to_distribute_before_report = module.w3.staking_module.fee_distributor.shares_to_distribute()
+    to_distribute_before_report = module.w3.staking_module.fee_distributor.shares_to_distribute('latest')
 
     switch_finalized, _ = running_finalized_slots
     # pylint:disable=duplicate-code
@@ -202,7 +202,7 @@ def test_staking_module_module_report(
             module._receive_last_finalized_slot()  # pylint: disable=protected-access
         )
 
-    last_processing_after_report = module.w3.staking_module.oracle.get_last_processing_ref_slot()
+    last_processing_after_report = module.w3.staking_module.oracle.get_last_processing_ref_slot('latest')
     assert last_processing_after_report == report_frame.ref_slot, (
         "Last processing ref slot should equal to initial ref slot"
     )
@@ -212,7 +212,7 @@ def test_staking_module_module_report(
     if to_distribute_before_report == 0:
         return
 
-    to_distribute_after_report = module.w3.staking_module.fee_distributor.shares_to_distribute()
+    to_distribute_after_report = module.w3.staking_module.fee_distributor.shares_to_distribute('latest')
     assert to_distribute_after_report < to_distribute_before_report, "Shares to distribute should decrease"
 
     nos_count = int(module.w3.staking_module.module.functions.getNodeOperatorsCount().call())

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -72,7 +72,7 @@ def lido_contract(web3_provider_integration, lido_locator_contract) -> LidoContr
     return get_contract(
         web3_provider_integration,
         LidoContract,
-        lido_locator_contract.lido(),
+        lido_locator_contract.lido('latest'),
     )
 
 
@@ -81,7 +81,7 @@ def accounting_oracle_contract(web3_provider_integration, lido_locator_contract)
     return get_contract(
         web3_provider_integration,
         AccountingOracleContract,
-        lido_locator_contract.accounting_oracle(),
+        lido_locator_contract.accounting_oracle('latest'),
     )
 
 
@@ -90,7 +90,7 @@ def accounting_contract(web3_provider_integration, lido_locator_contract) -> Acc
     return get_contract(
         web3_provider_integration,
         AccountingContract,
-        lido_locator_contract.accounting(),
+        lido_locator_contract.accounting('latest'),
     )
 
 
@@ -99,7 +99,7 @@ def staking_router_contract(web3_provider_integration, lido_locator_contract) ->
     return get_contract(
         web3_provider_integration,
         StakingRouterContract,
-        lido_locator_contract.staking_router(),
+        lido_locator_contract.staking_router('latest'),
     )
 
 
@@ -108,7 +108,7 @@ def validators_exit_bus_oracle_contract(web3_provider_integration, lido_locator_
     return get_contract(
         web3_provider_integration,
         ExitBusOracleContract,
-        lido_locator_contract.validator_exit_bus_oracle(),
+        lido_locator_contract.validator_exit_bus_oracle('latest'),
     )
 
 
@@ -117,7 +117,7 @@ def withdrawal_queue_nft_contract(web3_provider_integration, lido_locator_contra
     return get_contract(
         web3_provider_integration,
         WithdrawalQueueNftContract,
-        lido_locator_contract.withdrawal_queue(),
+        lido_locator_contract.withdrawal_queue('latest'),
     )
 
 
@@ -126,7 +126,7 @@ def oracle_report_sanity_checker_contract(web3_provider_integration, lido_locato
     return get_contract(
         web3_provider_integration,
         OracleReportSanityCheckerContract,
-        lido_locator_contract.oracle_report_sanity_checker(),
+        lido_locator_contract.oracle_report_sanity_checker('latest'),
     )
 
 
@@ -135,7 +135,7 @@ def oracle_daemon_config_contract(web3_provider_integration, lido_locator_contra
     return get_contract(
         web3_provider_integration,
         OracleDaemonConfigContract,
-        lido_locator_contract.oracle_daemon_config(),
+        lido_locator_contract.oracle_daemon_config('latest'),
     )
 
 
@@ -144,7 +144,7 @@ def burner_contract(web3_provider_integration, lido_locator_contract):
     return get_contract(
         web3_provider_integration,
         BurnerContract,
-        lido_locator_contract.burner(),
+        lido_locator_contract.burner('latest'),
     )
 
 
@@ -153,7 +153,7 @@ def vault_hub_contract(web3_provider_integration, lido_locator_contract):
     return get_contract(
         web3_provider_integration,
         VaultHubContract,
-        lido_locator_contract.vault_hub(),
+        lido_locator_contract.vault_hub('latest'),
     )
 
 
@@ -162,7 +162,7 @@ def lazy_oracle_contract(web3_provider_integration, lido_locator_contract):
     return get_contract(
         web3_provider_integration,
         LazyOracleContract,
-        lido_locator_contract.lazy_oracle(),
+        lido_locator_contract.lazy_oracle('latest'),
     )
 
 
@@ -185,7 +185,7 @@ def cs_accounting_contract(web3_provider_integration, cs_module_contract):
     return get_contract(
         web3_provider_integration,
         CSAccountingContract,
-        cs_module_contract.accounting(),
+        cs_module_contract.accounting('latest'),
     )
 
 
@@ -194,7 +194,7 @@ def cs_params_contract(web3_provider_integration, cs_module_contract):
     return get_contract(
         web3_provider_integration,
         CSParametersRegistryContract,
-        cs_module_contract.parameters_registry(),
+        cs_module_contract.parameters_registry('latest'),
     )
 
 
@@ -203,7 +203,7 @@ def cs_fee_distributor_contract(web3_provider_integration, cs_accounting_contrac
     return get_contract(
         web3_provider_integration,
         CSFeeDistributorContract,
-        cs_accounting_contract.fee_distributor(),
+        cs_accounting_contract.fee_distributor('latest'),
     )
 
 
@@ -212,7 +212,7 @@ def cs_fee_oracle_contract(web3_provider_integration, cs_fee_distributor_contrac
     return get_contract(
         web3_provider_integration,
         CSFeeOracleContract,
-        cs_fee_distributor_contract.oracle(),
+        cs_fee_distributor_contract.oracle('latest'),
     )
 
 
@@ -221,7 +221,7 @@ def cs_strikes_contract(web3_provider_integration, cs_fee_oracle_contract):
     return get_contract(
         web3_provider_integration,
         CSStrikesContract,
-        cs_fee_oracle_contract.strikes(),
+        cs_fee_oracle_contract.strikes('latest'),
     )
 
 
@@ -239,7 +239,7 @@ def hash_consensus_contract(web3_provider_integration, accounting_oracle_contrac
     return get_contract(
         web3_provider_integration,
         HashConsensusContract,
-        accounting_oracle_contract.get_consensus_contract(),
+        accounting_oracle_contract.get_consensus_contract('latest'),
     )
 
 

--- a/tests/integration/contracts/test_accounting_oracle.py
+++ b/tests/integration/contracts/test_accounting_oracle.py
@@ -11,7 +11,7 @@ def test_accounting_oracle_contract(accounting_oracle_contract, caplog):
     check_contract(
         accounting_oracle_contract,
         [
-            ('get_processing_state', None, make_checker(AccountingProcessingState)),
+            ('get_processing_state', ('latest',), make_checker(AccountingProcessingState)),
             ('submit_report_extra_data_empty', None, make_checker(ContractFunction)),
             ('submit_report_extra_data_list', (b'',), make_checker(ContractFunction)),
         ],

--- a/tests/integration/contracts/test_base_oracle.py
+++ b/tests/integration/contracts/test_base_oracle.py
@@ -17,13 +17,17 @@ def test_base_oracle_via_vebo(validators_exit_bus_oracle_contract, caplog):
     check_contract(
         validators_exit_bus_oracle_contract,
         [
-            ('get_consensus_contract', None, make_checker(ChecksumAddress)),
-            ('submit_data_role', None, lambda r: check_value_type(r, bytes)),
-            ('has_role', (role, validators_exit_bus_oracle_contract.address), lambda r: check_value_type(r, bool)),
-            ('get_contract_version', None, lambda r: check_value_type(r, int)),
-            ('get_consensus_version', None, lambda r: check_value_type(r, int)),
+            ('get_consensus_contract', ('latest',), make_checker(ChecksumAddress)),
+            ('submit_data_role', ('latest',), lambda r: check_value_type(r, bytes)),
+            (
+                'has_role',
+                (role, validators_exit_bus_oracle_contract.address, 'latest'),
+                lambda r: check_value_type(r, bool),
+            ),
+            ('get_contract_version', ('latest',), lambda r: check_value_type(r, int)),
+            ('get_consensus_version', ('latest',), lambda r: check_value_type(r, int)),
             ('submit_report_data', ((0, 0, 0, 0, b''), 1), make_checker(ContractFunction)),
-            ('get_last_processing_ref_slot', None, make_checker(SlotNumber)),
+            ('get_last_processing_ref_slot', ('latest',), make_checker(SlotNumber)),
         ],
         caplog,
     )

--- a/tests/integration/contracts/test_base_oracle.py
+++ b/tests/integration/contracts/test_base_oracle.py
@@ -10,7 +10,7 @@ from tests.integration.contracts.contract_utils import check_contract, check_val
 @pytest.mark.integration
 def test_base_oracle_via_vebo(validators_exit_bus_oracle_contract, caplog):
     """Tests BaseOracleContract methods via ValidatorsExitBusOracle (mainnet)."""
-    role = validators_exit_bus_oracle_contract.submit_data_role()
+    role = validators_exit_bus_oracle_contract.submit_data_role('latest')
     assert isinstance(role, bytes) and len(role) == 32
     caplog.clear()
 

--- a/tests/integration/contracts/test_bunker.py
+++ b/tests/integration/contracts/test_bunker.py
@@ -15,7 +15,7 @@ def test_burner(burner_contract, caplog):
         [
             (
                 'get_shares_requested_to_burn',
-                None,
+                ('latest',),
                 check_shares,
             ),
         ],

--- a/tests/integration/contracts/test_cs_accounting.py
+++ b/tests/integration/contracts/test_cs_accounting.py
@@ -9,8 +9,8 @@ def test_cs_accounting(cs_accounting_contract, caplog):
     check_contract(
         cs_accounting_contract,
         [
-            ("fee_distributor", None, make_checker(ChecksumAddress)),
-            ("get_bond_curve_id", (0,), make_checker(int)),
+            ("fee_distributor", ('latest',), make_checker(ChecksumAddress)),
+            ("get_bond_curve_id", (0, 'latest'), make_checker(int)),
         ],
         caplog,
     )

--- a/tests/integration/contracts/test_cs_fee_distributor.py
+++ b/tests/integration/contracts/test_cs_fee_distributor.py
@@ -10,10 +10,10 @@ def test_cs_fee_distributor(cs_fee_distributor_contract, caplog):
     check_contract(
         cs_fee_distributor_contract,
         [
-            ("oracle", None, make_checker(ChecksumAddress)),
-            ("shares_to_distribute", None, make_checker(int)),
-            ("tree_root", None, make_checker(HexBytes)),
-            ("tree_cid", None, make_checker(str)),
+            ("oracle", ('latest',), make_checker(ChecksumAddress)),
+            ("shares_to_distribute", ('latest',), make_checker(int)),
+            ("tree_root", ('latest',), make_checker(HexBytes)),
+            ("tree_cid", ('latest',), make_checker(str)),
         ],
         caplog,
     )

--- a/tests/integration/contracts/test_cs_fee_oracle.py
+++ b/tests/integration/contracts/test_cs_fee_oracle.py
@@ -9,7 +9,7 @@ def test_cs_fee_oracle(cs_fee_oracle_contract, caplog):
     check_contract(
         cs_fee_oracle_contract,
         [
-            ("is_paused", None, make_checker(bool)),
+            ("is_paused", ('latest',), make_checker(bool)),
         ],
         caplog,
     )
@@ -20,7 +20,7 @@ def test_cs_fee_oracle_v2(cs_fee_oracle_contract, caplog):
     check_contract(
         cs_fee_oracle_contract,
         [
-            ("strikes", None, make_checker(ChecksumAddress)),
+            ("strikes", ('latest',), make_checker(ChecksumAddress)),
         ],
         caplog,
     )

--- a/tests/integration/contracts/test_cs_module.py
+++ b/tests/integration/contracts/test_cs_module.py
@@ -10,8 +10,8 @@ def test_cs_module(cs_module_contract, caplog):
     check_contract(
         cs_module_contract,
         [
-            ("accounting", None, make_checker(ChecksumAddress)),
-            ("is_paused", None, make_checker(bool)),
+            ("accounting", ('latest',), make_checker(ChecksumAddress)),
+            ("is_paused", ('latest',), make_checker(bool)),
         ],
         caplog,
     )
@@ -23,7 +23,7 @@ def test_cs_module_v2(cs_module_contract, caplog):
     check_contract(
         cs_module_contract,
         [
-            ("parameters_registry", None, make_checker(ChecksumAddress)),
+            ("parameters_registry", ('latest',), make_checker(ChecksumAddress)),
         ],
         caplog,
     )

--- a/tests/integration/contracts/test_cs_parameters_registry.py
+++ b/tests/integration/contracts/test_cs_parameters_registry.py
@@ -16,10 +16,10 @@ def test_cs_parameters_registry(cs_params_contract, caplog):
     check_contract(
         cs_params_contract,
         [
-            ("get_performance_coefficients", [1], make_checker(PerformanceCoefficients)),
-            ("get_reward_share_data", [1], make_checker(KeyNumberValueIntervalList)),
-            ("get_performance_leeway_data", [1], make_checker(KeyNumberValueIntervalList)),
-            ("get_strikes_params", [1], make_checker(StrikesParams)),
+            ("get_performance_coefficients", [1, 'latest'], make_checker(PerformanceCoefficients)),
+            ("get_reward_share_data", [1, 'latest'], make_checker(KeyNumberValueIntervalList)),
+            ("get_performance_leeway_data", [1, 'latest'], make_checker(KeyNumberValueIntervalList)),
+            ("get_strikes_params", [1, 'latest'], make_checker(StrikesParams)),
         ],
         caplog,
     )

--- a/tests/integration/contracts/test_cs_strikes.py
+++ b/tests/integration/contracts/test_cs_strikes.py
@@ -9,8 +9,8 @@ def test_cs_strikes(cs_strikes_contract, caplog):
     check_contract(
         cs_strikes_contract,
         [
-            ("tree_root", None, make_checker(HexBytes)),
-            ("tree_cid", None, make_checker(str)),
+            ("tree_root", ('latest',), make_checker(HexBytes)),
+            ("tree_cid", ('latest',), make_checker(str)),
         ],
         caplog,
     )

--- a/tests/integration/contracts/test_delegation_contract.py
+++ b/tests/integration/contracts/test_delegation_contract.py
@@ -5,7 +5,7 @@ import pytest
 @pytest.mark.integration
 class TestDelegationContract:
     def test_get_admin__real_contract__returns_valid_address(self, delegation_contract, caplog):
-        admin_address = delegation_contract.get_admin()
+        admin_address = delegation_contract.get_admin('latest')
 
         assert isinstance(admin_address, str)
         assert admin_address.startswith('0x')
@@ -13,7 +13,7 @@ class TestDelegationContract:
         assert any('Call admin()' in message for message in caplog.messages)
 
     def test_get_delegatee__real_contract__returns_valid_address(self, delegation_contract, caplog):
-        delegatee_address = delegation_contract.get_delegatee()
+        delegatee_address = delegation_contract.get_delegatee('latest')
 
         assert isinstance(delegatee_address, str)
         assert delegatee_address.startswith('0x')

--- a/tests/integration/contracts/test_hash_consensus.py
+++ b/tests/integration/contracts/test_hash_consensus.py
@@ -9,7 +9,7 @@ from tests.integration.contracts.contract_utils import check_contract, check_val
 @pytest.mark.mainnet
 @pytest.mark.integration
 def test_hash_consensus_contract(hash_consensus_contract, caplog):
-    members, _ = hash_consensus_contract.get_members()
+    members, _ = hash_consensus_contract.get_members('latest')
     assert members, "Expected at least one committee member on mainnet"
     member_address = members[0]
     caplog.clear()

--- a/tests/integration/contracts/test_hash_consensus.py
+++ b/tests/integration/contracts/test_hash_consensus.py
@@ -17,12 +17,12 @@ def test_hash_consensus_contract(hash_consensus_contract, caplog):
     check_contract(
         hash_consensus_contract,
         [
-            ('get_members', None, lambda r: check_value_type(r, tuple)),
-            ('get_chain_config', None, make_checker(ChainConfig)),
-            ('get_current_frame', None, make_checker(CurrentFrame)),
-            ('get_initial_ref_slot', None, make_checker(SlotNumber)),
-            ('get_frame_config', None, make_checker(FrameConfig)),
-            ('get_consensus_state_for_member', (member_address,), lambda r: check_value_type(r, tuple)),
+            ('get_members', ('latest',), lambda r: check_value_type(r, tuple)),
+            ('get_chain_config', ('latest',), make_checker(ChainConfig)),
+            ('get_current_frame', ('latest',), make_checker(CurrentFrame)),
+            ('get_initial_ref_slot', ('latest',), make_checker(SlotNumber)),
+            ('get_frame_config', ('latest',), make_checker(FrameConfig)),
+            ('get_consensus_state_for_member', (member_address, 'latest'), lambda r: check_value_type(r, tuple)),
             ('submit_report', (0, b'\x00' * 32, 1), make_checker(ContractFunction)),
         ],
         caplog,

--- a/tests/integration/contracts/test_lazy_oracle.py
+++ b/tests/integration/contracts/test_lazy_oracle.py
@@ -10,9 +10,13 @@ def test_lazy_oracle_contract_call(lazy_oracle_contract, caplog):
     check_contract(
         lazy_oracle_contract,
         [
-            ('get_vaults_count', None, lambda response: check_value_type(response, int)),
-            ('get_latest_report_data', None, lambda response: check_value_type(response, OnChainIpfsVaultReportData)),
-            ('get_vaults', (0, 10), lambda response: check_value_type(response, list)),
+            ('get_vaults_count', ('latest',), lambda response: check_value_type(response, int)),
+            (
+                'get_latest_report_data',
+                ('latest',),
+                lambda response: check_value_type(response, OnChainIpfsVaultReportData),
+            ),
+            ('get_vaults', (0, 10, 'latest'), lambda response: check_value_type(response, list)),
             (
                 'get_validator_statuses',
                 (
@@ -21,6 +25,7 @@ def test_lazy_oracle_contract_call(lazy_oracle_contract, caplog):
                         "0xa5d9411ef615c74c9240634905d5ddd46dc40a87a09e8cc0332afddb246d291303e452a850917eefe09b3b8c70a307ce",
                     ],
                     5,
+                    'latest',
                 ),
                 lambda response: check_value_type(response, dict),
             ),

--- a/tests/integration/contracts/test_lido.py
+++ b/tests/integration/contracts/test_lido.py
@@ -10,8 +10,8 @@ def test_lido_contract_call(lido_contract, accounting_oracle_contract, burner_co
     check_contract(
         lido_contract,
         [
-            ('get_beacon_stat', None, lambda response: check_value_type(response, BeaconStat)),
-            ('total_supply', None, lambda response: check_value_type(response, int)),
+            ('get_beacon_stat', ('latest',), lambda response: check_value_type(response, BeaconStat)),
+            ('total_supply', ('latest',), lambda response: check_value_type(response, int)),
             # Uncomment after SRv3 release on mainnet
             # ('get_deposits_reserve', ('latest',), lambda response: check_value_type(response, int)),
             # ('get_withdrawals_reserve', ('latest',), lambda response: check_value_type(response, int)),

--- a/tests/integration/contracts/test_lido_locator.py
+++ b/tests/integration/contracts/test_lido_locator.py
@@ -10,16 +10,16 @@ def test_lido_locator_contract(lido_locator_contract, caplog):
     check_contract(
         lido_locator_contract,
         [
-            ('lido', None, make_checker(ChecksumAddress)),
-            ('accounting_oracle', None, make_checker(ChecksumAddress)),
-            ('staking_router', None, make_checker(ChecksumAddress)),
-            ('validator_exit_bus_oracle', None, make_checker(ChecksumAddress)),
-            ('withdrawal_queue', None, make_checker(ChecksumAddress)),
-            ('oracle_report_sanity_checker', None, make_checker(ChecksumAddress)),
-            ('oracle_daemon_config', None, make_checker(ChecksumAddress)),
-            ('burner', None, make_checker(ChecksumAddress)),
-            ('withdrawal_vault', None, make_checker(ChecksumAddress)),
-            ('el_rewards_vault', None, make_checker(ChecksumAddress)),
+            ('lido', ('latest',), make_checker(ChecksumAddress)),
+            ('accounting_oracle', ('latest',), make_checker(ChecksumAddress)),
+            ('staking_router', ('latest',), make_checker(ChecksumAddress)),
+            ('validator_exit_bus_oracle', ('latest',), make_checker(ChecksumAddress)),
+            ('withdrawal_queue', ('latest',), make_checker(ChecksumAddress)),
+            ('oracle_report_sanity_checker', ('latest',), make_checker(ChecksumAddress)),
+            ('oracle_daemon_config', ('latest',), make_checker(ChecksumAddress)),
+            ('burner', ('latest',), make_checker(ChecksumAddress)),
+            ('withdrawal_vault', ('latest',), make_checker(ChecksumAddress)),
+            ('el_rewards_vault', ('latest',), make_checker(ChecksumAddress)),
         ],
         caplog,
     )
@@ -31,9 +31,9 @@ def test_lido_locator_contract_testnet(lido_locator_contract, caplog):
     check_contract(
         lido_locator_contract,
         [
-            ('accounting', None, make_checker(ChecksumAddress)),
-            ('vault_hub', None, make_checker(ChecksumAddress)),
-            ('lazy_oracle', None, make_checker(ChecksumAddress)),
+            ('accounting', ('latest',), make_checker(ChecksumAddress)),
+            ('vault_hub', ('latest',), make_checker(ChecksumAddress)),
+            ('lazy_oracle', ('latest',), make_checker(ChecksumAddress)),
         ],
         caplog,
     )

--- a/tests/integration/contracts/test_oracle_daemon_config.py
+++ b/tests/integration/contracts/test_oracle_daemon_config.py
@@ -12,27 +12,27 @@ def test_oracle_daemon_config_contract(oracle_daemon_config_contract, caplog):
         [
             (
                 'normalized_cl_reward_mistake_rate_bp',
-                None,
+                ('latest',),
                 lambda response: check_value_type(response, int) and response < TOTAL_BASIS_POINTS,
             ),
             (
                 'rebase_check_nearest_epoch_distance',
-                None,
+                ('latest',),
                 lambda response: check_value_type(response, int),
             ),
             (
                 'rebase_check_distant_epoch_distance',
-                None,
+                ('latest',),
                 lambda response: check_value_type(response, int),
             ),
             (
                 'prediction_duration_in_slots',
-                None,
+                ('latest',),
                 lambda response: check_value_type(response, int),
             ),
             (
                 'finalization_max_negative_rebase_epoch_shift',
-                None,
+                ('latest',),
                 lambda response: check_value_type(response, int),
             ),
             # (

--- a/tests/integration/contracts/test_oracle_report_sanity_checker.py
+++ b/tests/integration/contracts/test_oracle_report_sanity_checker.py
@@ -11,7 +11,7 @@ def test_oracle_report_sanity_checker(oracle_report_sanity_checker_contract, cap
     check_contract(
         oracle_report_sanity_checker_contract,
         [
-            ('get_oracle_report_limits', None, make_checker(OracleReportLimits)),
+            ('get_oracle_report_limits', ('latest',), make_checker(OracleReportLimits)),
         ],
         caplog,
     )

--- a/tests/integration/contracts/test_staking_router.py
+++ b/tests/integration/contracts/test_staking_router.py
@@ -20,11 +20,11 @@ def test_staking_router(staking_router_contract, caplog):
             ),
             (
                 'get_all_node_operator_digests',
-                (StakingModuleFactory.build(id=1),),
+                (StakingModuleFactory.build(id=1), 'latest'),
                 lambda response: check_value_type(response, list)
                 and map(lambda sm: check_value_type(sm, NodeOperator), response),
             ),
-            ('get_contract_version', None, lambda response: check_value_type(response, int)),
+            ('get_contract_version', ('latest',), lambda response: check_value_type(response, int)),
         ],
         caplog,
     )

--- a/tests/integration/contracts/test_validator_exit_bus_oracle.py
+++ b/tests/integration/contracts/test_validator_exit_bus_oracle.py
@@ -13,8 +13,8 @@ def test_vebo(validators_exit_bus_oracle_contract, caplog):
     check_contract(
         validators_exit_bus_oracle_contract,
         [
-            ('is_paused', None, make_checker(bool)),
-            ('get_processing_state', None, make_checker(EjectorProcessingState)),
+            ('is_paused', ('latest',), make_checker(bool)),
+            ('get_processing_state', ('latest',), make_checker(EjectorProcessingState)),
         ],
         caplog,
     )

--- a/tests/integration/contracts/test_withdrawal_queue_nft_contract.py
+++ b/tests/integration/contracts/test_withdrawal_queue_nft_contract.py
@@ -10,14 +10,14 @@ def test_withdrawal_queue(withdrawal_queue_nft_contract, caplog):
     check_contract(
         withdrawal_queue_nft_contract,
         [
-            ('unfinalized_steth', None, make_checker(int)),
-            ('bunker_mode_since_timestamp', None, make_checker(int)),
-            ('get_last_finalized_request_id', None, make_checker(int)),
-            ('get_withdrawal_status', (1,), make_checker(WithdrawalRequestStatus)),
-            ('get_last_request_id', None, make_checker(int)),
-            ('is_paused', None, make_checker(bool)),
+            ('unfinalized_steth', ('latest',), make_checker(int)),
+            ('bunker_mode_since_timestamp', ('latest',), make_checker(int)),
+            ('get_last_finalized_request_id', ('latest',), make_checker(int)),
+            ('get_withdrawal_status', (1, 'latest'), make_checker(WithdrawalRequestStatus)),
+            ('get_last_request_id', ('latest',), make_checker(int)),
+            ('is_paused', ('latest',), make_checker(bool)),
             ('max_steth_withdrawal_amount', ('latest',), make_checker(int)),
-            ('max_batches_length', None, make_checker(int)),
+            ('max_batches_length', ('latest',), make_checker(int)),
             (
                 'calculate_finalization_batches',
                 (

--- a/tests/modules/accounting/bunker/test_bunker_abnormal_cl_rebase.py
+++ b/tests/modules/accounting/bunker/test_bunker_abnormal_cl_rebase.py
@@ -555,6 +555,8 @@ def test_calculate_injected_capital__v4__correct_wei_to_gwei_conversion(
     result = abnormal_case._calculate_injected_capital(prev_blockstamp, ref_blockstamp, [])
 
     assert result == Gwei(expected_gwei)
+    # The v4 upgrade check must read the contract version at the last report block
+    abnormal_case.w3.lido_contracts.lido.get_contract_version.assert_called_once_with(last_report_bs.block_number)
 
 
 @pytest.mark.unit
@@ -601,6 +603,8 @@ def test_calculate_injected_capital__v4__invalid_signature_deposit_excluded(web3
 
     # Only the valid 1000 ETH deposit should be counted; invalid 1 ETH excluded
     assert result == Gwei(1000 * 10**9)
+    # The v4 upgrade check must read the contract version at the last report block
+    abnormal_case.w3.lido_contracts.lido.get_contract_version.assert_called_once_with(last_report_bs.block_number)
 
 
 @pytest.mark.unit

--- a/tests/modules/accounting/staking_vault/test_fee_get_vaults.py
+++ b/tests/modules/accounting/staking_vault/test_fee_get_vaults.py
@@ -110,6 +110,9 @@ class TestGetVaultsFees:
         )
 
         assert fees[vault_adr].prev_fee == 0
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
+        )
 
     def test_negative_ref_slot_on_first_report(self, service, monkeypatch):
         # initial_epoch - frame_epoches <= 0
@@ -159,6 +162,9 @@ class TestGetVaultsFees:
             pre_total_pooled_ether=0,
             pre_total_shares=0,
             block_timestamps={},
+        )
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
         )
 
     def test_first_ref_slot_calculate_on_first_report(self, service, monkeypatch):
@@ -210,6 +216,9 @@ class TestGetVaultsFees:
             pre_total_shares=0,
             block_timestamps={},
         )
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
+        )
 
     def test_raises_if_liability_shares_mismatch(self, service, vault_hub_mock):
         # Setup
@@ -254,6 +263,9 @@ class TestGetVaultsFees:
                 chain_config=MagicMock(genesis_time=0, seconds_per_slot=FeeTestConstants.SECONDS_PER_SLOT),
                 current_frame=FrameNumber(0),
             )
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
+        )
 
     def test_prev_fee_reset_after_reconnect(self, service, vault_hub_mock):
         # Setup
@@ -303,6 +315,9 @@ class TestGetVaultsFees:
 
         # Assert
         assert fees[vault_adr].prev_fee == 0
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
+        )
 
     def test_no_events_liquidity_fee(self, service, vault_hub_mock):
         # Setup
@@ -363,6 +378,9 @@ class TestGetVaultsFees:
             fee_bp=FeeTestConstants.LIQUIDITY_FEE_BP,
         )
         assert fees[vault_adr].liquidity_fee == int(expected_fee.to_integral_value(ROUND_UP))
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
+        )
 
     def test_fee_elapsed_time_uses_ref_slot_seconds(self, service, vault_hub_mock):
         # Setup
@@ -403,6 +421,9 @@ class TestGetVaultsFees:
 
         # Assert
         assert fees[vault_adr].infra_fee == 2 * FeeTestConstants.SECONDS_PER_SLOT
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
+        )
 
     def test_fee_elapsed_time_missing_slots_at_start(self, service, vault_hub_mock):
         # Setup
@@ -447,6 +468,9 @@ class TestGetVaultsFees:
         # Assert
         expected_fee = StakingVaultsService.calc_fee_value(Decimal(total_value), time_elapsed_seconds, Decimal(1), 1)
         assert fees[vault_adr].infra_fee == int(expected_fee)
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
+        )
 
     def test_fee_elapsed_time_missing_slots_at_end_with_event(self, service, vault_hub_mock):
         # Setup
@@ -523,6 +547,9 @@ class TestGetVaultsFees:
             2,
         )
         assert fees[vault_adr].liquidity_fee == int(expected_fee)
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
+        )
 
     def test_fee_elapsed_time_missing_slots_in_middle(self, service, vault_hub_mock):
         # Setup
@@ -618,6 +645,9 @@ class TestGetVaultsFees:
             )
         )
         assert fees[vault_adr].liquidity_fee == int(expected_fee)
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
+        )
 
     def test_raises_if_time_elapsed_negative(self, service):
         # Setup
@@ -642,6 +672,9 @@ class TestGetVaultsFees:
                 chain_config=chain_config,
                 current_frame=FrameNumber(0),
             )
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
+        )
 
     def test_no_events_skip_block_timestamp_lookup(self, service, vault_hub_mock):
         # Setup
@@ -678,3 +711,6 @@ class TestGetVaultsFees:
 
         # Assert
         service.w3.eth.get_block.assert_not_called()
+        service.w3.lido_contracts.accounting_oracle.get_last_processing_ref_slot.assert_called_once_with(
+            blockstamp.block_hash
+        )

--- a/tests/modules/accounting/staking_vault/test_total_values.py
+++ b/tests/modules/accounting/staking_vault/test_total_values.py
@@ -111,6 +111,9 @@ class TestGetVaultsTotalValues:
             VaultAddresses.VAULT_3: 61_000_000_000_000_000_000,  # 60 ETH + 1 EL
         }
         assert result == expected
+        service.w3.lido_contracts.lazy_oracle.get_validator_statuses.assert_called_with(
+            pubkeys=ANY, block_identifier="latest", batch_size=ANY
+        )
 
     def test_pending_deposit_with_wrong_wc_ignored(self, web3, default_vaults_map):
         # Setup
@@ -153,6 +156,9 @@ class TestGetVaultsTotalValues:
             VaultAddresses.VAULT_3: 1_000_000_000_000_000_000,
         }
         assert result == expected
+        service.w3.lido_contracts.lazy_oracle.get_validator_statuses.assert_called_with(
+            pubkeys=ANY, block_identifier="latest", batch_size=ANY
+        )
 
     def test_multiple_pending_deposits_for_same_validator(self, web3, default_vaults_map):
         # Setup
@@ -207,6 +213,9 @@ class TestGetVaultsTotalValues:
             VaultAddresses.VAULT_3: 1_000_000_000_000_000_000,
         }
         assert result == expected
+        service.w3.lido_contracts.lazy_oracle.get_validator_statuses.assert_called_with(
+            pubkeys=ANY, block_identifier="latest", batch_size=ANY
+        )
 
     def test_pending_deposit_without_validator_counts_predeposit(self, web3, default_vaults_map):
         # Setup
@@ -230,7 +239,9 @@ class TestGetVaultsTotalValues:
         service = StakingVaultsService(web3)
 
         # Act
-        result = service.get_vaults_total_values(default_vaults_map, validators, pending_deposits)
+        result = service.get_vaults_total_values(
+            default_vaults_map, validators, pending_deposits, block_identifier="latest"
+        )
 
         # Assert
         expected = {
@@ -240,6 +251,9 @@ class TestGetVaultsTotalValues:
             VaultAddresses.VAULT_3: 1_000_000_000_000_000_000,
         }
         assert result == expected
+        service.w3.lido_contracts.lazy_oracle.get_validator_statuses.assert_called_with(
+            pubkeys=ANY, block_identifier="latest", batch_size=ANY
+        )
 
 
 @pytest.mark.unit
@@ -265,13 +279,16 @@ class TestGetVaultsTotalValuesWithValidatorStatuses:
         service = StakingVaultsService(web3)
 
         # Act
-        result = service.get_vaults_total_values(default_vaults_map, validators, [])
+        result = service.get_vaults_total_values(default_vaults_map, validators, [], block_identifier="latest")
 
         # Assert
         expected_vault_0 = default_vaults_map[VaultAddresses.VAULT_0].aggregated_balance + gwei_to_wei(
             Gwei(1_000_000_000)
         )
         assert result[VaultAddresses.VAULT_0] == expected_vault_0
+        service.w3.lido_contracts.lazy_oracle.get_validator_statuses.assert_called_with(
+            pubkeys=ANY, block_identifier="latest", batch_size=ANY
+        )
 
     def test_activated_validator_counts_full_balance_plus_pending(self, web3, default_vaults_map):
         # Setup
@@ -302,7 +319,9 @@ class TestGetVaultsTotalValuesWithValidatorStatuses:
         service = StakingVaultsService(web3)
 
         # Act
-        result = service.get_vaults_total_values(default_vaults_map, validators, pending_deposits)
+        result = service.get_vaults_total_values(
+            default_vaults_map, validators, pending_deposits, block_identifier="latest"
+        )
 
         # Assert
         expected_vault_0 = (
@@ -311,6 +330,9 @@ class TestGetVaultsTotalValuesWithValidatorStatuses:
             + gwei_to_wei(Gwei(31_000_000_000))
         )
         assert result[VaultAddresses.VAULT_0] == expected_vault_0
+        service.w3.lido_contracts.lazy_oracle.get_validator_statuses.assert_called_with(
+            pubkeys=ANY, block_identifier="latest", batch_size=ANY
+        )
 
     def test_proven_validator_not_counted(self, web3, default_vaults_map):
         # Setup
@@ -333,10 +355,13 @@ class TestGetVaultsTotalValuesWithValidatorStatuses:
         service = StakingVaultsService(web3)
 
         # Act
-        result = service.get_vaults_total_values(default_vaults_map, validators, [])
+        result = service.get_vaults_total_values(default_vaults_map, validators, [], block_identifier="latest")
 
         # Assert
         assert result[VaultAddresses.VAULT_0] == default_vaults_map[VaultAddresses.VAULT_0].aggregated_balance
+        service.w3.lido_contracts.lazy_oracle.get_validator_statuses.assert_called_with(
+            pubkeys=ANY, block_identifier="latest", batch_size=ANY
+        )
 
     def test_predeposited_validator_with_pending_deposit_no_double_count(self, web3, default_vaults_map):
         # Setup
@@ -367,13 +392,18 @@ class TestGetVaultsTotalValuesWithValidatorStatuses:
         service = StakingVaultsService(web3)
 
         # Act
-        result = service.get_vaults_total_values(default_vaults_map, validators, pending_deposits)
+        result = service.get_vaults_total_values(
+            default_vaults_map, validators, pending_deposits, block_identifier="latest"
+        )
 
         # Assert
         expected_vault_0 = default_vaults_map[VaultAddresses.VAULT_0].aggregated_balance + gwei_to_wei(
             Gwei(1_000_000_000)
         )
         assert result[VaultAddresses.VAULT_0] == expected_vault_0
+        service.w3.lido_contracts.lazy_oracle.get_validator_statuses.assert_called_with(
+            pubkeys=ANY, block_identifier="latest", batch_size=ANY
+        )
 
     def test_doppelganger_pubkey_not_counted(self, web3, default_vaults_map):
         # Setup
@@ -396,11 +426,14 @@ class TestGetVaultsTotalValuesWithValidatorStatuses:
         service = StakingVaultsService(web3)
 
         # Act
-        result = service.get_vaults_total_values(default_vaults_map, validators, [])
+        result = service.get_vaults_total_values(default_vaults_map, validators, [], block_identifier="latest")
 
         # Assert
         assert result[VaultAddresses.VAULT_0] == default_vaults_map[VaultAddresses.VAULT_0].aggregated_balance
         assert result[VaultAddresses.VAULT_1] == default_vaults_map[VaultAddresses.VAULT_1].aggregated_balance
+        service.w3.lido_contracts.lazy_oracle.get_validator_statuses.assert_called_with(
+            pubkeys=ANY, block_identifier="latest", batch_size=ANY
+        )
 
 
 @pytest.mark.unit
@@ -427,11 +460,14 @@ class TestGetVaultsTotalValuesEdgeCases:
         service = StakingVaultsService(web3)
 
         # Act
-        result = service.get_vaults_total_values(default_vaults_map, [], pending_deposits)
+        result = service.get_vaults_total_values(default_vaults_map, [], pending_deposits, block_identifier="latest")
 
         # Assert
         # No extra 1 ETH should be counted because stage is not PREDEPOSITED.
         assert result[VaultAddresses.VAULT_0] == default_vaults_map[VaultAddresses.VAULT_0].aggregated_balance
+        service.w3.lido_contracts.lazy_oracle.get_validator_statuses.assert_called_with(
+            pubkeys=ANY, block_identifier="latest", batch_size=ANY
+        )
 
     def test_far_future_validator_without_status_skipped(self, web3, default_vaults_map):
         # Setup
@@ -453,11 +489,14 @@ class TestGetVaultsTotalValuesEdgeCases:
         service = StakingVaultsService(web3)
 
         # Act
-        result = service.get_vaults_total_values(default_vaults_map, validators, [])
+        result = service.get_vaults_total_values(default_vaults_map, validators, [], block_identifier="latest")
 
         # Assert
         # Validator should be ignored entirely.
         assert result[VaultAddresses.VAULT_0] == default_vaults_map[VaultAddresses.VAULT_0].aggregated_balance
+        service.w3.lido_contracts.lazy_oracle.get_validator_statuses.assert_called_with(
+            pubkeys=ANY, block_identifier="latest", batch_size=ANY
+        )
 
 
 @pytest.mark.unit
@@ -477,7 +516,7 @@ class TestGetVaultsTotalValuesDefaults:
         service._calculate_vault_total_value = MagicMock(return_value=123)
 
         # Act
-        result = service.get_vaults_total_values(default_vaults_map, [], [])
+        result = service.get_vaults_total_values(default_vaults_map, [], [], block_identifier="latest")
 
         # Assert
         service._get_pubkey_statuses_by_vault.assert_has_calls(
@@ -494,6 +533,7 @@ class TestGetVaultsTotalValuesDefaults:
             ],
             any_order=False,
         )
+        service._get_pubkey_statuses_by_vault.assert_called_with(pubkeys=ANY, block_identifier="latest")
 
 
 @pytest.mark.unit

--- a/tests/modules/accounting/test_accounting_module.py
+++ b/tests/modules/accounting/test_accounting_module.py
@@ -480,7 +480,7 @@ def test_get_shares_to_burn(
     assert out == shares_data.cover_shares + shares_data.non_cover_shares, (
         "get_shares_to_burn returned unexpected value"
     )
-    call_mock.assert_called_once()
+    call_mock.assert_called_once_with(bs.block_hash)
 
 
 @pytest.mark.unit
@@ -629,6 +629,7 @@ def test_accounting_get_processing_state_no_yet_init_epoch(accounting: Accountin
     assert processing_state.processing_deadline_time == 200
     assert processing_state.main_data_submitted is False
     assert processing_state.main_data_hash == ZERO_HASH
+    accounting.report_contract.get_processing_state.assert_called_once_with(bs.block_hash)
 
 
 @pytest.mark.unit
@@ -639,6 +640,7 @@ def test_accounting_get_processing_state(accounting: Accounting):
     result = accounting._get_processing_state(bs)
 
     assert accounting_processing_state == result
+    accounting.report_contract.get_processing_state.assert_called_once_with(bs.block_hash)
 
 
 # ---- refresh_contracts / is_contracts_addresses_changed ----
@@ -823,6 +825,9 @@ def test_get_extra_data(accounting: Accounting, ref_bs: ReferenceBlockStamp):
 
     assert result is expected_result
     mock_collect.assert_called_once_with(exited_validators, 10, 20)
+    accounting.w3.lido_contracts.oracle_report_sanity_checker.get_oracle_report_limits.assert_called_once_with(
+        ref_bs.block_hash
+    )
 
 
 # ---- _handle_vaults_report ----

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -316,6 +316,10 @@ def test_get_last_finalized_withdrawal_request_epoch(safe_border):
     epoch = slot // safe_border.chain_config.slots_per_epoch
 
     assert safe_border._get_last_finalized_withdrawal_request_epoch() == epoch
+    safe_border.w3.lido_contracts.withdrawal_queue_nft.get_withdrawal_status.assert_called_once_with(
+        3,
+        safe_border.blockstamp.block_hash,
+    )
 
 
 @pytest.mark.unit

--- a/tests/modules/accounting/test_safe_border_unit.py
+++ b/tests/modules/accounting/test_safe_border_unit.py
@@ -114,7 +114,7 @@ def test_get_negative_rebase_border_epoch_bunker_not_started_yet(safe_border, pa
 def test_get_negative_rebase_border_epoch_max(safe_border, past_blockstamp):
     ref_epoch = past_blockstamp.ref_slot // SLOTS_PER_EPOCH
     max_negative_rebase_shift = (
-        safe_border.w3.lido_contracts.oracle_daemon_config.finalization_max_negative_rebase_epoch_shift()
+        safe_border.w3.lido_contracts.oracle_daemon_config.finalization_max_negative_rebase_epoch_shift('latest')
     )
     test_epoch = ref_epoch - max_negative_rebase_shift - 1
     safe_border._get_bunker_mode_start_timestamp = Mock(return_value=test_epoch * SLOTS_PER_EPOCH * SLOT_TIME)

--- a/tests/modules/csm/test_csm_module.py
+++ b/tests/modules/csm/test_csm_module.py
@@ -1116,6 +1116,7 @@ def test_is_main_data_submitted(module: CSPerformanceOracle, last_ref_slot: int,
     )
 
     assert module.is_main_data_submitted(blockstamp) is expected
+    module.w3.staking_module.get_last_processing_ref_slot.assert_called_once_with(blockstamp)
 
 
 @pytest.mark.parametrize("submitted", [True, False])

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -141,6 +141,14 @@ def test_ejector_execute_module_on_pause(ejector: Ejector, blockstamp: BlockStam
     result = ejector.execute_module(last_finalized_blockstamp=blockstamp)
 
     assert result is ModuleExecuteDelay.NEXT_SLOT, "execute_module should wait for the next slot"
+    # Compatibility check reads versions both at the report block and at the chain head
+    vebo = ejector.w3.lido_contracts.validators_exit_bus_oracle
+    vebo.get_contract_version.assert_any_call(blockstamp.block_hash)
+    vebo.get_contract_version.assert_any_call('latest')
+    vebo.get_consensus_version.assert_any_call(blockstamp.block_hash)
+    vebo.get_consensus_version.assert_any_call('latest')
+    # Pause state is intentionally checked at the chain head
+    vebo.is_paused.assert_called_once_with('latest')
 
 
 @pytest.mark.unit
@@ -490,6 +498,7 @@ def test_ejector_get_processing_state_no_yet_init_epoch(ejector: Ejector):
     assert processing_state.current_frame_ref_slot == 100
     assert processing_state.processing_deadline_time == 200
     assert processing_state.data_submitted is False
+    ejector.report_contract.get_processing_state.assert_called_once_with(bs.block_hash)
 
 
 @pytest.mark.unit
@@ -500,6 +509,7 @@ def test_ejector_get_processing_state(ejector: Ejector):
     result = ejector._get_processing_state(bs)
 
     assert accounting_processing_state == result
+    ejector.report_contract.get_processing_state.assert_called_once_with(bs.block_hash)
 
 
 @pytest.mark.unit
@@ -577,6 +587,10 @@ def test_get_deposit_lock_amount__calculates_frames_ceiling__scales_by_reserve(
     # 2.5 frames → 25 // 10 = 2 frames
     assert ejector._get_deposit_lock_amount(25, ref_blockstamp) == Wei(2 * reserve_per_frame)
 
+    # All on-chain reads must be pinned to the report block, not the chain head
+    ejector.w3.lido_contracts.accounting_oracle.get_consensus_contract.assert_called_with(ref_blockstamp.block_hash)
+    mock_consensus.get_frame_config.assert_called_with(ref_blockstamp.block_hash)
+
 
 @pytest.mark.unit
 def test_get_deposit_lock_amount__capped_by_max_wr_when_smaller(
@@ -595,6 +609,10 @@ def test_get_deposit_lock_amount__capped_by_max_wr_when_smaller(
     # reserve_per_frame = min(100, 30) = 30 → max_wr_wei is the binding constraint
     assert ejector._get_deposit_lock_amount(10, ref_blockstamp) == Wei(max_wr_wei)
     assert ejector._get_deposit_lock_amount(25, ref_blockstamp) == Wei(2 * max_wr_wei)
+
+    # All on-chain reads must be pinned to the report block, not the chain head
+    ejector.w3.lido_contracts.accounting_oracle.get_consensus_contract.assert_called_with(ref_blockstamp.block_hash)
+    mock_consensus.get_frame_config.assert_called_with(ref_blockstamp.block_hash)
 
 
 class ForcedIterator:

--- a/tests/modules/submodules/consensus/test_consensus.py
+++ b/tests/modules/submodules/consensus/test_consensus.py
@@ -231,6 +231,9 @@ def test_first_frame_is_not_yet_started(web3, consensus, caplog, use_account):
     assert member_info.current_frame_ref_slot == first_frame.ref_slot
     assert member_info.deadline_slot == first_frame.report_processing_deadline_slot
 
+    # Frame resolution must be pinned to the report block, not the chain head
+    consensus_contract.get_current_frame.assert_called_once_with(bs.block_hash)
+
 
 @pytest.mark.unit
 def test_get_blockstamp_for_report_slot_deadline_missed(web3, consensus, caplog, set_no_account):
@@ -284,6 +287,12 @@ def test_contract_upgrade_before_report_submited(consensus, contract_version, co
 
     assert expected == consensus._check_compatibility(bs)
 
+    # Versions are read both at the report block and at the chain head, then compared
+    consensus.report_contract.get_contract_version.assert_any_call(bs.block_hash)
+    consensus.report_contract.get_contract_version.assert_any_call('latest')
+    consensus.report_contract.get_consensus_version.assert_any_call(bs.block_hash)
+    consensus.report_contract.get_consensus_version.assert_any_call('latest')
+
 
 @pytest.mark.unit
 def test_incompatible_contract_version(consensus):
@@ -294,6 +303,9 @@ def test_incompatible_contract_version(consensus):
 
     with pytest.raises(IncompatibleOracleVersion):
         consensus._check_compatibility(bs)
+
+    # The first compatibility read must be pinned to the report block
+    consensus.report_contract.get_contract_version.assert_called_once_with(bs.block_hash)
 
 
 @pytest.mark.unit

--- a/tests/providers/test_lido.py
+++ b/tests/providers/test_lido.py
@@ -24,7 +24,7 @@ class TestLidoSmoke:
         return cast(
             LidoContract,
             web3_integration.eth.contract(
-                address=lido_locator.lido(),
+                address=lido_locator.lido('latest'),
                 ContractFactoryClass=LidoContract,
                 decode_tuples=True,
             ),

--- a/tests/providers/test_staking_vaults.py
+++ b/tests/providers/test_staking_vaults.py
@@ -26,13 +26,15 @@ class TestStakingVaultsContractsSmoke:
         assert len(events) == 0
 
     def test_vault_lazy_oracle_get_report(self, web3_integration):
-        report = web3_integration.lido_contracts.lazy_oracle.get_latest_report_data()
+        report = web3_integration.lido_contracts.lazy_oracle.get_latest_report_data('latest')
         assert report is not None
 
     def test_get_vaults(self, web3_integration):
-        vaults = web3_integration.lido_contracts.lazy_oracle.get_all_vaults()
+        vaults = web3_integration.lido_contracts.lazy_oracle.get_all_vaults('latest')
         assert len(vaults) != 0
 
     def test_get_slashing_reserve(self, web3_integration):
-        slashing_reserve = web3_integration.lido_contracts.oracle_daemon_config.slashing_reserve_we_right_shift()
+        slashing_reserve = web3_integration.lido_contracts.oracle_daemon_config.slashing_reserve_we_right_shift(
+            'latest'
+        )
         assert slashing_reserve != 0

--- a/tests/web3py/test_delegation_module.py
+++ b/tests/web3py/test_delegation_module.py
@@ -44,6 +44,8 @@ class TestDelegationModule:
         assert module.delegation_contract is not None
         assert module.is_enabled() is True
         assert 'Delegation contract validation passed' in caplog.text
+        module.delegation_contract.get_delegatee.assert_called_once_with('latest')
+        module.delegation_contract.get_admin.assert_called_once_with('latest')
 
     def test_init__no_account__skips_validation(self, mock_w3, monkeypatch, caplog):
         monkeypatch.setattr(variables, 'ACCOUNT', None)
@@ -59,6 +61,7 @@ class TestDelegationModule:
 
         with pytest.raises(DelegationModule.NotConfiguredError):
             DelegationModule(mock_w3, delegation_address=DUMMY_ADDRESS)
+        mock_w3.eth.contract.return_value.get_delegatee.assert_called_once_with('latest')
 
     def test_init__delegatee_mismatch__raises_mismatch_error(self, mock_w3, mock_account, monkeypatch):
         monkeypatch.setattr(variables, 'ACCOUNT', mock_account)
@@ -67,6 +70,7 @@ class TestDelegationModule:
 
         with pytest.raises(DelegationModule.DelegateMismatchError):
             DelegationModule(mock_w3, delegation_address=DUMMY_ADDRESS)
+        mock_w3.eth.contract.return_value.get_delegatee.assert_called_once_with('latest')
 
     def test_wrap_call_for_delegation__disabled_delegation__raises_runtime_error(self, mock_w3):
         module = DelegationModule(mock_w3, delegation_address=None)

--- a/tests/web3py/test_staking_module.py
+++ b/tests/web3py/test_staking_module.py
@@ -98,6 +98,7 @@ def test_get_rewards_tree_cid_returns_none_for_empty(w3: Web3StakingModule, bloc
     result = w3.staking_module.get_rewards_tree_cid(blockstamp)
 
     assert result is None
+    w3.staking_module.fee_distributor.tree_cid.assert_called_once_with(BLOCK_HASH)
 
 
 @pytest.mark.unit
@@ -108,6 +109,7 @@ def test_get_rewards_tree_cid_returns_cidv0(w3: Web3StakingModule, blockstamp):
 
     assert isinstance(result, CIDv0)
     assert str(result) == CIDV0_EXAMPLE
+    w3.staking_module.fee_distributor.tree_cid.assert_called_once_with(BLOCK_HASH)
 
 
 @pytest.mark.unit
@@ -118,6 +120,7 @@ def test_get_rewards_tree_cid_returns_cidv1(w3: Web3StakingModule, blockstamp):
 
     assert isinstance(result, CIDv1)
     assert str(result) == CIDV1_EXAMPLE
+    w3.staking_module.fee_distributor.tree_cid.assert_called_once_with(BLOCK_HASH)
 
 
 @pytest.mark.unit
@@ -138,6 +141,7 @@ def test_get_strikes_tree_cid_returns_none_for_empty(w3: Web3StakingModule, bloc
     result = w3.staking_module.get_strikes_tree_cid(blockstamp)
 
     assert result is None
+    w3.staking_module.strikes.tree_cid.assert_called_once_with(BLOCK_HASH)
 
 
 @pytest.mark.unit
@@ -148,6 +152,7 @@ def test_get_strikes_tree_cid_returns_cidv0(w3: Web3StakingModule, blockstamp):
 
     assert isinstance(result, CIDv0)
     assert str(result) == CIDV0_EXAMPLE
+    w3.staking_module.strikes.tree_cid.assert_called_once_with(BLOCK_HASH)
 
 
 @pytest.mark.unit
@@ -158,6 +163,7 @@ def test_get_strikes_tree_cid_returns_cidv1(w3: Web3StakingModule, blockstamp):
 
     assert isinstance(result, CIDv1)
     assert str(result) == CIDV1_EXAMPLE
+    w3.staking_module.strikes.tree_cid.assert_called_once_with(BLOCK_HASH)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Description
This pull request standardizes how contract-related methods handle the `block_identifier` parameter across multiple files. Previously, many contract interface methods defaulted this parameter to `'latest'`. Now, all such methods require the caller to explicitly provide a `block_identifier`, improving clarity and reducing the risk of accidental usage of the latest block when a specific block context is needed.

## Related Issue/Task
- Related task: #orc-535
- Epic: v9

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [ ] New tests added (if applicable)
- [ ] `CSM_STATE_VERSION` is bumped (if the new version affects data in the cache)
