### PR TITLE
fix: sort values before creating tree

### DIFF
--- a/src/modules/oracles/staking_modules/common/tree.py
+++ b/src/modules/oracles/staking_modules/common/tree.py
@@ -102,7 +102,9 @@ class RewardsTree(Tree[RewardsTreeLeaf]):
     @classmethod
     def new(cls, values) -> Self:
         """Create new instance around the wrapped tree out of the given values"""
-        return cls(StandardMerkleTree(values, ("uint256", "uint256")))
+        # Sort leaves by node operator id
+        sorted_values = sorted(values, key=lambda leaf: leaf[0])
+        return cls(StandardMerkleTree(sorted_values, ("uint256", "uint256")))
 
 
 class StrikesTreeJSONEncoder(TreeJSONEncoder):
@@ -144,4 +146,6 @@ class StrikesTree(Tree[StrikesTreeLeaf]):
     @classmethod
     def new(cls, values) -> Self:
         """Create new instance around the wrapped tree out of the given values"""
-        return cls(StandardMerkleTree(values, ("uint256", "bytes", "uint256[]")))
+        # Sort leaves by (node operator id, pubkey)
+        sorted_values = sorted(values, key=lambda leaf: (leaf[0], leaf[1]))
+        return cls(StandardMerkleTree(sorted_values, ("uint256", "bytes", "uint256[]")))

--- a/tests/modules/csm/test_tree.py
+++ b/tests/modules/csm/test_tree.py
@@ -54,6 +54,14 @@ class TreeTestBase[LeafType: Iterable](ABC):
         loaded = StandardMerkleTree.load(tree.dump())
         assert loaded.root == tree.root
 
+    @pytest.mark.unit
+    def test_new__input_order__does_not_affect_encoding(self):
+        forward = self.cls.new(list(self.values))
+        reverse = self.cls.new(list(reversed(self.values)))
+        assert forward.root == reverse.root
+        assert forward.values == reverse.values
+        assert forward.encode() == reverse.encode()
+
 
 class TestRewardsTree(TreeTestBase[RewardsTreeLeaf]):
     cls = RewardsTree

--- a/tests/modules/csm/test_tree.py
+++ b/tests/modules/csm/test_tree.py
@@ -56,8 +56,14 @@ class TreeTestBase[LeafType: Iterable](ABC):
 
     @pytest.mark.unit
     def test_new__input_order__does_not_affect_encoding(self):
-        forward = self.cls.new(list(self.values))
-        reverse = self.cls.new(list(reversed(self.values)))
+        # Arrange
+        values = list(self.values)
+
+        # Act
+        forward = self.cls.new(values)
+        reverse = self.cls.new(list(reversed(values)))
+
+        # Assert
         assert forward.root == reverse.root
         assert forward.values == reverse.values
         assert forward.encode() == reverse.encode()


### PR DESCRIPTION
## Description

Sort values before creating tree

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [ ] New tests added (if applicable)
