### PR TITLE
feat(orc-112): add final tests before image publishing

### DIFF
--- a/.github/actions/test-image/action.yml
+++ b/.github/actions/test-image/action.yml
@@ -1,0 +1,43 @@
+name: Build and test image
+description: >
+  Build the testing Docker image and run the test suite inside it.
+  Expects the required secrets to be set as env vars on the calling step.
+
+inputs:
+  pytest-args:
+    description: "Arguments passed to pytest inside the image"
+    default: "-m 'not fork' tests"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Build test image
+      shell: bash
+      run: docker build --target testing -t oracle:testing .
+
+    - name: Test the image with pytest
+      shell: bash
+      run: >
+        docker run --rm
+        -v "$PWD/tests:/app/tests"
+        -e EXECUTION_CLIENT_URI
+        -e CONSENSUS_CLIENT_URI
+        -e KEYS_API_URI
+        -e TESTNET_EXECUTION_CLIENT_URI
+        -e TESTNET_CONSENSUS_CLIENT_URI
+        -e TESTNET_KAPI_URI
+        -e CS_MODULE_ADDRESS
+        -e CURATED_MODULE_ADDRESS
+        -e PINATA_JWT
+        -e PINATA_DEDICATED_GATEWAY_URL
+        -e PINATA_DEDICATED_GATEWAY_TOKEN
+        -e LIDO_IPFS_TOKEN
+        -e LIDO_IPFS_HOST
+        -e FILEBASE_IPFS_HOST
+        -e FILEBASE_IPFS_TOKEN
+        oracle:testing
+        pytest ${{ inputs.pytest-args }}
+      env:
+        CS_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F"
+        CURATED_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F" # TODO: replace with actual address

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -9,17 +9,60 @@ on:
       - ".github/**"
       - "README.md"
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
-  # test:
-  #   ...
-
   deploy:
     runs-on: ubuntu-latest
-    # needs: test
     name: Build and deploy
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Build test image
+        run: docker build --target test -t oracle:test .
+
+      - name: Test the image with pytest
+        timeout-minutes: 60
+        run: >
+          docker run --rm
+          -e EXECUTION_CLIENT_URI
+          -e CONSENSUS_CLIENT_URI
+          -e KEYS_API_URI
+          -e TESTNET_EXECUTION_CLIENT_URI
+          -e TESTNET_CONSENSUS_CLIENT_URI
+          -e TESTNET_KAPI_URI
+          -e CS_MODULE_ADDRESS
+          -e CURATED_MODULE_ADDRESS
+          -e PINATA_JWT
+          -e PINATA_DEDICATED_GATEWAY_URL
+          -e PINATA_DEDICATED_GATEWAY_TOKEN
+          -e LIDO_IPFS_TOKEN
+          -e LIDO_IPFS_HOST
+          -e FILEBASE_IPFS_HOST
+          -e FILEBASE_IPFS_TOKEN
+          oracle:test
+          pytest -m 'not fork' tests
+        env:
+          EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}
+          CONSENSUS_CLIENT_URI: ${{ secrets.CONSENSUS_CLIENT_URI }}
+          KEYS_API_URI: ${{ secrets.KEYS_API_URI }}
+          TESTNET_EXECUTION_CLIENT_URI: ${{ secrets.TESTNET_EXECUTION_CLIENT_URI }}
+          TESTNET_CONSENSUS_CLIENT_URI: ${{ secrets.TESTNET_CONSENSUS_CLIENT_URI }}
+          TESTNET_KAPI_URI: ${{ secrets.TESTNET_KAPI_URI }}
+          CS_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F"
+          CURATED_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F" # TODO: replace with actual address
+          PINATA_JWT: ${{ secrets.PINATA_JWT }}
+          PINATA_DEDICATED_GATEWAY_URL: ${{ secrets.PINATA_DEDICATED_GATEWAY_URL }}
+          PINATA_DEDICATED_GATEWAY_TOKEN: ${{ secrets.PINATA_DEDICATED_GATEWAY_TOKEN }}
+          LIDO_IPFS_TOKEN: ${{ secrets.LIDO_IPFS_TOKEN }}
+          LIDO_IPFS_HOST: ${{ secrets.LIDO_IPFS_HOST }}
+          FILEBASE_IPFS_HOST: ${{ secrets.FILEBASE_IPFS_HOST }}
+          FILEBASE_IPFS_TOKEN: ${{ secrets.FILEBASE_IPFS_TOKEN }}
+
       - name: Testnet deploy
         uses: lidofinance/dispatch-workflow@v1
         env:

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Build test image
-        run: docker build --target test -t oracle:test .
+        run: docker build --target testing -t oracle:testing .
 
       - name: Test the image with pytest
         timeout-minutes: 60
@@ -45,7 +45,7 @@ jobs:
           -e LIDO_IPFS_HOST
           -e FILEBASE_IPFS_HOST
           -e FILEBASE_IPFS_TOKEN
-          oracle:test
+          oracle:testing
           pytest -m 'not fork' tests
         env:
           EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -29,6 +29,7 @@ jobs:
         timeout-minutes: 60
         run: >
           docker run --rm
+          -v "$PWD/tests:/app/tests"
           -e EXECUTION_CLIENT_URI
           -e CONSENSUS_CLIENT_URI
           -e KEYS_API_URI

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -2,6 +2,12 @@ name: CI Dev Hoodi
 
 on:
   workflow_dispatch:
+    inputs:
+      skip-tests:
+        description: "Deploy without running tests"
+        default: false
+        required: false
+        type: boolean
   push:
     branches:
       - develop
@@ -22,31 +28,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build test image
-        run: docker build --target testing -t oracle:testing .
-
-      - name: Test the image with pytest
+      - name: Build and test image
+        if: ${{ !inputs.skip-tests }}
         timeout-minutes: 60
-        run: >
-          docker run --rm
-          -v "$PWD/tests:/app/tests"
-          -e EXECUTION_CLIENT_URI
-          -e CONSENSUS_CLIENT_URI
-          -e KEYS_API_URI
-          -e TESTNET_EXECUTION_CLIENT_URI
-          -e TESTNET_CONSENSUS_CLIENT_URI
-          -e TESTNET_KAPI_URI
-          -e CS_MODULE_ADDRESS
-          -e CURATED_MODULE_ADDRESS
-          -e PINATA_JWT
-          -e PINATA_DEDICATED_GATEWAY_URL
-          -e PINATA_DEDICATED_GATEWAY_TOKEN
-          -e LIDO_IPFS_TOKEN
-          -e LIDO_IPFS_HOST
-          -e FILEBASE_IPFS_HOST
-          -e FILEBASE_IPFS_TOKEN
-          oracle:testing
-          pytest -m 'not fork' tests
+        uses: ./.github/actions/test-image
         env:
           EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}
           CONSENSUS_CLIENT_URI: ${{ secrets.CONSENSUS_CLIENT_URI }}
@@ -54,8 +39,6 @@ jobs:
           TESTNET_EXECUTION_CLIENT_URI: ${{ secrets.TESTNET_EXECUTION_CLIENT_URI }}
           TESTNET_CONSENSUS_CLIENT_URI: ${{ secrets.TESTNET_CONSENSUS_CLIENT_URI }}
           TESTNET_KAPI_URI: ${{ secrets.TESTNET_KAPI_URI }}
-          CS_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F"
-          CURATED_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F" # TODO: replace with actual address
           PINATA_JWT: ${{ secrets.PINATA_JWT }}
           PINATA_DEDICATED_GATEWAY_URL: ${{ secrets.PINATA_DEDICATED_GATEWAY_URL }}
           PINATA_DEDICATED_GATEWAY_TOKEN: ${{ secrets.PINATA_DEDICATED_GATEWAY_TOKEN }}

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -27,9 +27,9 @@ jobs:
 
       - name: Test the image with pytest
         timeout-minutes: 60
-        # Fork tests run in a separate workflow.
         run: >
           docker run --rm
+          -v "$PWD/tests:/app/tests"
           -e EXECUTION_CLIENT_URI
           -e CONSENSUS_CLIENT_URI
           -e KEYS_API_URI

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -13,18 +13,56 @@ permissions:
   contents: read
 
 jobs:
-  # test:
-  #   ...
-
   deploy:
     runs-on: ubuntu-latest
-    # needs: test
     name: Build and deploy
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           persist-credentials: false
+
+      - name: Build test image
+        run: docker build --target test -t oracle:test .
+
+      - name: Test the image with pytest
+        timeout-minutes: 60
+        # Fork tests run in a separate workflow.
+        run: >
+          docker run --rm
+          -e EXECUTION_CLIENT_URI
+          -e CONSENSUS_CLIENT_URI
+          -e KEYS_API_URI
+          -e TESTNET_EXECUTION_CLIENT_URI
+          -e TESTNET_CONSENSUS_CLIENT_URI
+          -e TESTNET_KAPI_URI
+          -e CS_MODULE_ADDRESS
+          -e CURATED_MODULE_ADDRESS
+          -e PINATA_JWT
+          -e PINATA_DEDICATED_GATEWAY_URL
+          -e PINATA_DEDICATED_GATEWAY_TOKEN
+          -e LIDO_IPFS_TOKEN
+          -e LIDO_IPFS_HOST
+          -e FILEBASE_IPFS_HOST
+          -e FILEBASE_IPFS_TOKEN
+          oracle:test
+          pytest -m 'not fork' tests
+        env:
+          EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}
+          CONSENSUS_CLIENT_URI: ${{ secrets.CONSENSUS_CLIENT_URI }}
+          KEYS_API_URI: ${{ secrets.KEYS_API_URI }}
+          TESTNET_EXECUTION_CLIENT_URI: ${{ secrets.TESTNET_EXECUTION_CLIENT_URI }}
+          TESTNET_CONSENSUS_CLIENT_URI: ${{ secrets.TESTNET_CONSENSUS_CLIENT_URI }}
+          TESTNET_KAPI_URI: ${{ secrets.TESTNET_KAPI_URI }}
+          CS_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F"
+          CURATED_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F" # TODO: replace with actual address
+          PINATA_JWT: ${{ secrets.PINATA_JWT }}
+          PINATA_DEDICATED_GATEWAY_URL: ${{ secrets.PINATA_DEDICATED_GATEWAY_URL }}
+          PINATA_DEDICATED_GATEWAY_TOKEN: ${{ secrets.PINATA_DEDICATED_GATEWAY_TOKEN }}
+          LIDO_IPFS_TOKEN: ${{ secrets.LIDO_IPFS_TOKEN }}
+          LIDO_IPFS_HOST: ${{ secrets.LIDO_IPFS_HOST }}
+          FILEBASE_IPFS_HOST: ${{ secrets.FILEBASE_IPFS_HOST }}
+          FILEBASE_IPFS_TOKEN: ${{ secrets.FILEBASE_IPFS_TOKEN }}
 
       - name: Tag name
         id: tag_name

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -8,6 +8,11 @@ on:
         default: ""
         required: false
         type: string
+      skip-tests:
+        description: "Deploy without running tests"
+        default: false
+        required: false
+        type: boolean
 
 permissions:
   contents: read
@@ -22,31 +27,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build test image
-        run: docker build --target testing -t oracle:testing .
-
-      - name: Test the image with pytest
+      - name: Build and test image
+        if: ${{ !inputs.skip-tests }}
         timeout-minutes: 60
-        run: >
-          docker run --rm
-          -v "$PWD/tests:/app/tests"
-          -e EXECUTION_CLIENT_URI
-          -e CONSENSUS_CLIENT_URI
-          -e KEYS_API_URI
-          -e TESTNET_EXECUTION_CLIENT_URI
-          -e TESTNET_CONSENSUS_CLIENT_URI
-          -e TESTNET_KAPI_URI
-          -e CS_MODULE_ADDRESS
-          -e CURATED_MODULE_ADDRESS
-          -e PINATA_JWT
-          -e PINATA_DEDICATED_GATEWAY_URL
-          -e PINATA_DEDICATED_GATEWAY_TOKEN
-          -e LIDO_IPFS_TOKEN
-          -e LIDO_IPFS_HOST
-          -e FILEBASE_IPFS_HOST
-          -e FILEBASE_IPFS_TOKEN
-          oracle:testing
-          pytest -m 'not fork' tests
+        uses: ./.github/actions/test-image
         env:
           EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}
           CONSENSUS_CLIENT_URI: ${{ secrets.CONSENSUS_CLIENT_URI }}
@@ -54,8 +38,6 @@ jobs:
           TESTNET_EXECUTION_CLIENT_URI: ${{ secrets.TESTNET_EXECUTION_CLIENT_URI }}
           TESTNET_CONSENSUS_CLIENT_URI: ${{ secrets.TESTNET_CONSENSUS_CLIENT_URI }}
           TESTNET_KAPI_URI: ${{ secrets.TESTNET_KAPI_URI }}
-          CS_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F"
-          CURATED_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F" # TODO: replace with actual address
           PINATA_JWT: ${{ secrets.PINATA_JWT }}
           PINATA_DEDICATED_GATEWAY_URL: ${{ secrets.PINATA_DEDICATED_GATEWAY_URL }}
           PINATA_DEDICATED_GATEWAY_TOKEN: ${{ secrets.PINATA_DEDICATED_GATEWAY_TOKEN }}

--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Build test image
-        run: docker build --target test -t oracle:test .
+        run: docker build --target testing -t oracle:testing .
 
       - name: Test the image with pytest
         timeout-minutes: 60
@@ -45,7 +45,7 @@ jobs:
           -e LIDO_IPFS_HOST
           -e FILEBASE_IPFS_HOST
           -e FILEBASE_IPFS_TOKEN
-          oracle:test
+          oracle:testing
           pytest -m 'not fork' tests
         env:
           EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -27,9 +27,9 @@ jobs:
 
       - name: Test the image with pytest
         timeout-minutes: 60
-        # Fork tests run in a separate workflow.
         run: >
           docker run --rm
+          -v "$PWD/tests:/app/tests"
           -e EXECUTION_CLIENT_URI
           -e CONSENSUS_CLIENT_URI
           -e KEYS_API_URI

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -9,17 +9,61 @@ on:
       - ".github/**"
       - "README.md"
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
-  # test:
-  #   ...
-
   deploy:
     runs-on: ubuntu-latest
-    # needs: test
     name: Build and deploy
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Build test image
+        run: docker build --target test -t oracle:test .
+
+      - name: Test the image with pytest
+        timeout-minutes: 60
+        # Fork tests run in a separate workflow.
+        run: >
+          docker run --rm
+          -e EXECUTION_CLIENT_URI
+          -e CONSENSUS_CLIENT_URI
+          -e KEYS_API_URI
+          -e TESTNET_EXECUTION_CLIENT_URI
+          -e TESTNET_CONSENSUS_CLIENT_URI
+          -e TESTNET_KAPI_URI
+          -e CS_MODULE_ADDRESS
+          -e CURATED_MODULE_ADDRESS
+          -e PINATA_JWT
+          -e PINATA_DEDICATED_GATEWAY_URL
+          -e PINATA_DEDICATED_GATEWAY_TOKEN
+          -e LIDO_IPFS_TOKEN
+          -e LIDO_IPFS_HOST
+          -e FILEBASE_IPFS_HOST
+          -e FILEBASE_IPFS_TOKEN
+          oracle:test
+          pytest -m 'not fork' tests
+        env:
+          EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}
+          CONSENSUS_CLIENT_URI: ${{ secrets.CONSENSUS_CLIENT_URI }}
+          KEYS_API_URI: ${{ secrets.KEYS_API_URI }}
+          TESTNET_EXECUTION_CLIENT_URI: ${{ secrets.TESTNET_EXECUTION_CLIENT_URI }}
+          TESTNET_CONSENSUS_CLIENT_URI: ${{ secrets.TESTNET_CONSENSUS_CLIENT_URI }}
+          TESTNET_KAPI_URI: ${{ secrets.TESTNET_KAPI_URI }}
+          CS_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F"
+          CURATED_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F" # TODO: replace with actual address
+          PINATA_JWT: ${{ secrets.PINATA_JWT }}
+          PINATA_DEDICATED_GATEWAY_URL: ${{ secrets.PINATA_DEDICATED_GATEWAY_URL }}
+          PINATA_DEDICATED_GATEWAY_TOKEN: ${{ secrets.PINATA_DEDICATED_GATEWAY_TOKEN }}
+          LIDO_IPFS_TOKEN: ${{ secrets.LIDO_IPFS_TOKEN }}
+          LIDO_IPFS_HOST: ${{ secrets.LIDO_IPFS_HOST }}
+          FILEBASE_IPFS_HOST: ${{ secrets.FILEBASE_IPFS_HOST }}
+          FILEBASE_IPFS_TOKEN: ${{ secrets.FILEBASE_IPFS_TOKEN }}
+
       - name: Staging deploy
         uses: lidofinance/dispatch-workflow@v1
         env:

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -2,6 +2,12 @@ name: CI Staging
 
 on:
   workflow_dispatch:
+    inputs:
+      skip-tests:
+        description: "Deploy without running tests"
+        default: false
+        required: false
+        type: boolean
   push:
     branches:
       - master
@@ -22,31 +28,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build test image
-        run: docker build --target testing -t oracle:testing .
-
-      - name: Test the image with pytest
+      - name: Build and test image
+        if: ${{ !inputs.skip-tests }}
         timeout-minutes: 60
-        run: >
-          docker run --rm
-          -v "$PWD/tests:/app/tests"
-          -e EXECUTION_CLIENT_URI
-          -e CONSENSUS_CLIENT_URI
-          -e KEYS_API_URI
-          -e TESTNET_EXECUTION_CLIENT_URI
-          -e TESTNET_CONSENSUS_CLIENT_URI
-          -e TESTNET_KAPI_URI
-          -e CS_MODULE_ADDRESS
-          -e CURATED_MODULE_ADDRESS
-          -e PINATA_JWT
-          -e PINATA_DEDICATED_GATEWAY_URL
-          -e PINATA_DEDICATED_GATEWAY_TOKEN
-          -e LIDO_IPFS_TOKEN
-          -e LIDO_IPFS_HOST
-          -e FILEBASE_IPFS_HOST
-          -e FILEBASE_IPFS_TOKEN
-          oracle:testing
-          pytest -m 'not fork' tests
+        uses: ./.github/actions/test-image
         env:
           EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}
           CONSENSUS_CLIENT_URI: ${{ secrets.CONSENSUS_CLIENT_URI }}
@@ -54,8 +39,6 @@ jobs:
           TESTNET_EXECUTION_CLIENT_URI: ${{ secrets.TESTNET_EXECUTION_CLIENT_URI }}
           TESTNET_CONSENSUS_CLIENT_URI: ${{ secrets.TESTNET_CONSENSUS_CLIENT_URI }}
           TESTNET_KAPI_URI: ${{ secrets.TESTNET_KAPI_URI }}
-          CS_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F"
-          CURATED_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F" # TODO: replace with actual address
           PINATA_JWT: ${{ secrets.PINATA_JWT }}
           PINATA_DEDICATED_GATEWAY_URL: ${{ secrets.PINATA_DEDICATED_GATEWAY_URL }}
           PINATA_DEDICATED_GATEWAY_TOKEN: ${{ secrets.PINATA_DEDICATED_GATEWAY_TOKEN }}

--- a/.github/workflows/ci-staging.yml
+++ b/.github/workflows/ci-staging.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Build test image
-        run: docker build --target test -t oracle:test .
+        run: docker build --target testing -t oracle:testing .
 
       - name: Test the image with pytest
         timeout-minutes: 60
@@ -45,7 +45,7 @@ jobs:
           -e LIDO_IPFS_HOST
           -e FILEBASE_IPFS_HOST
           -e FILEBASE_IPFS_TOKEN
-          oracle:test
+          oracle:testing
           pytest -m 'not fork' tests
         env:
           EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}

--- a/.github/workflows/create-tag-and-trigger-deploy.yml
+++ b/.github/workflows/create-tag-and-trigger-deploy.yml
@@ -9,6 +9,11 @@ on:
         description: 'Tag version (e.g., 1.2.3)'
         required: true
         type: string
+      skip-tests:
+        description: 'Deploy without running tests'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -55,3 +60,4 @@ jobs:
     secrets: inherit
     with:
       tag: ${{ needs.bump.outputs.tag }}
+      skip-tests: ${{ inputs.skip-tests || false }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,27 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python 3.14
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.14"
-
-      - name: Setup poetry
-        run: >
-          curl -sSL https://install.python-poetry.org | python - &&
-          echo "$POETRY_HOME/bin" >> "$GITHUB_PATH"
-        env:
-          POETRY_HOME: "/opt/poetry"
-          POETRY_VERSION: 2.3.2
-
-      - name: Install dependencies
-        run: |
-          poetry install --no-interaction --with=dev
-
-      - name: Test with pytest
+      - name: Build and test image
         timeout-minutes: 60
-        # Fork tests running in separate workflow
-        run: poetry run pytest --cov=src -m 'not fork' tests
+        uses: ./.github/actions/test-image
+        with:
+          pytest-args: "--cov=src -m 'not fork' tests"
         env:
           EXECUTION_CLIENT_URI: ${{ secrets.EXECUTION_CLIENT_URI }}
           CONSENSUS_CLIENT_URI: ${{ secrets.CONSENSUS_CLIENT_URI }}
@@ -41,8 +25,6 @@ jobs:
           TESTNET_EXECUTION_CLIENT_URI: ${{ secrets.TESTNET_EXECUTION_CLIENT_URI }}
           TESTNET_CONSENSUS_CLIENT_URI: ${{ secrets.TESTNET_CONSENSUS_CLIENT_URI }}
           TESTNET_KAPI_URI: ${{ secrets.TESTNET_KAPI_URI }}
-          CS_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F"
-          CURATED_MODULE_ADDRESS: "0xdA7dE2ECdDfccC6c3AF10108Db212ACBBf9EA83F" # TODO: replace with actual address
           PINATA_JWT: ${{ secrets.PINATA_JWT }}
           PINATA_DEDICATED_GATEWAY_URL: ${{ secrets.PINATA_DEDICATED_GATEWAY_URL }}
           PINATA_DEDICATED_GATEWAY_TOKEN: ${{ secrets.PINATA_DEDICATED_GATEWAY_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,21 @@ COPY pyproject.toml poetry.lock ./
 RUN python3 -m venv "$VENV_PATH" && \
     VIRTUAL_ENV="$VENV_PATH" poetry install --no-root --with dev
 
+# Test stage: same venv and source as production, plus dev dependencies, so CI
+# can run the suite against the same code that ships. Must NOT be the last stage:
+# infra builds the Dockerfile without --target and pushes the last stage to the
+# registry, which has to stay `production`.
+FROM base AS test
+
+ARG POETRY_VERSION
+RUN pip install --no-cache-dir poetry==${POETRY_VERSION}
+
+COPY --from=builder $VENV_PATH $VENV_PATH
+WORKDIR /app
+COPY . .
+
+RUN VIRTUAL_ENV="$VENV_PATH" poetry install --no-root --with dev
+
 FROM base AS production
 
 COPY --from=builder $VENV_PATH $VENV_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,11 +66,11 @@ COPY pyproject.toml poetry.lock ./
 RUN python3 -m venv "$VENV_PATH" && \
     VIRTUAL_ENV="$VENV_PATH" poetry install --no-root --with dev
 
-# Test stage: same venv and source as production, plus dev dependencies, so CI
+# Testing stage: same venv and source as production, plus dev dependencies, so CI
 # can run the suite against the same code that ships. Must NOT be the last stage:
 # infra builds the Dockerfile without --target and pushes the last stage to the
 # registry, which has to stay `production`.
-FROM base AS test
+FROM base AS testing
 
 ARG POETRY_VERSION
 RUN pip install --no-cache-dir poetry==${POETRY_VERSION}


### PR DESCRIPTION
## Description
This pull request updates the CI/CD workflows and Dockerfile to improve the reliability and consistency of testing across development, staging, and production environments. The main changes introduce a dedicated Docker build stage for testing, and update the workflows to run tests inside this standardized environment before deploying.

## Related Issue/Task
- Related task: #[task number] (e.g., #123)
- Epic: [epic name or link, if applicable]

## How Has This Been Tested?
Describe how you tested the changes:
- [ ] Local tests (e.g., `pytest`)
- [x] Manual testing (describe steps)
Runned locally because u need to prepare release to test it fully on CI
- [] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [ ] New tests added (if applicable)
