### PR TITLE
fix: use quantized effective balance for churn/exit-epoch prediction

### DIFF
--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -32,6 +32,7 @@ from src.types import BlockStamp, EpochNumber, Gwei, NodeOperatorGlobalIndex, Re
 from src.utils.cache import global_lru_cache as lru_cache
 from src.utils.units import gwei_to_wei
 from src.utils.validator_balance import (
+    get_predictable_effective_balance,
     get_predictable_full_inbound_balance,
     get_predictable_inbound_balance,
     get_predictable_inbound_sweep,
@@ -176,6 +177,7 @@ class Ejector(OracleModule[Web3]):
 
         validators_to_eject: list[tuple[NodeOperatorGlobalIndex, LidoValidator]] = []
         total_balance_to_eject_gwei = Gwei(0)
+        total_churn_balance_to_eject_gwei = Gwei(0)
         validators_iterator = iter(
             ValidatorExitIterator(
                 w3=self.w3,
@@ -189,10 +191,12 @@ class Ejector(OracleModule[Web3]):
                 validators_to_eject.append((gid, next_validator))
 
                 val_balance = get_predictable_inbound_balance(next_validator)
+                val_churn_balance = get_predictable_effective_balance(next_validator)
 
                 total_balance_to_eject_gwei += val_balance
+                total_churn_balance_to_eject_gwei += val_churn_balance
 
-                predictable_el_balance = self._get_predicted_el_balance(total_balance_to_eject_gwei, blockstamp)
+                predictable_el_balance = self._get_predicted_el_balance(total_churn_balance_to_eject_gwei, blockstamp)
 
                 if predictable_el_balance + gwei_to_wei(total_balance_to_eject_gwei) >= to_withdraw_amount:
                     break
@@ -215,7 +219,7 @@ class Ejector(OracleModule[Web3]):
 
         return validators_to_eject
 
-    def _get_predicted_el_balance(self, to_exit_gwei: Gwei, blockstamp: ReferenceBlockStamp) -> Wei:
+    def _get_predicted_el_balance(self, to_exit_churn_gwei: Gwei, blockstamp: ReferenceBlockStamp) -> Wei:
         chain_config = self.get_chain_config(blockstamp)
 
         total_available_balance = self._get_total_el_balance(blockstamp)
@@ -242,8 +246,18 @@ class Ejector(OracleModule[Web3]):
             )
         )
 
+        going_to_withdraw_churn_balance_gwei = Gwei(
+            sum(
+                map(
+                    get_predictable_effective_balance,
+                    validators_going_to_exit,
+                ),
+                Gwei(0),
+            )
+        )
+
         withdrawal_epoch = self._get_predicted_withdrawable_epoch(
-            going_to_withdraw_balance_gwei + to_exit_gwei,
+            going_to_withdraw_churn_balance_gwei + to_exit_churn_gwei,
             blockstamp,
         )
         logger.info({'msg': 'Withdrawal epoch', 'value': withdrawal_epoch})

--- a/src/utils/validator_balance.py
+++ b/src/utils/validator_balance.py
@@ -1,3 +1,4 @@
+from src.constants import EFFECTIVE_BALANCE_INCREMENT
 from src.types import Gwei
 from src.utils.validator_state import get_max_effective_balance
 from src.web3py.extensions.lido_validators import LidoValidator
@@ -30,6 +31,26 @@ def get_predictable_inbound_balance(validator: LidoValidator) -> Gwei:
     max_effective_balance = get_max_effective_balance(validator.validator)
     predictable_full_balance = get_predictable_full_inbound_balance(validator)
     return min(predictable_full_balance, max_effective_balance)
+
+
+def get_predictable_effective_balance(validator: LidoValidator) -> Gwei:
+    """
+    Same as `get_predictable_inbound_balance`, but the pre-cap balance is floored to the
+    nearest `EFFECTIVE_BALANCE_INCREMENT` first, matching the quantization the real chain
+    applies to `effective_balance` during epoch processing.
+
+    Intended for churn/exit-epoch prediction, where the chain compares against a
+    quantized effective balance.
+
+    Note this is still an approximation of a future value: `balance` keeps growing between
+    now and whenever the validator's exit actually gets processed on-chain, and the real
+    `effective_balance` only updates once that growth crosses a hysteresis threshold
+    (`process_effective_balance_updates`) — so it won't always match exactly either way.
+    """
+    max_effective_balance = get_max_effective_balance(validator.validator)
+    predictable_full_balance = get_predictable_full_inbound_balance(validator)
+    floored_balance = Gwei(predictable_full_balance - predictable_full_balance % EFFECTIVE_BALANCE_INCREMENT)
+    return min(floored_balance, max_effective_balance)
 
 
 def get_predictable_inbound_sweep(validator: LidoValidator) -> Gwei:

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -23,7 +23,7 @@ from src.providers.consensus.types import (
 from src.providers.execution.contracts.exit_bus_oracle import ExitBusOracleContract
 from src.services.exit_order_iterator import WeightsNotUpdatedError
 from src.types import BlockStamp, EpochNumber, Gwei, ReferenceBlockStamp, SlotNumber, Wei
-from src.utils.validator_balance import get_predictable_inbound_balance
+from src.utils.validator_balance import get_predictable_effective_balance, get_predictable_inbound_balance
 from src.web3py.extensions.lido_validators import (
     LidoValidator,
     NodeOperatorId,
@@ -303,6 +303,36 @@ class TestGetValidatorsToEject:
             "Exact coverage after second validator must eject exactly two"
         )
 
+    @pytest.mark.unit
+    def test_churn_input_uses_floored_balance__el_comparison_uses_raw_balance(
+        self,
+        ejector: Ejector,
+        ref_blockstamp: ReferenceBlockStamp,
+        chain_config: ChainConfig,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        ejector.get_chain_config = Mock(return_value=chain_config)
+        ejector.w3.lido_contracts.withdrawal_queue_nft.unfinalized_steth = Mock(return_value=Wei(10**18))
+        ejector._get_predicted_el_balance = Mock(return_value=Wei(0))
+
+        # Compounding validator below its 2048 ETH cap with a sub-1-ETH remainder — its raw
+        # (capped) balance and its floored balance differ.
+        balance = Gwei(100 * 10**9 + 500_000_000)
+        validator = build_extended_validator_with_balance(balance, meb=MAX_EFFECTIVE_BALANCE_ELECTRA)
+        validators = [((StakingModuleId(0), NodeOperatorId(1)), validator)]
+
+        with monkeypatch.context() as m:
+            ejector.get_consensus_version = Mock(return_value=3)
+            val_iter = iter(SimpleIterator(validators))
+            m.setattr(
+                ejector_module.ValidatorExitIterator,
+                "__iter__",
+                Mock(return_value=val_iter),
+            )
+            ejector.get_validators_to_eject(ref_blockstamp)
+
+        ejector._get_predicted_el_balance.assert_any_call(Gwei(100 * 10**9), ref_blockstamp)
+
 
 @pytest.mark.unit
 def test_is_main_data_submitted(ejector: Ejector, blockstamp: BlockStamp) -> None:
@@ -382,6 +412,29 @@ class TestGetPredictedElBalance:
         ejector._get_predicted_el_balance(to_exit_gwei, ref_blockstamp)
 
         ejector._get_predicted_withdrawable_epoch.assert_called_once_with(capped_balance + to_exit_gwei, ref_blockstamp)
+
+    @pytest.mark.unit
+    def test_going_to_exit_compounding_validator_with_remainder__el_balance_keeps_it_churn_input_floors_it(
+        self,
+        ejector: Ejector,
+        ref_blockstamp: ReferenceBlockStamp,
+    ) -> None:
+        # Compounding validator well below its 2048 ETH cap, with rewards accrued past a whole
+        # ETH — real effective_balance would be quantized to EFFECTIVE_BALANCE_INCREMENT once the
+        # chain processes the exit, but the raw balance is not.
+        balance = Gwei(100 * 10**9 + 500_000_000)
+        going_to_exit_validator = build_extended_validator_with_balance(balance, meb=MAX_EFFECTIVE_BALANCE_ELECTRA)
+
+        ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(
+            return_value=[going_to_exit_validator]
+        )
+
+        result = ejector._get_predicted_el_balance(Gwei(0), ref_blockstamp)
+
+        assert result == balance * GWEI_TO_WEI, (
+            "The predicted EL balance must keep the sub-increment remainder — it's real ETH regardless of rounding"
+        )
+        ejector._get_predicted_withdrawable_epoch.assert_called_once_with(Gwei(100 * 10**9), ref_blockstamp)
 
 
 class TestPredictedWithdrawableEpoch:
@@ -585,6 +638,34 @@ def test_get_predicted_withdrawable_balance(ejector: Ejector) -> None:
     )
     result = get_predictable_inbound_balance(validator)
     assert result == (MAX_EFFECTIVE_BALANCE + 1), "Expect MAX_EFFECTIVE_BALANCE + 1"
+
+
+@pytest.mark.unit
+def test_get_predictable_effective_balance(ejector: Ejector) -> None:
+    validator = build_extended_validator_with_balance(Gwei(0))
+    assert get_predictable_effective_balance(validator) == 0, "Expected zero"
+
+    # Regular validator: whenever balance exceeds the 32 ETH cap it's clamped there directly,
+    # so flooring to EFFECTIVE_BALANCE_INCREMENT has no additional effect.
+    validator = build_extended_validator_with_balance(Gwei(MAX_EFFECTIVE_BALANCE + 1))
+    assert get_predictable_effective_balance(validator) == MAX_EFFECTIVE_BALANCE, "Expect MAX_EFFECTIVE_BALANCE"
+
+    # Compounding validator sitting below its 2048 ETH cap with a sub-1-ETH remainder: the raw
+    # balance is not yet quantized like a real effective_balance would be, so it must be floored.
+    validator = build_extended_validator_with_balance(
+        Gwei(MAX_EFFECTIVE_BALANCE + 1),
+        meb=MAX_EFFECTIVE_BALANCE_ELECTRA,
+    )
+    assert get_predictable_effective_balance(validator) == MAX_EFFECTIVE_BALANCE, (
+        "Expect the sub-increment remainder to be floored away, unlike get_predictable_inbound_balance"
+    )
+
+    # A remainder well under the cap should floor down to the nearest whole ETH too.
+    validator = build_extended_validator_with_balance(
+        Gwei(100 * 10**9 + 500_000_000),
+        meb=MAX_EFFECTIVE_BALANCE_ELECTRA,
+    )
+    assert get_predictable_effective_balance(validator) == Gwei(100 * 10**9), "Expect floor to nearest whole ETH"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Churn accounting on-chain compares against effective_balance, which is always a multiple of EFFECTIVE_BALANCE_INCREMENT — unlike the raw balance we were feeding it, which for compounding validators below their cap can carry a sub-1-ETH remainder. Floor that input separately from the EL-balance prediction, which must keep the raw remainder since it's still real ETH regardless of rounding. Applied symmetrically to both validators_going_to_exit and get_validators_to_eject's churn input.