### PR TITLE
feat(gloas): proposer-duties v2 endpoint with relaxed v1 fallback

### DIFF
--- a/src/modules/sidecars/performance/collector/checkpoint.py
+++ b/src/modules/sidecars/performance/collector/checkpoint.py
@@ -390,17 +390,29 @@ class FrameCheckpointProcessor:
         self, epoch: EpochNumber, checkpoint_block_roots: list[BlockRoot | None], checkpoint_slot: SlotNumber
     ) -> dict[SlotNumber, ProposalDuty]:
         duties = {}
-        dependent_root = self._get_dependent_root_for_proposer_duties(epoch, checkpoint_block_roots, checkpoint_slot)
-        proposer_duties = self.cc.get_proposer_duties(epoch, dependent_root)
+        # v1's dependent_root is the last slot of epoch-1; v2's (EIP-7917) is one epoch earlier,
+        # the last slot of epoch-2 (fork-invariant, https://github.com/ethereum/beacon-APIs/pull/563).
+        # Both are computed up front because we don't know which endpoint the CL node will answer with.
+        dependent_root_v1 = self._get_dependent_root_for_proposer_duties(
+            epoch, checkpoint_block_roots, checkpoint_slot, epochs_back=1
+        )
+        dependent_root_v2 = self._get_dependent_root_for_proposer_duties(
+            epoch, checkpoint_block_roots, checkpoint_slot, epochs_back=2
+        )
+        proposer_duties = self.cc.get_proposer_duties(epoch, dependent_root_v1, dependent_root_v2)
         for duty in proposer_duties:
             duties[duty.slot] = ProposalDuty(validator_index=duty.validator_index, is_proposed=False)
         return duties
 
     def _get_dependent_root_for_proposer_duties(
-        self, epoch: EpochNumber, checkpoint_block_roots: list[BlockRoot | None], checkpoint_slot: SlotNumber
+        self,
+        epoch: EpochNumber,
+        checkpoint_block_roots: list[BlockRoot | None],
+        checkpoint_slot: SlotNumber,
+        epochs_back: int,
     ) -> BlockRoot:
         dependent_root = None
-        dependent_slot = self.converter.get_epoch_last_slot(EpochNumber(epoch - 1))
+        dependent_slot = self.converter.get_epoch_last_slot(EpochNumber(epoch - epochs_back))
         try:
             while not dependent_root:
                 dependent_root = self._select_block_root_by_slot(

--- a/src/providers/consensus/client.py
+++ b/src/providers/consensus/client.py
@@ -66,6 +66,7 @@ class ConsensusClient(HTTPProvider):
     API_GET_ATTESTATION_COMMITTEES = 'eth/v1/beacon/states/{}/committees'
     API_GET_SYNC_COMMITTEE = 'eth/v1/beacon/states/{}/sync_committees'
     API_GET_PROPOSER_DUTIES = 'eth/v1/validator/duties/proposer/{}'
+    API_GET_PROPOSER_DUTIES_V2 = 'eth/v2/validator/duties/proposer/{}'
     API_GET_STATE = 'eth/v2/debug/beacon/states/{}'
     API_GET_SPEC = 'eth/v1/config/spec'
     API_GET_GENESIS = 'eth/v1/beacon/genesis'
@@ -209,24 +210,71 @@ class ConsensusClient(HTTPProvider):
                 raise error
         return SyncCommittee.from_response(**data)  # type: ignore[arg-type]
 
-    @list_of_dataclasses(ProposerDuties.from_response)
-    def get_proposer_duties(self, epoch: EpochNumber, expected_dependent_root: BlockRoot) -> list[ProposerDuties]:
-        """Spec: https://ethereum.github.io/beacon-APIs/#/Validator/getProposerDuties"""
+    def get_proposer_duties(
+        self,
+        epoch: EpochNumber,
+        expected_dependent_root_v1: BlockRoot,
+        expected_dependent_root_v2: BlockRoot,
+    ) -> list[ProposerDuties]:
+        """
+        Spec: https://ethereum.github.io/beacon-APIs/#/Validator/getProposerDutiesV2
 
+        Prefers the v2 endpoint (EIP-7917), whose dependent_root formula is fork-invariant across
+        the Fulu boundary (https://github.com/ethereum/beacon-APIs/pull/563). Falls back to the
+        deprecated v1 endpoint on CL nodes that have not shipped v2 yet (e.g. Nimbus): v1's
+        dependent_root is not computed consistently across clients post-Fulu, so on that path a
+        mismatch is only logged, not treated as fatal.
+        """
+        try:
+            return self._get_proposer_duties_v2(epoch, expected_dependent_root_v2)
+        except ConsensusClientError as error:
+            if error.status != HTTPStatus.NOT_FOUND:
+                raise
+            logger.info(
+                {
+                    'msg': f'{self.API_GET_PROPOSER_DUTIES_V2} not available on CL node(s), '
+                    f'falling back to {self.API_GET_PROPOSER_DUTIES} for epoch {epoch}.'
+                }
+            )
+            return self._get_proposer_duties_v1(epoch, expected_dependent_root_v1)
+
+    @list_of_dataclasses(ProposerDuties.from_response)
+    def _get_proposer_duties_v2(self, epoch: EpochNumber, expected_dependent_root: BlockRoot) -> list[ProposerDuties]:
         def data_is_list_and_dependent_root_matches(data: Any, meta: dict, endpoint: str):
             data_is_list(data, meta, endpoint=endpoint)
-            # It is recommended by spec to use the dependent root to ensure the epoch is correct
+            # v2's dependent_root is trustworthy, so a mismatch is a fatal reorg-safety signal.
             if meta["dependent_root"] != expected_dependent_root:
                 raise ValueError(
-                    "Dependent root for proposer duties request mismatch: "
+                    "Dependent root for proposer duties (v2) request mismatch: "
                     f"{meta['dependent_root']=} is not {expected_dependent_root=}. "
                     "Probably, CL node is not fully synced."
                 )
 
         data, _ = self._get(
-            self.API_GET_PROPOSER_DUTIES,
+            self.API_GET_PROPOSER_DUTIES_V2,
             path_params=(epoch,),
             validate_response=data_is_list_and_dependent_root_matches,
+        )
+        return data
+
+    @list_of_dataclasses(ProposerDuties.from_response)
+    def _get_proposer_duties_v1(self, epoch: EpochNumber, expected_dependent_root: BlockRoot) -> list[ProposerDuties]:
+        def data_is_list_and_dependent_root_relaxed(data: Any, meta: dict, endpoint: str):
+            data_is_list(data, meta, endpoint=endpoint)
+            # v1 is deprecated and its dependent_root is not computed consistently across clients
+            # post-Fulu (observed on Hoodi), so a mismatch here is logged rather than raised.
+            if meta["dependent_root"] != expected_dependent_root:
+                logger.warning(
+                    {
+                        'msg': 'Dependent root for proposer duties (v1, deprecated) mismatch: '
+                        f'{meta["dependent_root"]=} is not {expected_dependent_root=}.'
+                    }
+                )
+
+        data, _ = self._get(
+            self.API_GET_PROPOSER_DUTIES,
+            path_params=(epoch,),
+            validate_response=data_is_list_and_dependent_root_relaxed,
         )
         return data
 

--- a/src/providers/consensus/client.py
+++ b/src/providers/consensus/client.py
@@ -67,6 +67,7 @@ class ConsensusClient(HTTPProvider):
     API_GET_ATTESTATION_COMMITTEES = 'eth/v1/beacon/states/{}/committees'
     API_GET_SYNC_COMMITTEE = 'eth/v1/beacon/states/{}/sync_committees'
     API_GET_PROPOSER_DUTIES = 'eth/v1/validator/duties/proposer/{}'
+    API_GET_PROPOSER_DUTIES_V2 = 'eth/v2/validator/duties/proposer/{}'
     API_GET_STATE = 'eth/v2/debug/beacon/states/{}'
     API_GET_SPEC = 'eth/v1/config/spec'
     API_GET_GENESIS = 'eth/v1/beacon/genesis'
@@ -210,24 +211,71 @@ class ConsensusClient(HTTPProvider):
                 raise error
         return SyncCommittee.from_response(**data)  # type: ignore[arg-type]
 
-    @list_of_dataclasses(ProposerDuties.from_response)
-    def get_proposer_duties(self, epoch: EpochNumber, expected_dependent_root: BlockRoot) -> list[ProposerDuties]:
-        """Spec: https://ethereum.github.io/beacon-APIs/#/Validator/getProposerDuties"""
+    def get_proposer_duties(
+        self,
+        epoch: EpochNumber,
+        expected_dependent_root_v1: BlockRoot,
+        expected_dependent_root_v2: BlockRoot,
+    ) -> list[ProposerDuties]:
+        """
+        Spec: https://ethereum.github.io/beacon-APIs/#/Validator/getProposerDutiesV2
 
+        Prefers the v2 endpoint (EIP-7917), whose dependent_root formula is fork-invariant across
+        the Fulu boundary (https://github.com/ethereum/beacon-APIs/pull/563). Falls back to the
+        deprecated v1 endpoint on CL nodes that have not shipped v2 yet (e.g. Nimbus): v1's
+        dependent_root is not computed consistently across clients post-Fulu, so on that path a
+        mismatch is only logged, not treated as fatal.
+        """
+        try:
+            return self._get_proposer_duties_v2(epoch, expected_dependent_root_v2)
+        except ConsensusClientError as error:
+            if error.status != HTTPStatus.NOT_FOUND:
+                raise
+            logger.info(
+                {
+                    'msg': f'{self.API_GET_PROPOSER_DUTIES_V2} not available on CL node(s), '
+                    f'falling back to {self.API_GET_PROPOSER_DUTIES} for epoch {epoch}.'
+                }
+            )
+            return self._get_proposer_duties_v1(epoch, expected_dependent_root_v1)
+
+    @list_of_dataclasses(ProposerDuties.from_response)
+    def _get_proposer_duties_v2(self, epoch: EpochNumber, expected_dependent_root: BlockRoot) -> list[ProposerDuties]:
         def data_is_list_and_dependent_root_matches(data: Any, meta: dict, endpoint: str):
             data_is_list(data, meta, endpoint=endpoint)
-            # It is recommended by spec to use the dependent root to ensure the epoch is correct
+            # v2's dependent_root is trustworthy, so a mismatch is a fatal reorg-safety signal.
             if meta["dependent_root"] != expected_dependent_root:
                 raise ValueError(
-                    "Dependent root for proposer duties request mismatch: "
+                    "Dependent root for proposer duties (v2) request mismatch: "
                     f"{meta['dependent_root']=} is not {expected_dependent_root=}. "
                     "Probably, CL node is not fully synced."
                 )
 
         data, _ = self._get(
-            self.API_GET_PROPOSER_DUTIES,
+            self.API_GET_PROPOSER_DUTIES_V2,
             path_params=(epoch,),
             validate_response=data_is_list_and_dependent_root_matches,
+        )
+        return data
+
+    @list_of_dataclasses(ProposerDuties.from_response)
+    def _get_proposer_duties_v1(self, epoch: EpochNumber, expected_dependent_root: BlockRoot) -> list[ProposerDuties]:
+        def data_is_list_and_dependent_root_relaxed(data: Any, meta: dict, endpoint: str):
+            data_is_list(data, meta, endpoint=endpoint)
+            # v1 is deprecated and its dependent_root is not computed consistently across clients
+            # post-Fulu (observed on Hoodi), so a mismatch here is logged rather than raised.
+            if meta["dependent_root"] != expected_dependent_root:
+                logger.warning(
+                    {
+                        'msg': 'Dependent root for proposer duties (v1, deprecated) mismatch: '
+                        f'{meta["dependent_root"]=} is not {expected_dependent_root=}.'
+                    }
+                )
+
+        data, _ = self._get(
+            self.API_GET_PROPOSER_DUTIES,
+            path_params=(epoch,),
+            validate_response=data_is_list_and_dependent_root_relaxed,
         )
         return data
 

--- a/tests/modules/sidecars/performance/collector/test_checkpoint.py
+++ b/tests/modules/sidecars/performance/collector/test_checkpoint.py
@@ -634,9 +634,11 @@ class TestProposeDuties:
         ) as get_prev_non_missed_slot_mock:
             duties = processor._prepare_propose_duties(epoch, checkpoint_block_roots, checkpoint_slot)
 
-        get_prev_non_missed_slot_mock.assert_called_once()
-        processor.cc.get_block_root.assert_called_once_with(dependent_slot)
-        processor.cc.get_proposer_duties.assert_called_once_with(epoch, fallback_root)
+        # Both the v1 (epoch-1) and v2 (epoch-2) dependent roots are resolved via the CL fallback,
+        # so the fallback path runs twice and both roots resolve to fallback_root.
+        assert get_prev_non_missed_slot_mock.call_count == 2
+        processor.cc.get_block_root.assert_any_call(dependent_slot)
+        processor.cc.get_proposer_duties.assert_called_once_with(epoch, fallback_root, fallback_root)
 
         expected_duties = {
             processor.converter.get_epoch_first_slot(epoch): ProposalDuty(validator_index=1, is_proposed=False),
@@ -658,6 +660,7 @@ class TestProposeDuties:
             epoch,
             checkpoint_block_roots,
             checkpoint_slot,
+            epochs_back=1,
         )
 
         assert dependent_root == expected_root
@@ -683,6 +686,7 @@ class TestProposeDuties:
                 epoch,
                 checkpoint_block_roots,
                 checkpoint_slot,
+                epochs_back=1,
             )
 
         processor.cc.get_block_root.assert_called_once_with(non_missed_slot)

--- a/tests/providers/consensus/test_consensus_client.py
+++ b/tests/providers/consensus/test_consensus_client.py
@@ -264,7 +264,7 @@ def test_get_returns_nor_dict_nor_list(consensus_client: ConsensusClient):
         consensus_client.get_sync_committee(bs, EpochNumber(0))
 
     with raises:
-        consensus_client.get_proposer_duties(EpochNumber(0), Mock())
+        consensus_client.get_proposer_duties(EpochNumber(0), Mock(), Mock())
 
     with raises:
         consensus_client.get_state_block_roots(SlotNumber(0))
@@ -281,11 +281,76 @@ def test_get_returns_nor_dict_nor_list(consensus_client: ConsensusClient):
 
 @pytest.mark.unit
 def test_get_proposer_duties_fails_on_root_check(consensus_client: ConsensusClient):
+    # v2 is tried first and returns 200 with a mismatching dependent_root -> fatal.
     resp = requests.Response()
     resp.status_code = 200
     resp._content = b'{"data": [], "dependent_root": "0x01"}'
 
     consensus_client.session.get = Mock(return_value=resp)
 
-    with pytest.raises(ValueError, match="Dependent root for proposer duties request mismatch"):
-        consensus_client.get_proposer_duties(EpochNumber(0), "0x02")
+    with pytest.raises(ValueError, match="Dependent root for proposer duties .v2. request mismatch"):
+        consensus_client.get_proposer_duties(EpochNumber(0), "0x02", "0x02")
+
+
+# --- Proposer duties v2 preference + v1 fallback (EIP-7917) ---
+
+
+@pytest.mark.unit
+class TestProposerDutiesV2Fallback:
+    @pytest.fixture
+    def client(self):
+        return ConsensusClient(['http://localhost:5051'], 30)
+
+    def test_get_proposer_duties__v2_available__uses_v2_no_fallback(self, client):
+        from unittest.mock import Mock
+
+        client._get_proposer_duties_v2 = Mock(return_value=['v2'])
+        client._get_proposer_duties_v1 = Mock()
+
+        result = client.get_proposer_duties(EpochNumber(0), "0x_v1", "0x_v2")
+
+        assert result == ['v2']
+        client._get_proposer_duties_v2.assert_called_once_with(EpochNumber(0), "0x_v2")
+        client._get_proposer_duties_v1.assert_not_called()
+
+    def test_get_proposer_duties__v2_not_found__falls_back_to_v1(self, client):
+        from http import HTTPStatus
+        from unittest.mock import Mock
+
+        from src.providers.consensus.client import ConsensusClientError
+
+        client._get_proposer_duties_v2 = Mock(
+            side_effect=ConsensusClientError("no v2", status=HTTPStatus.NOT_FOUND, text="not found")
+        )
+        client._get_proposer_duties_v1 = Mock(return_value=['v1'])
+
+        result = client.get_proposer_duties(EpochNumber(0), "0x_v1", "0x_v2")
+
+        assert result == ['v1']
+        client._get_proposer_duties_v1.assert_called_once_with(EpochNumber(0), "0x_v1")
+
+    def test_get_proposer_duties__v2_other_error__propagates(self, client):
+        from http import HTTPStatus
+        from unittest.mock import Mock
+
+        from src.providers.consensus.client import ConsensusClientError
+
+        client._get_proposer_duties_v2 = Mock(
+            side_effect=ConsensusClientError("boom", status=HTTPStatus.INTERNAL_SERVER_ERROR, text="err")
+        )
+        client._get_proposer_duties_v1 = Mock()
+
+        with pytest.raises(ConsensusClientError):
+            client.get_proposer_duties(EpochNumber(0), "0x_v1", "0x_v2")
+        client._get_proposer_duties_v1.assert_not_called()
+
+    def test_get_proposer_duties_v1__dependent_root_mismatch__does_not_raise(self, client):
+        from unittest.mock import Mock
+
+        resp = requests.Response()
+        resp.status_code = 200
+        resp._content = b'{"data": [], "dependent_root": "0x01"}'
+        client.session.get = Mock(return_value=resp)
+
+        # Relaxed validation: a mismatch on the deprecated v1 path is logged, not fatal.
+        assert client._get_proposer_duties_v1(EpochNumber(0), "0x02") == []

--- a/tests/providers/consensus/test_consensus_client.py
+++ b/tests/providers/consensus/test_consensus_client.py
@@ -267,7 +267,7 @@ def test_get_returns_nor_dict_nor_list(consensus_client: ConsensusClient):
         consensus_client.get_sync_committee(bs, EpochNumber(0))
 
     with raises:
-        consensus_client.get_proposer_duties(EpochNumber(0), Mock())
+        consensus_client.get_proposer_duties(EpochNumber(0), Mock(), Mock())
 
     with raises:
         consensus_client.get_state_block_roots(SlotNumber(0))
@@ -306,11 +306,76 @@ def test_get_state_view_no_cache__state_fetched__logs_fingerprint_of_returned_st
 
 @pytest.mark.unit
 def test_get_proposer_duties_fails_on_root_check(consensus_client: ConsensusClient):
+    # v2 is tried first and returns 200 with a mismatching dependent_root -> fatal.
     resp = requests.Response()
     resp.status_code = 200
     resp._content = b'{"data": [], "dependent_root": "0x01"}'
 
     consensus_client.session.get = Mock(return_value=resp)
 
-    with pytest.raises(ValueError, match="Dependent root for proposer duties request mismatch"):
-        consensus_client.get_proposer_duties(EpochNumber(0), "0x02")
+    with pytest.raises(ValueError, match="Dependent root for proposer duties .v2. request mismatch"):
+        consensus_client.get_proposer_duties(EpochNumber(0), "0x02", "0x02")
+
+
+# --- Proposer duties v2 preference + v1 fallback (EIP-7917) ---
+
+
+@pytest.mark.unit
+class TestProposerDutiesV2Fallback:
+    @pytest.fixture
+    def client(self):
+        return ConsensusClient(['http://localhost:5051'], 30)
+
+    def test_get_proposer_duties__v2_available__uses_v2_no_fallback(self, client):
+        from unittest.mock import Mock
+
+        client._get_proposer_duties_v2 = Mock(return_value=['v2'])
+        client._get_proposer_duties_v1 = Mock()
+
+        result = client.get_proposer_duties(EpochNumber(0), "0x_v1", "0x_v2")
+
+        assert result == ['v2']
+        client._get_proposer_duties_v2.assert_called_once_with(EpochNumber(0), "0x_v2")
+        client._get_proposer_duties_v1.assert_not_called()
+
+    def test_get_proposer_duties__v2_not_found__falls_back_to_v1(self, client):
+        from http import HTTPStatus
+        from unittest.mock import Mock
+
+        from src.providers.consensus.client import ConsensusClientError
+
+        client._get_proposer_duties_v2 = Mock(
+            side_effect=ConsensusClientError("no v2", status=HTTPStatus.NOT_FOUND, text="not found")
+        )
+        client._get_proposer_duties_v1 = Mock(return_value=['v1'])
+
+        result = client.get_proposer_duties(EpochNumber(0), "0x_v1", "0x_v2")
+
+        assert result == ['v1']
+        client._get_proposer_duties_v1.assert_called_once_with(EpochNumber(0), "0x_v1")
+
+    def test_get_proposer_duties__v2_other_error__propagates(self, client):
+        from http import HTTPStatus
+        from unittest.mock import Mock
+
+        from src.providers.consensus.client import ConsensusClientError
+
+        client._get_proposer_duties_v2 = Mock(
+            side_effect=ConsensusClientError("boom", status=HTTPStatus.INTERNAL_SERVER_ERROR, text="err")
+        )
+        client._get_proposer_duties_v1 = Mock()
+
+        with pytest.raises(ConsensusClientError):
+            client.get_proposer_duties(EpochNumber(0), "0x_v1", "0x_v2")
+        client._get_proposer_duties_v1.assert_not_called()
+
+    def test_get_proposer_duties_v1__dependent_root_mismatch__does_not_raise(self, client):
+        from unittest.mock import Mock
+
+        resp = requests.Response()
+        resp.status_code = 200
+        resp._content = b'{"data": [], "dependent_root": "0x01"}'
+        client.session.get = Mock(return_value=resp)
+
+        # Relaxed validation: a mismatch on the deprecated v1 path is logged, not fatal.
+        assert client._get_proposer_duties_v1(EpochNumber(0), "0x02") == []


### PR DESCRIPTION
## Glamsterdam — 4/4: proposer-duties v2 endpoint with relaxed v1 fallback (EIP-7917)

Independent of the other three PRs (based directly on `feat/oracle-v9`).

EIP-7917 moves proposer-lookahead one epoch earlier and changes the `dependent_root` the duties
endpoint returns. Post-Fulu the deprecated v1 endpoint reports it inconsistently across clients,
which the oracle's reorg-safety check hard-fails on.

### What changes
- Prefer `GET /eth/v2/validator/duties/proposer` (fork-invariant `dependent_root`); validated
  strictly — a mismatch is fatal.
- Fall back to v1 only on a 404 for v2 (e.g. Nimbus); on that path a `dependent_root` mismatch is a
  warning, not fatal.
- Performance collector computes both dependent roots: v1 = last slot of epoch-1, v2 = last slot of
  epoch-2.

### Testing
- New unit tests in `tests/providers/consensus/test_consensus_client.py` (v2 preferred; 404 →
  relaxed v1 fallback; non-404 propagates; v1 mismatch does not raise) and updated checkpoint tests.
- Full unit suite green; `ruff` + `pyright` clean.

### Note for reviewers
The v2 `dependent_root` uses **last slot of epoch-2** (the correct one-epoch EIP-7917 shift from
v1's last-slot-of-epoch-1). Confirm against a node that has shipped beacon-APIs#563.

Config compatibility (`SLOT_DURATION_MS`) is already present on the dev line — no code here.

Base: `feat/oracle-v9`.
