### PR TITLE
fix: Fix sweep calculation for validators to eject

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG SOURCE_DATE_EPOCH
 RUN apt-get update && apt-get install -y --no-install-recommends -qq \
     libffi-dev=3.4.8-2 \
     g++=4:14.2.0-1 \
-    curl=8.14.1-2+deb13u3 \
+    curl=8.14.1-2+deb13u4 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /var/cache/* \

--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -28,7 +28,7 @@ from src.providers.execution.contracts.hash_consensus import HashConsensusContra
 from src.services.exit_order_iterator import ValidatorExitIterator, WeightsNotUpdatedError
 from src.services.prediction import RewardsPredictionService
 from src.services.validator_state import LidoValidatorStateService
-from src.types import BlockStamp, EpochNumber, Gwei, NodeOperatorGlobalIndex, ReferenceBlockStamp, ValidatorIndex
+from src.types import BlockStamp, EpochNumber, Gwei, NodeOperatorGlobalIndex, ReferenceBlockStamp
 from src.utils.cache import global_lru_cache as lru_cache
 from src.utils.units import gwei_to_wei
 from src.utils.validator_balance import (
@@ -235,15 +235,12 @@ class Ejector(OracleModule[Web3]):
         going_to_withdraw_balance_gwei = Gwei(
             sum(
                 map(
-                    get_predictable_full_inbound_balance,
+                    get_predictable_inbound_balance,
                     validators_going_to_exit,
                 ),
                 Gwei(0),
             )
         )
-
-        # must be excluded from the sweep total below to avoid double-counting their excess balance.
-        going_to_withdraw_indices = frozenset(v.index for v in validators_going_to_exit)
 
         withdrawal_epoch = self._get_predicted_withdrawable_epoch(
             going_to_withdraw_balance_gwei + to_exit_gwei,
@@ -257,9 +254,7 @@ class Ejector(OracleModule[Web3]):
         future_rewards = time_to_last_withdrawal_in_epoch * rewards_speed_per_epoch
         logger.info({'msg': 'Calculate future rewards.', 'value': future_rewards})
 
-        future_withdrawals = self._get_withdrawable_lido_validators_balance(
-            withdrawal_epoch, blockstamp, going_to_withdraw_indices
-        )
+        future_withdrawals = self._get_withdrawable_lido_validators_balance(withdrawal_epoch, blockstamp)
         logger.info({'msg': 'Calculate future withdrawals sum.', 'value': future_withdrawals})
 
         deposit_lock = self._get_deposit_lock_amount(time_to_last_withdrawal_in_epoch, blockstamp)
@@ -274,21 +269,13 @@ class Ejector(OracleModule[Web3]):
         )
 
     @lru_cache(maxsize=1)
-    def _get_withdrawable_lido_validators_balance(
-        self,
-        on_epoch: EpochNumber,
-        blockstamp: BlockStamp,
-        exclude_indices: frozenset[ValidatorIndex],
-    ) -> Wei:
+    def _get_withdrawable_lido_validators_balance(self, on_epoch: EpochNumber, blockstamp: BlockStamp) -> Wei:
         lido_validators = self.w3.lido_validators.get_active_lido_validators(blockstamp=blockstamp)
 
         result = Gwei(0)
 
         for v in lido_validators:
             if v.consolidating_as_source:
-                continue
-
-            if v.index in exclude_indices:
                 continue
 
             if is_fully_withdrawable_validator(v.validator, v.balance, on_epoch):

--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -28,7 +28,7 @@ from src.providers.execution.contracts.hash_consensus import HashConsensusContra
 from src.services.exit_order_iterator import ValidatorExitIterator, WeightsNotUpdatedError
 from src.services.prediction import RewardsPredictionService
 from src.services.validator_state import LidoValidatorStateService
-from src.types import BlockStamp, EpochNumber, Gwei, NodeOperatorGlobalIndex, ReferenceBlockStamp
+from src.types import BlockStamp, EpochNumber, Gwei, NodeOperatorGlobalIndex, ReferenceBlockStamp, ValidatorIndex
 from src.utils.cache import global_lru_cache as lru_cache
 from src.utils.units import gwei_to_wei
 from src.utils.validator_balance import (
@@ -242,6 +242,9 @@ class Ejector(OracleModule[Web3]):
             )
         )
 
+        # must be excluded from the sweep total below to avoid double-counting their excess balance.
+        going_to_withdraw_indices = frozenset(v.index for v in validators_going_to_exit)
+
         withdrawal_epoch = self._get_predicted_withdrawable_epoch(
             going_to_withdraw_balance_gwei + to_exit_gwei,
             blockstamp,
@@ -254,7 +257,9 @@ class Ejector(OracleModule[Web3]):
         future_rewards = time_to_last_withdrawal_in_epoch * rewards_speed_per_epoch
         logger.info({'msg': 'Calculate future rewards.', 'value': future_rewards})
 
-        future_withdrawals = self._get_withdrawable_lido_validators_balance(withdrawal_epoch, blockstamp)
+        future_withdrawals = self._get_withdrawable_lido_validators_balance(
+            withdrawal_epoch, blockstamp, going_to_withdraw_indices
+        )
         logger.info({'msg': 'Calculate future withdrawals sum.', 'value': future_withdrawals})
 
         deposit_lock = self._get_deposit_lock_amount(time_to_last_withdrawal_in_epoch, blockstamp)
@@ -269,13 +274,21 @@ class Ejector(OracleModule[Web3]):
         )
 
     @lru_cache(maxsize=1)
-    def _get_withdrawable_lido_validators_balance(self, on_epoch: EpochNumber, blockstamp: BlockStamp) -> Wei:
+    def _get_withdrawable_lido_validators_balance(
+        self,
+        on_epoch: EpochNumber,
+        blockstamp: BlockStamp,
+        exclude_indices: frozenset[ValidatorIndex],
+    ) -> Wei:
         lido_validators = self.w3.lido_validators.get_active_lido_validators(blockstamp=blockstamp)
 
         result = Gwei(0)
 
         for v in lido_validators:
             if v.consolidating_as_source:
+                continue
+
+            if v.index in exclude_indices:
                 continue
 
             if is_fully_withdrawable_validator(v.validator, v.balance, on_epoch):

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -259,6 +259,68 @@ def test_is_contract_reportable(ejector: Ejector, blockstamp: BlockStamp) -> Non
     ejector.is_main_data_submitted.assert_called_once_with(blockstamp)
 
 
+class TestGetPredictedElBalance:
+    """
+    Covers the going-to-exit balance leg of `_get_predicted_el_balance`: validators recently
+    requested to exit but not yet exiting must contribute only their capped (sweep-excluded)
+    balance, both to the returned EL balance and to the churn/withdrawal-epoch prediction —
+    otherwise the excess above the effective balance cap (which is separately swept) gets
+    double-counted.
+    """
+
+    @pytest.fixture(autouse=True)
+    def mock_common(self, ejector: Ejector, chain_config: ChainConfig, ref_blockstamp: ReferenceBlockStamp) -> None:
+        ejector.get_chain_config = Mock(return_value=chain_config)
+        ejector._get_total_el_balance = Mock(return_value=Wei(0))
+        ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
+        ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(0))
+        ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
+        ejector._get_withdrawable_lido_validators_balance = Mock(return_value=Wei(0))
+        ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
+
+    @pytest.mark.unit
+    def test_going_to_exit_validator_above_cap__returned_balance_uses_capped_amount(
+        self,
+        ejector: Ejector,
+        ref_blockstamp: ReferenceBlockStamp,
+    ) -> None:
+        # Regular (non-compounding) validator sitting above its 32 ETH effective balance cap,
+        # e.g. because it hasn't been swept yet.
+        balance = Gwei(40 * 10**9)
+        going_to_exit_validator = build_extended_validator_with_balance(balance, meb=MAX_EFFECTIVE_BALANCE)
+        capped_balance = Gwei(MIN_ACTIVATION_BALANCE)
+
+        ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(
+            return_value=[going_to_exit_validator]
+        )
+
+        result = ejector._get_predicted_el_balance(Gwei(0), ref_blockstamp)
+
+        assert result == capped_balance * GWEI_TO_WEI, (
+            "Only the capped portion of a going-to-exit validator's balance should count — "
+            "the excess above the cap is already accounted for via the sweep and must not be added twice"
+        )
+
+    @pytest.mark.unit
+    def test_going_to_exit_validator_above_cap__withdrawal_epoch_prediction_uses_capped_amount(
+        self,
+        ejector: Ejector,
+        ref_blockstamp: ReferenceBlockStamp,
+    ) -> None:
+        balance = Gwei(40 * 10**9)
+        going_to_exit_validator = build_extended_validator_with_balance(balance, meb=MAX_EFFECTIVE_BALANCE)
+        capped_balance = Gwei(MIN_ACTIVATION_BALANCE)
+        to_exit_gwei = Gwei(5 * 10**9)
+
+        ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(
+            return_value=[going_to_exit_validator]
+        )
+
+        ejector._get_predicted_el_balance(to_exit_gwei, ref_blockstamp)
+
+        ejector._get_predicted_withdrawable_epoch.assert_called_once_with(capped_balance + to_exit_gwei, ref_blockstamp)
+
+
 class TestPredictedWithdrawableEpoch:
     @pytest.fixture
     def ref_blockstamp(self) -> ReferenceBlockStamp:

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -23,7 +23,7 @@ from src.providers.consensus.types import (
 from src.providers.execution.contracts.exit_bus_oracle import ExitBusOracleContract
 from src.services.exit_order_iterator import WeightsNotUpdatedError
 from src.types import BlockStamp, EpochNumber, Gwei, ReferenceBlockStamp, SlotNumber, Wei
-from src.utils.validator_balance import get_predictable_inbound_balance
+from src.utils.validator_balance import get_predictable_inbound_balance, get_predictable_inbound_sweep
 from src.web3py.extensions.lido_validators import (
     LidoValidator,
     NodeOperatorId,
@@ -433,10 +433,10 @@ def test_get_withdrawable_lido_validators_balance(
             Mock(side_effect=lambda _1, b, _2: b > 32),
         )
 
-        result = ejector._get_withdrawable_lido_validators_balance(42, ref_blockstamp)
+        result = ejector._get_withdrawable_lido_validators_balance(42, ref_blockstamp, frozenset())
         assert result == 42 * GWEI_TO_WEI, "Unexpected withdrawable amount"
 
-        ejector._get_withdrawable_lido_validators_balance(42, ref_blockstamp)
+        ejector._get_withdrawable_lido_validators_balance(42, ref_blockstamp, frozenset())
         ejector.w3.lido_validators.get_active_lido_validators.assert_called_once()
 
 
@@ -738,8 +738,37 @@ def test_get_withdrawable_lido_validators_balance__consolidating_as_source__excl
         )
         # Use a different epoch to avoid LRU cache collision with other tests
         result = ejector._get_withdrawable_lido_validators_balance(
-            EpochNumber(ref_blockstamp.ref_epoch + 1), ref_blockstamp
+            EpochNumber(ref_blockstamp.ref_epoch + 1), ref_blockstamp, frozenset()
         )
 
     # Only the normal validator contributes; consolidating_as_source is skipped
     assert result == normal_validator.balance * GWEI_TO_WEI
+
+
+@pytest.mark.unit
+def test_get_withdrawable_lido_validators_balance__excluded_index__not_double_counted(
+    ejector: Ejector,
+    ref_blockstamp: ReferenceBlockStamp,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # This validator is assumed to be recently requested to exit and already counted
+    # via going_to_withdraw_balance_gwei, so it must be excluded here.
+    excluded_validator = build_extended_validator_with_balance(Gwei(42))
+    included_validator = build_extended_validator_with_balance(Gwei(42))
+
+    ejector.w3.lido_validators.get_active_lido_validators = Mock(return_value=[excluded_validator, included_validator])
+
+    with monkeypatch.context() as m:
+        m.setattr(
+            ejector_module,
+            "is_fully_withdrawable_validator",
+            Mock(return_value=False),
+        )
+        result = ejector._get_withdrawable_lido_validators_balance(
+            EpochNumber(ref_blockstamp.ref_epoch + 2),
+            ref_blockstamp,
+            frozenset([excluded_validator.index]),
+        )
+
+    expected = get_predictable_inbound_sweep(included_validator)
+    assert result == expected * GWEI_TO_WEI, "Excluded validator's balance must not be counted"

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -23,7 +23,7 @@ from src.providers.consensus.types import (
 from src.providers.execution.contracts.exit_bus_oracle import ExitBusOracleContract
 from src.services.exit_order_iterator import WeightsNotUpdatedError
 from src.types import BlockStamp, EpochNumber, Gwei, ReferenceBlockStamp, SlotNumber, Wei
-from src.utils.validator_balance import get_predictable_inbound_balance, get_predictable_inbound_sweep
+from src.utils.validator_balance import get_predictable_inbound_balance
 from src.web3py.extensions.lido_validators import (
     LidoValidator,
     NodeOperatorId,
@@ -433,10 +433,10 @@ def test_get_withdrawable_lido_validators_balance(
             Mock(side_effect=lambda _1, b, _2: b > 32),
         )
 
-        result = ejector._get_withdrawable_lido_validators_balance(42, ref_blockstamp, frozenset())
+        result = ejector._get_withdrawable_lido_validators_balance(42, ref_blockstamp)
         assert result == 42 * GWEI_TO_WEI, "Unexpected withdrawable amount"
 
-        ejector._get_withdrawable_lido_validators_balance(42, ref_blockstamp, frozenset())
+        ejector._get_withdrawable_lido_validators_balance(42, ref_blockstamp)
         ejector.w3.lido_validators.get_active_lido_validators.assert_called_once()
 
 
@@ -738,37 +738,8 @@ def test_get_withdrawable_lido_validators_balance__consolidating_as_source__excl
         )
         # Use a different epoch to avoid LRU cache collision with other tests
         result = ejector._get_withdrawable_lido_validators_balance(
-            EpochNumber(ref_blockstamp.ref_epoch + 1), ref_blockstamp, frozenset()
+            EpochNumber(ref_blockstamp.ref_epoch + 1), ref_blockstamp
         )
 
     # Only the normal validator contributes; consolidating_as_source is skipped
     assert result == normal_validator.balance * GWEI_TO_WEI
-
-
-@pytest.mark.unit
-def test_get_withdrawable_lido_validators_balance__excluded_index__not_double_counted(
-    ejector: Ejector,
-    ref_blockstamp: ReferenceBlockStamp,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    # This validator is assumed to be recently requested to exit and already counted
-    # via going_to_withdraw_balance_gwei, so it must be excluded here.
-    excluded_validator = build_extended_validator_with_balance(Gwei(42))
-    included_validator = build_extended_validator_with_balance(Gwei(42))
-
-    ejector.w3.lido_validators.get_active_lido_validators = Mock(return_value=[excluded_validator, included_validator])
-
-    with monkeypatch.context() as m:
-        m.setattr(
-            ejector_module,
-            "is_fully_withdrawable_validator",
-            Mock(return_value=False),
-        )
-        result = ejector._get_withdrawable_lido_validators_balance(
-            EpochNumber(ref_blockstamp.ref_epoch + 2),
-            ref_blockstamp,
-            frozenset([excluded_validator.index]),
-        )
-
-    expected = get_predictable_inbound_sweep(included_validator)
-    assert result == expected * GWEI_TO_WEI, "Excluded validator's balance must not be counted"


### PR DESCRIPTION
## Summary

`_get_predicted_el_balance` double-counted the sweepable excess balance of validators that were recently requested to exit but haven't started their CL exit yet (`exit_epoch == FAR_FUTURE_EPOCH`).

Their balance was added twice, in two independent places:
- once via `going_to_withdraw_balance_gwei`, using `get_predictable_full_inbound_balance` (the validator's **full**, uncapped balance)
- again via `_get_withdrawable_lido_validators_balance`, which — since these validators are still "active" and not yet `is_fully_withdrawable` — treats them like any other active validator and adds their sweep excess (`get_predictable_inbound_sweep`, i.e. balance above `MAX_EFFECTIVE_BALANCE`)

Since the sweep excess is a subset of the full balance, not a separate amount, this overstated predicted EL liquidity by the aggregate sweepable excess of these validators — which could cause the oracle to skip a validator exit request that was actually needed.

## Fix

Use `get_predictable_inbound_balance` (the balance capped at `MAX_EFFECTIVE_BALANCE`) instead of `get_predictable_full_inbound_balance` when summing `going_to_withdraw_balance_gwei`.

This splits each validator's full balance `B` into two non-overlapping pieces instead of double-counting:
- `going_to_withdraw_balance_gwei` now claims only the capped portion (`B - E`)
- `_get_withdrawable_lido_validators_balance` (unchanged) still adds the sweep excess `E`
- Total: `(B - E) + E = B` — counted exactly once

As a side benefit, this also makes the unit passed into the exit-churn epoch prediction consistent: `_get_predicted_withdrawable_epoch(going_to_withdraw_balance_gwei + to_exit_gwei, ...)` feeds `compute_exit_epoch_and_update_churn`, which per the consensus-spec churn limit operates on **effective balance**, not raw balance — and `to_exit_gwei` (from `get_validators_to_eject`) already uses the capped `get_predictable_inbound_balance`. Previously the two were mixed (capped + full in the same sum); now both use the same, correct unit.