### PR TITLE
feat: log what each Keys API instance answered

### DIFF
--- a/src/modules/oracles/common/consensus.py
+++ b/src/modules/oracles/common/consensus.py
@@ -233,28 +233,28 @@ class ConsensusModule[W3: Web3Base](ABC):
         latest_blockstamp, member_info = self._get_latest_data()
 
         # Check if the contract is currently reportable
-        # if not self.is_contract_reportable(latest_blockstamp):
-        #     logger.info({'msg': 'Contract is not reportable.'})
-        #     return None
+        if not self.is_contract_reportable(latest_blockstamp):
+            logger.info({'msg': 'Contract is not reportable.'})
+            return None
 
         logger.info({'msg': 'Fetch member info.', 'value': member_info})
 
         # Check if the current slot is higher than the member slot
-        # if last_finalized_blockstamp.slot_number < member_info.current_frame_ref_slot:
-        #     logger.info({'msg': 'Reference slot is not yet finalized.'})
-        #     return None
-        #
+        if last_finalized_blockstamp.slot_number < member_info.current_frame_ref_slot:
+            logger.info({'msg': 'Reference slot is not yet finalized.'})
+            return None
+
         # Check the latest block didn't miss the deadline.
-        # if latest_blockstamp.slot_number >= member_info.deadline_slot:
-        #     logger.info({'msg': 'Deadline missed.'})
-        #     return None
+        if latest_blockstamp.slot_number >= member_info.deadline_slot:
+            logger.info({'msg': 'Deadline missed.'})
+            return None
 
         converter = self._get_web3_converter(last_finalized_blockstamp)
 
         bs = get_reference_blockstamp(
             cc=self.w3.cc,
-            ref_slot=14846399,
-            ref_epoch=converter.get_epoch_by_slot(14846399),
+            ref_slot=member_info.current_frame_ref_slot,
+            ref_epoch=converter.get_epoch_by_slot(member_info.current_frame_ref_slot),
             last_finalized_slot_number=last_finalized_blockstamp.slot_number,
         )
         logger.info({'msg': 'Calculate blockstamp for report.', 'value': bs})

--- a/src/providers/http_provider.py
+++ b/src/providers/http_provider.py
@@ -218,6 +218,8 @@ class HTTPProvider(ProviderConsistencyModule, ABC):
                 logger.debug({'msg': response_fail_msg})
                 raise self.PROVIDER_EXCEPTION(status=0, text='JSON decode error.') from error
 
+            response_bytes = None if stream else len(response.content)
+
         meta: dict[str, Any] = {}
         try:
             data = json_response["data"]  # type: ignore[index]
@@ -228,6 +230,9 @@ class HTTPProvider(ProviderConsistencyModule, ABC):
         except (KeyError, TypeError):
             # NOTE: Used by KeysAPIClient and PerformanceClient only.
             data = json_response
+
+        if response_bytes is not None:
+            meta['response_bytes'] = response_bytes
 
         validate_response(data, meta, endpoint=endpoint)
         if stream_consumer is not None:

--- a/src/providers/keys/client.py
+++ b/src/providers/keys/client.py
@@ -1,3 +1,4 @@
+import logging
 from time import sleep
 from typing import TypedDict, cast
 
@@ -6,6 +7,9 @@ from src.providers.http_provider import HTTPProvider, NotOkResponse, data_is_dic
 from src.providers.keys.types import KeysApiStatus, LidoKey
 from src.types import BlockStamp, StakingModuleAddress
 from src.utils.cache import global_lru_cache as lru_cache
+
+
+logger = logging.getLogger(__name__)
 
 
 class KeysOutdatedException(Exception):
@@ -55,8 +59,19 @@ class KeysAPIClient(HTTPProvider):
         """
         for i in range(self.retry_count):
             data, meta = self._get(url, query_params=params)
-            blocknumber_meta = meta['meta']['elBlockSnapshot']['blockNumber']
+            snapshot = meta['meta']['elBlockSnapshot']
+            blocknumber_meta = snapshot['blockNumber']
             KEYS_API_LATEST_BLOCKNUMBER.set(blocknumber_meta)
+            logger.info(
+                {
+                    'msg': 'Keys API response.',
+                    'endpoint': url,
+                    'attempt': i + 1,
+                    'requested_block_number': blockstamp.block_number,
+                    'response_bytes': meta.get('response_bytes'),
+                    'el_block_snapshot': snapshot,
+                }
+            )
             if blocknumber_meta >= blockstamp.block_number:
                 return data
 

--- a/tests/providers_clients/test_keys_api_client.py
+++ b/tests/providers_clients/test_keys_api_client.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from typing import cast
 from unittest import mock
@@ -468,3 +469,29 @@ class TestUnitKeysAPIClient:
 
         with pytest.raises(KAPIInconsistentData, match="duplicated"):
             keys_api_client.get_used_module_operators_keys(module_address, empty_blockstamp)
+
+    @responses.activate
+    def test_get_used_lido_keys__response__logs_snapshot_and_size(
+        self,
+        keys_api_client: KeysAPIClient,
+        empty_blockstamp,
+        caplog,
+    ):
+        caplog.set_level(logging.INFO)
+        snapshot = {
+            'blockNumber': 0,
+            'blockHash': '0xabc',
+            'timestamp': 1,
+            'lastChangedBlockHash': '0xdef',
+        }
+        responses.get(
+            self.KEYS_API_MOCK_URL + keys_api_client.USED_KEYS,
+            json={'data': [], 'meta': {'elBlockSnapshot': snapshot}},
+        )
+
+        keys_api_client.get_used_lido_keys(empty_blockstamp)
+
+        line = next(r.msg for r in caplog.records if r.msg.get('msg') == 'Keys API response.')
+        assert line['el_block_snapshot'] == snapshot
+        assert line['response_bytes'] == len(responses.calls[0].response.content)
+        assert line['requested_block_number'] == empty_blockstamp.block_number


### PR DESCRIPTION
Two commits: the revert, then Keys API request logging. Nothing else.

## Why

Every operator runs their own Keys API. When members' report hashes disagree it is one of the few inputs that can legitimately differ — and the only one that cannot be reconstructed afterwards, since the service answers only for its current block. On 2026-07-25, establishing what each instance had returned took an offline rebuild of the report.

## What

One line per Keys API request, alongside the block number already being read for metrics:

```json
{"msg": "Keys API response.", "endpoint": "v1/keys?used=true", "attempt": 1,
 "requested_block_number": 25611854, "response_bytes": 47216233,
 "el_block_snapshot": {"blockNumber": 25611854, "blockHash": "0xe1b0…",
                       "timestamp": 1785007403, "lastChangedBlockHash": "0x7698…"}}
```

- **`lastChangedBlockHash`** — the block at which a watched contract last changed the key set. Equal across two members means both instances consumed the same on-chain updates, so a difference below that is the instance's own bookkeeping rather than a different view of the chain. It was already in the response and was being discarded.
- **`response_bytes`** — covers every field of the answer at once. All operators run the same Keys API build, so identical data at an identical snapshot serialises identically. Read together with the snapshot: an instance running ahead legitimately returns more keys and more bytes.

## Scope

| file | |
|---|---|
| `src/providers/keys/client.py` | the log line, +20 lines |
| `src/providers/http_provider.py` | `len(response.content)` into `meta`, non-streamed only, +7 lines |
| `tests/providers_clients/test_keys_api_client.py` | asserts the snapshot and byte count reach the log |

Nothing that feeds a report changes. No new module, no new dependency, no new network call.

The one shared-code touch is `response_bytes` in `http_provider`. A streamed body is consumed lazily so its length is unknown there, hence non-streamed only. It goes into `meta`, which existing callers tolerate: the only consumer that spreads `meta` into a constructor is `BlockHeaderFullResponse.from_response`, and `FromResponse` drops fields it does not declare.

## Deferred

The rest of #970 — input fingerprints (`count`/`digest`/`xor`), and the used-keys-versus-`depositedValidators` conservation checks — stays out of this branch and out of the audit scope for now.

## Test

`ruff` and `pyright` clean, 1475 unit tests pass.