### PR TITLE
fix: build the image from a checkout without submodules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ ENV PYTHONUNBUFFERED=1 \
     POETRY_VIRTUALENVS_IN_PROJECT=false \
     POETRY_NO_INTERACTION=1 \
     POETRY_INSTALLER_PARALLEL=false \
+    # No credential store exists in a build container, but poetry still probes one before
+    # installing: that pulls in keyring -> SecretStorage -> cryptography's native module,
+    # which is a pointless dependency here and an observed crash source on arm64 hosts.
+    PYTHON_KEYRING_BACKEND="keyring.backends.null.Keyring" \
     VENV_PATH="/opt/venv" \
     # Building reproducible .so files by enforcing consistent CFLAGS across builds
     CFLAGS="-g0 -O2 -ffile-prefix-map=/src=."
@@ -32,6 +36,13 @@ FROM base AS builder
 
 ARG POETRY_VERSION
 RUN pip install --no-cache-dir poetry==${POETRY_VERSION}
+
+# Only needed so build_blst.sh can fetch blst when the build context was produced by a
+# checkout without submodules. Stays in this stage; production copies just the venv.
+RUN apt-get update && apt-get install -y --no-install-recommends -qq \
+    git=1:2.47.3-0+deb13u1 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /
 COPY pyproject.toml poetry.lock ./
@@ -70,6 +81,18 @@ RUN python3 -m venv "$VENV_PATH" && \
 FROM base AS production
 
 COPY --from=builder $VENV_PATH $VENV_PATH
+
+# blst is not a PyPI dependency: it is compiled in the builder stage. Were it ever missing
+# from the venv, the image would start fine and only fail on the first deposit signature
+# check — mid-report, in production. Assert it here so such an image cannot be published,
+# whichever pipeline builds it.
+RUN python3 -c "import blst" || { \
+      echo "FATAL: blst is missing from the image."; \
+      echo "The build context had no vendor/blst — check out submodules before building:"; \
+      echo "  actions/checkout with 'submodules: recursive', or 'git submodule update --init --recursive'"; \
+      exit 1; \
+    }
+
 WORKDIR /app
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -173,8 +173,14 @@ Where `{tag}` is a version of the image. You can find the latest version in the 
 **OR** You can build it locally using the following command (make sure build it from latest [release](https://github.com/lidofinance/lido-oracle/releases)):
 
 ```bash
+git clone --recurse-submodules https://github.com/lidofinance/lido-oracle.git
 docker build -t lidofinance/oracle .
 ```
+
+The BLS bindings used to validate deposit signatures are compiled from `vendor/blst`
+during the build rather than installed from PyPI. Cloning with `--recurse-submodules` is
+the recommended path and keeps the build offline; without it the same sources are fetched
+over the network at the commit pinned in `scripts/build_blst.sh`.
 
 Full variables list could be found [here](https://github.com/lidofinance/lido-oracle#env-variables).
 

--- a/scripts/build_blst.sh
+++ b/scripts/build_blst.sh
@@ -1,17 +1,53 @@
 #!/bin/sh
-# Builds the blst (https://github.com/supranational/blst) Python bindings from the
-# vendor/blst git submodule and drops the resulting `blst.py` + compiled extension into the
-# active Python environment's site-packages, so `import blst` works like a normal dependency.
+# Builds the blst (https://github.com/supranational/blst) Python bindings and drops the
+# resulting `blst.py` + compiled extension into the active Python environment's
+# site-packages, so `import blst` works like a normal dependency.
 #
-# Requires `swig` and a C++ compiler on PATH.
+# Sources come from the vendor/blst submodule when it is checked out. When it is not —
+# which happens whenever the image is built from a plain checkout, including pipelines
+# living in other repositories — they are fetched at the pinned commit below instead, so
+# the build does not depend on how the caller cloned this repo.
+#
+# Requires `swig` and a C++ compiler on PATH; `git` too when the submodule is absent.
 set -eu
 
+# Must match the gitlink in vendor/blst. Checked automatically below whenever git metadata
+# is available, so the two cannot drift silently.
+BLST_COMMIT="${BLST_COMMIT:-54e6e55674722fc2797ebb4bbb71b26d881eb4b8}"
+BLST_URL="${BLST_URL:-https://github.com/supranational/blst}"
+
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-BINDINGS_DIR="$ROOT_DIR/vendor/blst/bindings/python"
+VENDOR_DIR="$ROOT_DIR/vendor/blst"
+BINDINGS_DIR="$VENDOR_DIR/bindings/python"
+
+# Guard against the pin drifting away from the submodule. Only possible where the repo's
+# git metadata is present — inside the image it is not, hence the pin. Ask git rather than
+# testing for a .git directory: in worktrees and submodules .git is a file.
+if command -v git >/dev/null 2>&1 && git -C "$ROOT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+    gitlink="$(git -C "$ROOT_DIR" ls-tree HEAD vendor/blst 2>/dev/null | awk '{print $3}')"
+    if [ -n "$gitlink" ] && [ "$gitlink" != "$BLST_COMMIT" ]; then
+        echo "BLST_COMMIT ($BLST_COMMIT) does not match the vendor/blst submodule ($gitlink)." >&2
+        echo "Update the pin in $0 to keep container builds on the same sources." >&2
+        exit 1
+    fi
+fi
 
 if [ ! -f "$BINDINGS_DIR/run.me" ]; then
-    echo "vendor/blst submodule is empty. Run: git submodule update --init" >&2
-    exit 1
+    echo "vendor/blst is not checked out; fetching blst at $BLST_COMMIT" >&2
+    if ! command -v git >/dev/null 2>&1; then
+        echo "git is required to fetch blst. Either install git, or check out submodules:" >&2
+        echo "  git submodule update --init --recursive" >&2
+        exit 1
+    fi
+    # Fetching the commit by hash makes the content self-verifying: git checks the object
+    # hashes, so no separate checksum has to be maintained alongside the pin.
+    rm -rf "$VENDOR_DIR"
+    mkdir -p "$VENDOR_DIR"
+    git -C "$VENDOR_DIR" init -q
+    git -C "$VENDOR_DIR" remote add origin "$BLST_URL"
+    git -C "$VENDOR_DIR" fetch -q --depth 1 origin "$BLST_COMMIT"
+    git -C "$VENDOR_DIR" checkout -q FETCH_HEAD
+    rm -rf "$VENDOR_DIR/.git"
 fi
 
 # -fPIC is required to link libblst.a into the shared _blst extension. build.sh normally


### PR DESCRIPTION
The image build currently fails when the checkout has no submodules:

```
#15 11.64 vendor/blst submodule is empty. Run: git submodule update --init
#15 ERROR: ... exit code: 1
```

`blst` is compiled from `vendor/blst` rather than installed from PyPI, so a checkout
without submodules leaves an empty directory and `build_blst.sh` stops the build. The
symptom is visible in the build log: `COPY vendor/blst vendor/blst` completes in 0.0s and
the whole context is 1.76 MB, while blst alone is ~10 MB.

Every workflow in this repository that needs the submodule already requests it. The
failing build is dispatched to `lidofinance/infra-mainnet` (`ci-dev.yml` →
`deploy_hoodi_testnet_lido_oracle.yaml`), and its checkout is where the submodule is
missing — outside this repo. **Fixing that checkout is still the right thing to do**;
this PR makes the build stop depending on how the caller cloned us.

## Changes

**`scripts/build_blst.sh`** — when `vendor/blst` is not checked out, fetch blst at the
pinned commit instead of failing. Fetching by commit hash makes the sources
self-verifying (git checks the object hashes), so no separate checksum has to be
maintained alongside the pin. A submodule that is present still wins, and that path
touches no network.

The pin duplicates a value that already exists as the gitlink, so the script compares the
two wherever git metadata is available and refuses to run on a mismatch. Inside the image
there is no git metadata, which is why the pin exists at all.

**`Dockerfile`**
- `git` in the builder stage only, for the fetch above. Verified absent from production.
- `RUN python3 -c "import blst"` in the production stage. Were the bindings ever missing,
  the image would start normally and only fail on the first deposit signature check —
  mid-report, in production. This makes such an image unpublishable regardless of which
  pipeline builds it.
- `PYTHON_KEYRING_BACKEND=null`. Poetry probes a credential store before installing, which
  drags in keyring → SecretStorage → cryptography's native module. Useless in a build
  container, and it SIGILLs on arm64 hosts — `poetry install` dies before it reaches any
  project dependency.

**`README.md`** — document that the bindings are compiled from the submodule, and that
`--recurse-submodules` is the recommended path.

## Verification

Built locally on linux/arm64, both paths end to end:

| context | result |
|---|---|
| with submodule | production image built, `import blst` → `BLST_SUCCESS = 0` |
| **without submodule** (reproduces CI) | `fetching blst at 54e6e556…` → image built, `import blst` → `BLST_SUCCESS = 0` |

Also checked: `git` is not present in the production image; the drift guard exits 1 when
the pin and the gitlink disagree and is silent when they match.

## Trade-off worth a second opinion

With the submodule absent the build now reaches out to github.com for a cryptographic
library. Content is fixed by the commit hash, but availability of the remote and of that
commit becomes a build-time dependency. For hermetic builds the submodule path remains
correct and is what `docs/reproducible-builds.md` prescribes — this fallback insures
against a broken checkout, it does not replace fixing one. Say the word if you would
rather only fix the checkout in infra-mainnet and drop the fallback; the `import blst`
assertion and the keyring fix stand on their own either way.

I have not touched `docs/reproducible-builds.md` — tell me if it should mention the
fallback.