### PR TITLE
fix: fix get_all_groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG SOURCE_DATE_EPOCH
 RUN apt-get update && apt-get install -y --no-install-recommends -qq \
     libffi-dev=3.4.8-2 \
     g++=4:14.2.0-1 \
-    curl=8.14.1-2+deb13u3 \
+    curl=8.14.1-2+deb13u4 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /var/cache/* \

--- a/src/providers/execution/contracts/meta_registry.py
+++ b/src/providers/execution/contracts/meta_registry.py
@@ -92,5 +92,7 @@ class MetaRegistryContract(ContractInterface):
         return response
 
     def get_all_groups(self, block_identifier: BlockIdentifier) -> list[OperatorGroup]:
+        # Group IDs are one-based: the contract reserves NO_GROUP_ID = 0
+        # and creates real groups with IDs 1..groupsCount.
         all_groups = self.get_operator_groups_count(block_identifier)
-        return [self.get_operator_group(group_id, block_identifier) for group_id in range(all_groups)]
+        return [self.get_operator_group(group_id, block_identifier) for group_id in range(1, all_groups + 1)]

--- a/tests/execution/contracts/test_contract_transformations.py
+++ b/tests/execution/contracts/test_contract_transformations.py
@@ -5,7 +5,7 @@ pass-through methods (to maintain coverage without integration tests).
 
 from collections import namedtuple
 from typing import cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from eth_typing import BlockNumber, ChecksumAddress, Hash32
@@ -866,6 +866,7 @@ class TestMetaRegistryGetAllGroups:
         contract.get_operator_group.assert_any_call(1, "latest")
         contract.get_operator_group.assert_any_call(2, "latest")
         contract.get_operator_group.assert_any_call(3, "latest")
+        assert call(0, "latest") not in contract.get_operator_group.call_args_list
 
     def test_single_group(self):
         contract = _mock_contract()

--- a/tests/execution/contracts/test_contract_transformations.py
+++ b/tests/execution/contracts/test_contract_transformations.py
@@ -863,9 +863,9 @@ class TestMetaRegistryGetAllGroups:
         result = MetaRegistryContract.get_all_groups(contract, block_identifier="latest")
 
         assert result == groups
-        contract.get_operator_group.assert_any_call(0, "latest")
         contract.get_operator_group.assert_any_call(1, "latest")
         contract.get_operator_group.assert_any_call(2, "latest")
+        contract.get_operator_group.assert_any_call(3, "latest")
 
     def test_single_group(self):
         contract = _mock_contract()
@@ -876,6 +876,7 @@ class TestMetaRegistryGetAllGroups:
         result = MetaRegistryContract.get_all_groups(contract, block_identifier=100)
 
         assert result == [group]
+        contract.get_operator_group.assert_called_once_with(1, 100)
 
 
 @pytest.mark.unit

--- a/tests/integration/contracts/test_meta_registry.py
+++ b/tests/integration/contracts/test_meta_registry.py
@@ -30,7 +30,7 @@ def test_meta_registry_get_operator_group(meta_registry_contract, caplog):
     check_contract(
         meta_registry_contract,
         [
-            ('get_operator_group', (0, 'latest'), make_checker(OperatorGroup)),
+            ('get_operator_group', (1, 'latest'), make_checker(OperatorGroup)),
         ],
         caplog,
     )


### PR DESCRIPTION
## Description

This pull request updates the logic for fetching operator groups from the MetaRegistry contract to correctly handle group IDs as one-based (starting from 1) rather than zero-based. The associated tests have been updated to reflect this change and ensure proper coverage.

**Operator group indexing fix:**

* Updated `get_all_groups` in `meta_registry.py` to fetch groups using group IDs from 1 to `groupsCount` (inclusive), instead of starting from 0. This aligns with the contract's convention that group IDs are one-based and 0 is reserved.

**Test updates for new indexing:**

* Modified `test_contract_transformations.py` to remove assertions for group ID 0 and ensure that group fetching starts at 1, including checks for higher group IDs as appropriate. [[1]](diffhunk://#diff-88e2c22f238bf3b2c531bf575117faa7c85eca6743d6cd6b61e096e93493781fL866-R868) [[2]](diffhunk://#diff-88e2c22f238bf3b2c531bf575117faa7c85eca6743d6cd6b61e096e93493781fR879)
* Updated `test_meta_registry.py` integration test to expect the first group ID as 1 instead of 0.

## Related Issue/Task
- Related task: n/a
- Epic: srv3

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [ ] New tests added (if applicable)
