### PR TITLE
fix(orc-748): VEE-DEMAND-03 — Exact withdrawal coverage ejects one ad…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG SOURCE_DATE_EPOCH
 RUN apt-get update && apt-get install -y --no-install-recommends -qq \
     libffi-dev=3.4.8-2 \
     g++=4:14.2.0-1 \
-    curl=8.14.1-2+deb13u3 \
+    curl=8.14.1-2+deb13u4 \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
  && rm -rf /var/cache/* \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lido-oracle"
-version = "8.0.2"
+version = "8.0.3"
 description = "Oracle daemon for the Lido decentralized staking protocol. It collects consensus-layer data — including the number of active validators and their aggregated balances — and securely reports this information to the Lido dApp smart contracts operating on the execution layer."
 authors = [
     "Dmitry Chernukhin",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "lido-oracle"
-version = "8.0.1"
+version = "8.0.2"
 description = "Oracle daemon for the Lido decentralized staking protocol. It collects consensus-layer data — including the number of active validators and their aggregated balances — and securely reports this information to the Lido dApp smart contracts operating on the execution layer."
 authors = [
     "Dmitry Chernukhin",

--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -194,7 +194,7 @@ class Ejector(OracleModule[Web3]):
 
                 predictable_el_balance = self._get_predicted_el_balance(total_balance_to_eject_gwei, blockstamp)
 
-                if predictable_el_balance + gwei_to_wei(total_balance_to_eject_gwei) > to_withdraw_amount:
+                if predictable_el_balance + gwei_to_wei(total_balance_to_eject_gwei) >= to_withdraw_amount:
                     break
         else:
             logger.info({'msg': 'Predicted EL balance is enough to fulfill withdrawal queue.'})

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -1,5 +1,5 @@
 from typing import cast
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 from web3.exceptions import ContractCustomError
@@ -239,6 +239,69 @@ class TestGetValidatorsToEject:
             )
             result = ejector.get_validators_to_eject(ref_blockstamp)
             assert [v[1].index for v in result] == [validators[0][1].index], "Unexpected validators to eject"
+
+    @pytest.mark.unit
+    def test_get_validators_to_eject__exact_coverage_after_first_validator__ejects_only_first(
+        self,
+        ejector: Ejector,
+        ref_blockstamp: ReferenceBlockStamp,
+        chain_config: ChainConfig,
+    ):
+        # Arrange
+        ejector.get_chain_config = Mock(return_value=chain_config)
+        predicted_el_balance = Wei(100)
+        ejector._get_predicted_el_balance = Mock(return_value=predicted_el_balance)
+
+        validators = [
+            ((StakingModuleId(0), NodeOperatorId(1)), build_extended_validator_with_balance(32)),
+            ((StakingModuleId(0), NodeOperatorId(3)), build_extended_validator_with_balance(32)),
+        ]
+        first_validator_balance_wei = get_predictable_inbound_balance(validators[0][1]) * GWEI_TO_WEI
+        ejector.w3.lido_contracts.withdrawal_queue_nft.unfinalized_steth = Mock(
+            return_value=predicted_el_balance + first_validator_balance_wei
+        )
+
+        val_iter = iter(SimpleIterator(validators))
+        with patch.object(ejector_module.ValidatorExitIterator, "__iter__", Mock(return_value=val_iter)):
+            # Act
+            result = ejector.get_validators_to_eject(ref_blockstamp)
+
+        # Assert
+        assert [v[1].index for v in result] == [validators[0][1].index], "Exact coverage must not eject extra validator"
+
+    @pytest.mark.unit
+    def test_get_validators_to_eject__exact_coverage_after_second_validator__ejects_two(
+        self,
+        ejector: Ejector,
+        ref_blockstamp: ReferenceBlockStamp,
+        chain_config: ChainConfig,
+    ):
+        # Arrange
+        ejector.get_chain_config = Mock(return_value=chain_config)
+        predicted_el_balance = Wei(100)
+        ejector._get_predicted_el_balance = Mock(return_value=predicted_el_balance)
+
+        validators = [
+            ((StakingModuleId(0), NodeOperatorId(1)), build_extended_validator_with_balance(32)),
+            ((StakingModuleId(0), NodeOperatorId(3)), build_extended_validator_with_balance(32)),
+            ((StakingModuleId(0), NodeOperatorId(5)), build_extended_validator_with_balance(32)),
+        ]
+        first_two_validators_balance_wei = (
+            get_predictable_inbound_balance(validators[0][1]) + get_predictable_inbound_balance(validators[1][1])
+        ) * GWEI_TO_WEI
+        ejector.w3.lido_contracts.withdrawal_queue_nft.unfinalized_steth = Mock(
+            return_value=predicted_el_balance + first_two_validators_balance_wei
+        )
+
+        val_iter = iter(SimpleIterator(validators))
+        with patch.object(ejector_module.ValidatorExitIterator, "__iter__", Mock(return_value=val_iter)):
+            # Act
+            result = ejector.get_validators_to_eject(ref_blockstamp)
+
+        # Assert
+        assert [v[1].index for v in result] == [validators[0][1].index, validators[1][1].index], (
+            "Exact coverage after second validator must eject exactly two"
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Description
This pull request makes an important fix to the validator ejection logic and adds new unit tests to ensure correct behavior when the predicted EL balance exactly matches the withdrawal requirement. The main changes are:

**Bug Fixes:**

* The condition in `get_validators_to_eject` (`ejector.py`) was updated to use `>=` instead of `>` to ensure validators are not unnecessarily ejected when the predicted EL balance exactly covers the withdrawal amount.

**Testing Improvements:**

* Added two new unit tests in `test_ejector.py`:
  - Test that only the first validator is ejected when the predicted balance exactly covers the withdrawal after the first validator.
  - Test that exactly two validators are ejected when the predicted balance exactly covers the withdrawal after the second validator.
* Updated imports to include `patch` from `unittest.mock` for mocking in the new tests.

## Related Issue/Task
- Related task: #orc-748
- Epic: srv3

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [x] New tests added (if applicable)
