### PR TITLE
test: front-run refusal at both detection points; one open question on discarded deposits

### DIFF
--- a/src/modules/oracles/common/oracle_module.py
+++ b/src/modules/oracles/common/oracle_module.py
@@ -24,7 +24,10 @@ from src.providers.keys.client import KAPIInconsistentData, KeysOutdatedExceptio
 from src.types import BlockStamp
 from src.utils.cache import clear_global_cache
 from src.utils.slot import InconsistentData, NoSlotsAvailable, SlotNotFinalized
-from src.web3py.extensions.lido_validators import CountOfKeysDiffersException
+from src.web3py.extensions.lido_validators import (
+    CountOfKeysDiffersException,
+    ForeignWithdrawalCredentialsException,
+)
 from src.web3py.types import Web3Base
 
 
@@ -91,6 +94,14 @@ class OracleModule[W3: Web3Base](DaemonModule, ConsensusModule[W3], ABC):
             logger.error({'msg': 'Keys API service returns outdated data.', 'error': str(error)})
         except CountOfKeysDiffersException as error:
             logger.error({'msg': 'Keys API service returned incorrect number of keys.', 'error': str(error)})
+        except ForeignWithdrawalCredentialsException as error:
+            logger.error(
+                {
+                    'msg': 'Used Lido keys sit on validators with non-Lido withdrawal credentials. '
+                    'Reporting is blocked until this is resolved; it cannot clear on its own.',
+                    'error': str(error),
+                }
+            )
         except Web3Exception as error:
             logger.error({'msg': 'Web3py exception.', 'error': str(error)})
         except IPFSError as error:

--- a/src/web3py/extensions/lido_validators.py
+++ b/src/web3py/extensions/lido_validators.py
@@ -177,6 +177,19 @@ class CountOfKeysDiffersException(Exception):
     pass
 
 
+class ForeignWithdrawalCredentialsException(Exception):
+    """A used Lido key sits on a validator whose withdrawal credentials are not Lido's.
+
+    Someone other than the protocol can withdraw ether the protocol paid for — the key's owner
+    front-ran Lido's deposit with their own credentials. This is refused rather than written out of
+    TVL: silently dropping the balance would disguise a captured deposit as an ordinary loss.
+
+    Withdrawal credentials of an existing validator cannot be changed, so unlike a front run still
+    sitting in the deposit queue this state does not resolve on its own. Reporting stays blocked
+    until the key is dealt with, which is deliberate — it needs a human, not an adjustment.
+    """
+
+
 type ValidatorsByNodeOperator = dict[NodeOperatorGlobalIndex, list[LidoValidator]]
 type PendingValidator = tuple[LidoKey, list[PendingDeposit]]
 
@@ -371,6 +384,8 @@ class LidoValidatorsProvider(Module):
                 'pending_lido_keys': len(pending_lido_keys),
             }
         )
+        self._validate_withdrawal_credentials(lido_validators, blockstamp)
+
         return lido_validators, pending_lido_keys
 
     def _kapi_sanity_check(self, keys_count_received: int, blockstamp: BlockStamp):
@@ -433,6 +448,40 @@ class LidoValidatorsProvider(Module):
             raise CountOfKeysDiffersException(
                 f'Keys API Service returned lesser keys than deposited validators. Total mismatched: {mismatched}'
             )
+
+    def _validate_withdrawal_credentials(self, lido_validators: list[LidoValidator], blockstamp: BlockStamp) -> None:
+        """
+        Refuse to report when a used Lido key sits on a validator whose withdrawal credentials are
+        not Lido's. See `ForeignWithdrawalCredentialsException` for why this raises instead of
+        dropping the balance out of TVL.
+
+        `_collect_valid_pending_deposits` covers the same attack while the deposit is still queued,
+        but only there: its filter is the set of keys not yet on the CL, so the pubkey leaves it as
+        soon as the validator is created. This closes the other half.
+        """
+        lido_wc_list = self.get_lido_wc_list(blockstamp)
+        foreign = {
+            validator.lido_id.key: validator.validator.withdrawal_credentials
+            for validator in lido_validators
+            if validator.validator.withdrawal_credentials not in lido_wc_list
+        }
+        if not foreign:
+            return
+
+        logger.error(
+            {
+                'msg': 'Used Lido keys on validators with non-Lido withdrawal credentials. '
+                'Ether the protocol paid for is withdrawable by someone else.',
+                'value': len(foreign),
+                'pubkeys': sorted(foreign)[:10],
+                'withdrawal_credentials': sorted(set(foreign.values()))[:10],
+                'expected_withdrawal_credentials': lido_wc_list,
+            }
+        )
+        raise ForeignWithdrawalCredentialsException(
+            f'{len(foreign)} used Lido key(s) belong to validators with non-Lido withdrawal '
+            f'credentials, e.g. {sorted(foreign)[:10]}'
+        )
 
     def _kapi_sanity_check_pending_deposits(self, lido_keys: list[LidoKey], blockstamp: BlockStamp) -> None:
         """

--- a/src/web3py/extensions/lido_validators.py
+++ b/src/web3py/extensions/lido_validators.py
@@ -468,19 +468,33 @@ class LidoValidatorsProvider(Module):
         if not foreign:
             return
 
+        # Summary first, so that a flood of the per-key lines below is self-explanatory rather than
+        # alarming on its own -- a misconfigured locator would put every Lido validator in here.
         logger.error(
             {
                 'msg': 'Used Lido keys on validators with non-Lido withdrawal credentials. '
-                'Ether the protocol paid for is withdrawable by someone else.',
+                'Ether the protocol paid for is withdrawable by someone else. '
+                'One line follows per key.',
                 'value': len(foreign),
-                'pubkeys': sorted(foreign)[:10],
-                'withdrawal_credentials': sorted(set(foreign.values()))[:10],
                 'expected_withdrawal_credentials': lido_wc_list,
+                'block_number': blockstamp.block_number,
             }
         )
+        # Every key gets its own line: this is the actionable output, and truncating it would hide
+        # keys an operator has to act on.
+        for pubkey in sorted(foreign):
+            logger.error(
+                {
+                    'msg': 'Used Lido key on a validator with non-Lido withdrawal credentials.',
+                    'pubkey': pubkey,
+                    'withdrawal_credentials': foreign[pubkey],
+                    'expected_withdrawal_credentials': lido_wc_list,
+                }
+            )
+
         raise ForeignWithdrawalCredentialsException(
             f'{len(foreign)} used Lido key(s) belong to validators with non-Lido withdrawal '
-            f'credentials, e.g. {sorted(foreign)[:10]}'
+            f'credentials. See the preceding log lines for every affected key.'
         )
 
     def _kapi_sanity_check_pending_deposits(self, lido_keys: list[LidoKey], blockstamp: BlockStamp) -> None:

--- a/src/web3py/extensions/lido_validators.py
+++ b/src/web3py/extensions/lido_validators.py
@@ -178,22 +178,9 @@ class CountOfKeysDiffersException(Exception):
 
 
 class FrontRunAttackError(Exception):
-    """A Lido key's own owner deposited it onto withdrawal credentials that are not Lido's.
+    """A Lido key was deposited onto withdrawal credentials that are not Lido's.
 
-    Only the holder of the validator's secret key can sign a deposit onto foreign credentials, so
-    this is the key owner, not an outsider. Someone other than the protocol can now withdraw ether
-    the protocol paid for. Refused rather than written out of TVL: silently dropping the balance
-    would disguise a captured deposit as an ordinary loss.
-
-    Detected at two points, because one alone is not enough:
-
-    * `_collect_valid_pending_deposits`, while the deposit is still in the CL queue. Its filter is
-      the set of Lido keys not yet on the CL, so the pubkey leaves it as soon as the validator is
-      created;
-    * `_validate_withdrawal_credentials`, once the validator exists. From then on
-      `compute_lido_validators` matches it to a Lido key by pubkey alone, and its balance would
-      otherwise be reported as Lido's — permanently, since withdrawal credentials of an existing
-      validator cannot be changed.
+    Governance has to schedule and handle such an incident manually, so we do not report.
     """
 
 
@@ -475,7 +462,11 @@ class LidoValidatorsProvider(Module):
     def _validate_withdrawal_credentials(self, lido_validators: list[LidoValidator], blockstamp: BlockStamp) -> None:
         """
         Refuse to report when a used Lido key sits on a validator whose withdrawal credentials are
-        not Lido's — the created-validator half of `FrontRunAttackError`, see its docstring.
+        not Lido's.
+
+        `_collect_valid_pending_deposits` catches the same attack while the deposit is still queued,
+        but its filter is the set of keys not yet on the CL, so it stops applying once the validator
+        is created. Credentials cannot be changed afterwards.
         """
         lido_wc_list = self.get_lido_wc_list(blockstamp)
         foreign = {

--- a/tests/web3py/test_lido_validators.py
+++ b/tests/web3py/test_lido_validators.py
@@ -730,18 +730,34 @@ def test_validate_withdrawal_credentials__no_validators__does_not_raise(web3):
 
 
 @pytest.mark.unit
-def test_validate_withdrawal_credentials__foreign_credentials__raises_naming_the_pubkey(web3):
-    """A used key on a validator with someone else's credentials must stop the report by name.
-
-    The pubkey has to reach the operator: withdrawal credentials cannot be changed, so this is not
-    something that clears itself, and whoever is on call needs to know which key to act on.
-    """
+def test_validate_withdrawal_credentials__foreign_credentials__raises_with_the_count(web3):
     web3.lido_validators.get_lido_wc_list = Mock(return_value=[_LIDO_WC_0X01, _LIDO_WC_0X02])
     captured = _lido_validator_with_wc(_FOREIGN_WC, pubkey='0xdeadbeef')
     honest = _lido_validator_with_wc(_LIDO_WC_0X01, pubkey='0xc0ffee')
 
-    with pytest.raises(ForeignWithdrawalCredentialsException, match='0xdeadbeef'):
+    with pytest.raises(ForeignWithdrawalCredentialsException, match='1 used Lido key'):
         web3.lido_validators._validate_withdrawal_credentials([honest, captured], blockstamp)
+
+
+@pytest.mark.unit
+def test_validate_withdrawal_credentials__many_foreign_keys__logs_every_one_of_them(web3, caplog):
+    """Every affected key gets its own log line, with no truncation.
+
+    Withdrawal credentials cannot be changed, so this is not a state that clears itself: whoever is
+    on call has to act on each key individually, and a truncated list would hide some of them.
+    """
+    web3.lido_validators.get_lido_wc_list = Mock(return_value=[_LIDO_WC_0X01, _LIDO_WC_0X02])
+    # More than any plausible truncation limit.
+    pubkeys = [f'0x{i:04x}' for i in range(25)]
+    captured = [_lido_validator_with_wc(_FOREIGN_WC, pubkey=pubkey) for pubkey in pubkeys]
+
+    with pytest.raises(ForeignWithdrawalCredentialsException):
+        web3.lido_validators._validate_withdrawal_credentials(captured, blockstamp)
+
+    per_key_lines = [r for r in caplog.records if 'pubkey' in str(r.msg)]
+    assert len(per_key_lines) == len(pubkeys), 'one line per key, none dropped'
+    for pubkey in pubkeys:
+        assert pubkey in caplog.text, f'{pubkey} must be logged'
 
 
 @pytest.mark.unit

--- a/tests/web3py/test_lido_validators.py
+++ b/tests/web3py/test_lido_validators.py
@@ -1,12 +1,14 @@
 from unittest.mock import Mock, patch
 
 import pytest
+from eth_typing import HexStr
 
 from src.constants import COMPOUNDING_WITHDRAWAL_PREFIX, ETH1_ADDRESS_WITHDRAWAL_PREFIX
 from src.modules.oracles.accounting.types import BeaconStat
 from src.types import NodeOperatorId
 from src.web3py.extensions.lido_validators import (
     CountOfKeysDiffersException,
+    ForeignWithdrawalCredentialsException,
     LidoValidatorsProvider,
     NodeOperator,
     NodeOperatorLimitMode,
@@ -18,6 +20,7 @@ from tests.factory.no_registry import (
     NodeOperatorFactory,
     StakingModuleFactory,
     ValidatorFactory,
+    ValidatorStateFactory,
 )
 
 
@@ -43,6 +46,8 @@ def test_get_lido_validators(web3):
     web3.lido_validators._kapi_sanity_check_pending_deposits = Mock()
     web3.lido_validators.get_pending_lido_validators = Mock(return_value={})
     web3.lido_validators._validate_total_validators_count = Mock()
+    # These validators are Lido's, so their credentials are the Lido ones by definition.
+    web3.lido_validators.get_lido_wc_list = Mock(return_value=[v.validator.withdrawal_credentials for v in validators])
 
     web3.cc.get_validators = Mock(return_value=validators)
     web3.kac.get_used_lido_keys = Mock(return_value=lido_keys)
@@ -69,6 +74,7 @@ def test_kapi_has_lesser_keys_than_deposited_validators_count(web3):
     web3.lido_validators._kapi_sanity_check_pending_deposits = Mock()
     web3.lido_validators.get_pending_lido_validators = Mock(return_value={})
     web3.lido_validators._validate_total_validators_count = Mock()
+    web3.lido_validators.get_lido_wc_list = Mock(return_value=[v.validator.withdrawal_credentials for v in validators])
     web3.cc.get_validators = Mock(return_value=validators)
     web3.kac.get_used_lido_keys = Mock(return_value=lido_keys)
     web3.cc.get_pending_deposits = Mock(return_value=[])
@@ -690,3 +696,62 @@ def test_get_active_lido_validators__handles_multiple_consolidations(web3):
     assert len(active_validators) == len(mock_validators)
     assert active_validators[0].consolidating_as_source is not None
     assert len(active_validators[1].consolidating_as_target) == 2
+
+
+# ---- _validate_withdrawal_credentials ----
+
+_VAULT = '0x' + 'ab' * 20
+_LIDO_WC_0X01 = HexStr(ETH1_ADDRESS_WITHDRAWAL_PREFIX + '0' * 22 + _VAULT[2:])
+_LIDO_WC_0X02 = HexStr(COMPOUNDING_WITHDRAWAL_PREFIX + '0' * 22 + _VAULT[2:])
+_FOREIGN_WC = HexStr(ETH1_ADDRESS_WITHDRAWAL_PREFIX + '0' * 22 + 'cd' * 20)
+
+
+def _lido_validator_with_wc(wc, pubkey='0xaabb'):
+    return LidoValidatorFactory.build(
+        lido_id=LidoKeyFactory.build(key=pubkey),
+        validator=ValidatorStateFactory.build(pubkey=pubkey, withdrawal_credentials=wc),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize('wc', [_LIDO_WC_0X01, _LIDO_WC_0X02])
+def test_validate_withdrawal_credentials__lido_credentials__does_not_raise(web3, wc):
+    """Both 0x01 and 0x02 forms of the withdrawal vault are Lido's."""
+    web3.lido_validators.get_lido_wc_list = Mock(return_value=[_LIDO_WC_0X01, _LIDO_WC_0X02])
+
+    web3.lido_validators._validate_withdrawal_credentials([_lido_validator_with_wc(wc)], blockstamp)
+
+
+@pytest.mark.unit
+def test_validate_withdrawal_credentials__no_validators__does_not_raise(web3):
+    web3.lido_validators.get_lido_wc_list = Mock(return_value=[_LIDO_WC_0X01, _LIDO_WC_0X02])
+
+    web3.lido_validators._validate_withdrawal_credentials([], blockstamp)
+
+
+@pytest.mark.unit
+def test_validate_withdrawal_credentials__foreign_credentials__raises_naming_the_pubkey(web3):
+    """A used key on a validator with someone else's credentials must stop the report by name.
+
+    The pubkey has to reach the operator: withdrawal credentials cannot be changed, so this is not
+    something that clears itself, and whoever is on call needs to know which key to act on.
+    """
+    web3.lido_validators.get_lido_wc_list = Mock(return_value=[_LIDO_WC_0X01, _LIDO_WC_0X02])
+    captured = _lido_validator_with_wc(_FOREIGN_WC, pubkey='0xdeadbeef')
+    honest = _lido_validator_with_wc(_LIDO_WC_0X01, pubkey='0xc0ffee')
+
+    with pytest.raises(ForeignWithdrawalCredentialsException, match='0xdeadbeef'):
+        web3.lido_validators._validate_withdrawal_credentials([honest, captured], blockstamp)
+
+
+@pytest.mark.unit
+def test_validate_withdrawal_credentials__foreign_credentials__logs_expected_and_actual(web3, caplog):
+    web3.lido_validators.get_lido_wc_list = Mock(return_value=[_LIDO_WC_0X01, _LIDO_WC_0X02])
+
+    with pytest.raises(ForeignWithdrawalCredentialsException):
+        web3.lido_validators._validate_withdrawal_credentials(
+            [_lido_validator_with_wc(_FOREIGN_WC, pubkey='0xdeadbeef')], blockstamp
+        )
+
+    assert _FOREIGN_WC in caplog.text, 'the offending credentials must be logged'
+    assert _LIDO_WC_0X01 in caplog.text, 'so must the expected ones, to make the diff obvious'

--- a/tests/web3py/test_lido_validators_deposit_reconciliation.py
+++ b/tests/web3py/test_lido_validators_deposit_reconciliation.py
@@ -1,23 +1,28 @@
-"""Reconciliation of Keys API used keys against Lido's on-chain ``depositedValidators`` counter.
+"""A deposit the protocol lost must drop out of TVL.
 
-``LidoValidatorsProvider._validate_total_validators_count`` requires
-
-    len(active_lido_validators) + len(pending_lido_validators) == lido.depositedValidators
-
-These tests build the protocol states that break that equality while the Keys API response is
-*complete and correct*, so any failure is attributable to the reconciliation rule itself rather
-than to a KAPI defect.
+Ether that Lido sent to the deposit contract but can no longer withdraw -- redirected by a node
+operator's front run, or discarded outright by the CL -- must not be reported as TVL. The oracle is
+what carries that write-off: ``clValidatorsBalance`` and ``clPendingBalance`` are the only CL-side
+TVL inputs the contract takes (``ReportSimulationPayload``), and ``depositedValidators`` is not one
+of them -- deposits are tracked on-chain by nonce (``BalanceStats``). So a lost key simply falling
+out of both the active and the pending set *is* the mechanism by which the loss reaches TVL.
 
 Deposit signatures are produced with real BLS keys and checked by the production verifier
-(``src.services.deposit_signature_verification``). Both failure modes below hinge on whether a
-signature actually verifies, so mocking the verifier away would make the tests vacuous.
+(``src.services.deposit_signature_verification``). Both loss scenarios turn on whether a signature
+actually verifies, so mocking the verifier away would make these tests vacuous.
 
 Shared fixture state (see ``lido_protocol``): one staking module, one node operator with
-``total_deposited_validators == 3``, and three used keys at indexes 0/1/2:
+``total_deposited_validators == 3``, and three used keys at indexes 0/1/2 -- a complete, correct
+Keys API response, so nothing here is attributable to a KAPI defect:
 
-  * key 0 -- already a validator on the CL       -> counted as *active*
-  * key 1 -- valid 32 ETH deposit to Lido WC     -> counted as *pending*
+  * key 0 -- already a validator on the CL       -> *active*
+  * key 1 -- valid 32 ETH deposit to Lido WC     -> *pending*
   * key 2 -- the variable under test
+
+The tests that state the write-off requirement are marked ``xfail(strict=True)``: they fail today
+because ``LidoValidatorsProvider._validate_total_validators_count`` requires
+``active + pending == depositedValidators``, which equates "ether still owned on the CL" with
+"ether ever sent to the deposit contract" and so forbids the write-off outright.
 """
 
 from unittest.mock import Mock
@@ -25,10 +30,18 @@ from unittest.mock import Mock
 import blst
 import pytest
 from eth_typing import HexStr
+from web3.types import Wei
 
 from src.constants import DOMAIN_DEPOSIT_TYPE, ETH1_ADDRESS_WITHDRAWAL_PREFIX
+from src.modules.common.types import ZERO_HASH
 from src.modules.oracles.accounting.accounting import Accounting
-from src.modules.oracles.accounting.types import BeaconStat
+from src.modules.oracles.accounting.third_phase.types import FormatList
+from src.modules.oracles.accounting.types import (
+    BeaconStat,
+    FinalizationShareRate,
+    VaultsTreeCid,
+    VaultsTreeRoot,
+)
 from src.providers.consensus.types import PendingDeposit
 from src.services.deposit_signature_verification import (
     _POP_DST,
@@ -63,6 +76,9 @@ _OPERATOR_OWN_VAULT = '0x' + 'cd' * 20
 _GENESIS_FORK_VERSION = HexStr('0x10000038')
 _DEPOSIT_AMOUNT = Gwei(32 * 10**9)
 _DEPOSIT_SLOT = SlotNumber(1)
+
+# Pinned so the TVL assertions below can name exact Gwei figures.
+_VALIDATOR_BALANCE = Gwei(32_100_000_000)
 
 # 96-byte value that is well-formed for `blst.P2_Affine` but verifies against nothing.
 _GARBAGE_SIGNATURE = HexStr('0x' + 'c0' + '00' * 95)
@@ -169,7 +185,12 @@ def lido_protocol(web3):
         validators = [
             ValidatorFactory.build(
                 index=index,
-                validator=ValidatorStateFactory.build(pubkey=_pubkey(seed), withdrawal_credentials=wc),
+                balance=_VALIDATOR_BALANCE,
+                validator=ValidatorStateFactory.build(
+                    pubkey=_pubkey(seed),
+                    withdrawal_credentials=wc,
+                    effective_balance=_DEPOSIT_AMOUNT,
+                ),
             )
             for index, (seed, wc) in enumerate(seeds_with_wc)
         ]
@@ -192,9 +213,14 @@ def lido_protocol(web3):
     )
 
 
-# ---- baseline: the reconciliation must hold on a healthy state ----------------------------------
+@pytest.fixture
+def accounting(lido_protocol) -> Accounting:
+    return Accounting(lido_protocol.web3)
+
+
+# ---- baselines: states with nothing to write off ------------------------------------------------
 #
-# Without this test the failing ones below would prove nothing -- they could be failing because the
+# Without these, the xfailing tests below would prove nothing -- they could be failing because the
 # fixture is wired wrong rather than because of the state under test.
 
 
@@ -241,42 +267,18 @@ def test_get_active_lido_validators__garbage_signature_then_lido_deposit__reconc
     assert _pubkey(_SUBJECT_KEY) in pending
 
 
-# ---- failure mode 1: node operator front-runs its own key --------------------------------------
-
-
 @pytest.mark.unit
-def test_get_active_lido_validators__operator_frontran_own_key__blocks_reporting(lido_protocol):
-    """A key owner can stall the reconciliation on demand.
+def test_get_active_lido_validators__frontrun_validator_created_on_cl__balance_re_enters_tvl(lido_protocol, accounting):
+    """Once the CL creates the front-run validator, its balance is credited to Lido again.
 
-    The operator signs a deposit for its own pubkey with its own withdrawal credentials and lands
-    it ahead of Lido's. `_collect_valid_pending_deposits` deliberately drops that pubkey entirely
-    ("Ignoring key. Possible front run attack") so its balance is not credited to Lido -- which is
-    the conservative, intended behaviour. `depositedValidators` was already incremented on the EL,
-    so the key is now counted in neither `active` nor `pending` and the equality cannot hold.
-    """
-    # Arrange
-    lido_protocol.set_pending_deposits(
-        _deposit(_PENDING_KEY, _LIDO_WC),
-        _deposit(_SUBJECT_KEY, _OPERATOR_WC),  # front run, validly signed by the key owner
-        _deposit(_SUBJECT_KEY, _LIDO_WC),  # Lido's own deposit, right behind it
-    )
+    `compute_lido_validators` matches CL validators to Lido keys by pubkey only, and nothing on the
+    active path consults `get_lido_wc_list` -- it is checked for pending deposits and in
+    `abnormal_cl_rebase`, never for active validators. So a validator holding the operator's own
+    withdrawal credentials contributes its full balance to `clValidatorsBalance` even though only
+    the operator can withdraw it, which is the same "lost ether in TVL" this file is about.
 
-    # Act / Assert: the front-run key is excluded from pending, so 1 + 1 != 3
-    pending = lido_protocol.web3.lido_validators.get_pending_lido_validators(ref_bs)
-    assert _pubkey(_SUBJECT_KEY) not in pending
-    assert len(pending) == 1
-
-    with pytest.raises(CountOfKeysDiffersException, match=r'\(2\).*does not match deposited validators count \(3\)'):
-        lido_protocol.web3.lido_validators.get_active_lido_validators(ref_bs)
-
-
-@pytest.mark.unit
-def test_get_active_lido_validators__frontrun_validator_created_on_cl__reconciles_again(lido_protocol):
-    """The stall above lasts exactly as long as the deposit sits in the CL queue.
-
-    Once the CL creates the validator, `compute_lido_validators` matches it by pubkey regardless of
-    its withdrawal credentials, so it counts as active and the equality holds again. This bounds
-    the outage to the pending-deposit queue delay -- but the operator can repeat it per key.
+    Documented as the current behaviour rather than asserted as correct: the write-off above lasts
+    only as long as the deposit sits in the CL queue, and this is where it silently reverses.
     """
     # Arrange: the front-run validator now exists on the CL with the operator's own credentials.
     lido_protocol.set_cl_validators((_ACTIVE_KEY, _LIDO_WC), (_SUBJECT_KEY, _OPERATOR_WC))
@@ -290,87 +292,121 @@ def test_get_active_lido_validators__frontrun_validator_created_on_cl__reconcile
 
     # Assert
     assert len(active) == 2
-    assert len(active) + len(lido_protocol.web3.lido_validators.get_pending_lido_validators(ref_bs)) == 3
+    assert _OPERATOR_WC in {v.validator.withdrawal_credentials for v in active}
+    assert accounting._get_cl_validators_balance(ref_bs) == 2 * _VALIDATOR_BALANCE
 
 
-# ---- failure mode 2: the CL discarded the deposit ----------------------------------------------
+# ---- the two states where a used key is neither active nor pending -----------------------------
+#
+# In both cases 32 ETH is gone: the operator's front run redirected it, or the CL discarded the
+# deposit outright. The oracle's job is to drop that ether out of TVL, and the report is what
+# carries the loss -- `clValidatorsBalance` and `clPendingBalance` are the only CL-side TVL inputs
+# the contract has (`ReportSimulationPayload`), and `depositedValidators` is not one of them.
+#
+# These tests state that requirement. They fail today because
+# `_validate_total_validators_count` demands `active + pending == depositedValidators`, which is an
+# equality between "ether still owned on the CL" and "ether ever sent to the deposit contract" --
+# so it forbids the write-off. `strict=True` makes them fail loudly once the check is relaxed,
+# which is the signal to drop the marker.
+
+_WRITE_OFF_FORBIDDEN = pytest.mark.xfail(
+    raises=CountOfKeysDiffersException,
+    strict=True,
+    reason='_validate_total_validators_count requires active + pending == depositedValidators, '
+    'which forbids writing a lost deposit out of TVL. Remove this marker once the check no '
+    'longer blocks the report.',
+)
+
+
+def _assert_lost_deposit_excluded_from_tvl(accounting: Accounting) -> None:
+    """The surviving key's ether is reported; the lost key's 32 ETH appears in neither TVL term."""
+    cl_balance = accounting._get_cl_validators_balance(ref_bs)
+    cl_pending_balance = accounting._get_cl_pending_validators_balance(ref_bs)
+
+    assert cl_balance == _VALIDATOR_BALANCE, 'only the one active validator contributes'
+    assert cl_pending_balance == _DEPOSIT_AMOUNT, 'only the one healthy pending deposit contributes'
+    assert cl_balance + cl_pending_balance == _VALIDATOR_BALANCE + _DEPOSIT_AMOUNT
+    # The written-off key contributed nothing, i.e. 32 ETH left TVL.
+    assert cl_pending_balance != 2 * _DEPOSIT_AMOUNT
 
 
 @pytest.mark.unit
-def test_get_active_lido_validators__cl_discarded_the_deposit__blocks_reporting_permanently(lido_protocol):
-    """A used key can be absent from both the validator registry and the deposit queue, forever.
+@_WRITE_OFF_FORBIDDEN
+def test_report_balances__operator_frontran_own_key__lost_deposit_excluded_from_tvl(lido_protocol, accounting):
+    """A key owner redirects its own deposit, so that ether must leave TVL.
+
+    The operator signs a deposit for its own pubkey with its own withdrawal credentials and lands
+    it ahead of Lido's. Only the holder of the secret key can produce that proof of possession,
+    which is why `_collect_valid_pending_deposits` treats it as a front run and drops the pubkey --
+    the ether is no longer withdrawable by the protocol, so crediting it would overstate TVL.
+    """
+    # Arrange
+    lido_protocol.set_pending_deposits(
+        _deposit(_PENDING_KEY, _LIDO_WC),
+        _deposit(_SUBJECT_KEY, _OPERATOR_WC),  # front run, validly signed by the key owner
+        _deposit(_SUBJECT_KEY, _LIDO_WC),  # Lido's own deposit, right behind it
+    )
+
+    # Act / Assert
+    assert _pubkey(_SUBJECT_KEY) not in lido_protocol.web3.lido_validators.get_pending_lido_validators(ref_bs)
+    _assert_lost_deposit_excluded_from_tvl(accounting)
+
+
+@pytest.mark.unit
+@_WRITE_OFF_FORBIDDEN
+def test_report_balances__cl_discarded_the_deposit__lost_deposit_excluded_from_tvl(lido_protocol, accounting):
+    """The CL can drop a deposit permanently, and TVL has to follow.
 
     Per Electra `apply_pending_deposit`, a deposit for an unknown pubkey creates a validator only
-    if `is_valid_deposit_signature` passes; otherwise it is ignored. `process_pending_deposits`
-    pops the entry either way, so an invalid-signature deposit leaves no trace on the CL. Lido's
-    `depositedValidators` counter was incremented at deposit time on the EL and never decreases,
-    so `active + pending == depositedValidators` is violated for the lifetime of the protocol.
-
-    Deposit signatures are supplied by node operators and are not validated on-chain; the DSM
-    guardians check them off-chain, which makes this a process guarantee rather than a protocol one.
+    if `is_valid_deposit_signature` passes; `process_pending_deposits` pops the entry either way.
+    An invalid-signature deposit therefore leaves neither a validator nor a queue entry, while
+    Lido's `depositedValidators` was incremented on the EL and never decreases -- so this state is
+    permanent, and so is the write-off. Deposit signatures come from node operators and are not
+    validated on-chain; the DSM guardians check them off-chain, which makes this a process
+    guarantee rather than a protocol one.
     """
     # Arrange: key 2 is used and deposited, but the CL has neither a validator nor a queued deposit.
     lido_protocol.set_pending_deposits(_deposit(_PENDING_KEY, _LIDO_WC))
 
     # Act / Assert
-    with pytest.raises(CountOfKeysDiffersException, match=r'\(2\).*does not match deposited validators count \(3\)'):
-        lido_protocol.web3.lido_validators.get_active_lido_validators(ref_bs)
+    _assert_lost_deposit_excluded_from_tvl(accounting)
 
 
-# ---- the same states, driven through the accounting oracle --------------------------------------
+# ---- the write-off must also survive the report build ------------------------------------------
 
 
-@pytest.fixture
-def accounting(lido_protocol) -> Accounting:
-    return Accounting(lido_protocol.web3)
+@pytest.mark.unit
+@_WRITE_OFF_FORBIDDEN
+def test_calculate_report__operator_frontran_own_key__report_is_built(lido_protocol, accounting):
+    """A written-off deposit must not stop the frame from being reported at all.
 
-
-@pytest.fixture
-def _frontrun_state(lido_protocol):
+    `_calculate_report` reads the CL balance second, so a raise there costs the whole report --
+    and because `CountOfKeysDiffersException` is caught by `OracleModule.exception_handler`, the
+    daemon does not crash, it just abandons the cycle and retries the same reference slot. For the
+    permanent state above that is an indefinite reporting outage visible only in the logs.
+    """
+    # Arrange: everything `_calculate_report` needs after the two balance terms.
     lido_protocol.set_pending_deposits(
         _deposit(_PENDING_KEY, _LIDO_WC),
         _deposit(_SUBJECT_KEY, _OPERATOR_WC),
         _deposit(_SUBJECT_KEY, _LIDO_WC),
     )
-    return lido_protocol
-
-
-@pytest.mark.unit
-def test_calculate_report__frontrun_key__aborts_before_any_report_data(accounting, _frontrun_state):
-    """`_calculate_report` reads the CL balance second, so the whole report build dies there."""
-    # Arrange
     accounting.get_consensus_version = Mock(return_value=4)
+    accounting._get_newly_exited_validators_by_modules = Mock(return_value=([], []))
+    accounting._get_balances_by_modules = Mock(return_value=([], []))
+    accounting.w3.lido_contracts.get_withdrawal_balance = Mock(return_value=Wei(0))
+    accounting.w3.lido_contracts.get_el_vault_balance = Mock(return_value=Wei(0))
+    accounting.get_shares_to_burn = Mock(return_value=0)
+    accounting._get_finalization_data = Mock(return_value=([], FinalizationShareRate(0)))
+    accounting._is_bunker = Mock(return_value=False)
+    accounting._handle_vaults_report = Mock(return_value=(VaultsTreeRoot(ZERO_HASH), VaultsTreeCid('')))
+    accounting.get_extra_data = Mock(
+        return_value=Mock(format=FormatList.EXTRA_DATA_FORMAT_LIST_EMPTY.value, data_hash=ZERO_HASH, items_count=0)
+    )
 
-    # Act / Assert
-    with pytest.raises(CountOfKeysDiffersException):
-        accounting.build_report(ref_bs)
+    # Act
+    report_data = accounting._calculate_report(ref_bs)
 
-
-@pytest.mark.unit
-def test_daemon_cycle__frontrun_key__no_report_submitted_and_cycle_retries(accounting, _frontrun_state, caplog):
-    """Operational consequence: the daemon does not crash -- it silently stops reporting.
-
-    `OracleModule.exception_handler` catches `CountOfKeysDiffersException`, so the cycle is
-    abandoned and `_slot_threshold` is left untouched, i.e. the next cycle retries the same
-    reference slot. For a state that never resolves (see `cl_discarded_the_deposit`) that is an
-    indefinite reporting outage visible only in the logs.
-    """
-    # Arrange
-    accounting._receive_last_finalized_slot = Mock(return_value=ref_bs)
-    accounting.refresh_contracts_if_address_change = Mock()
-    accounting.get_blockstamp_for_report = Mock(return_value=ref_bs)
-    accounting._check_compatibility = Mock(return_value=True)
-    accounting.get_consensus_version = Mock(return_value=4)
-    accounting._process_report_hash = Mock()
-    accounting._process_report_data = Mock()
-    accounting.process_extra_data = Mock()
-
-    # Act: a full daemon cycle, with only the report-frame selection and submission stubbed out.
-    accounting._cycle()
-
-    # Assert
-    accounting._process_report_hash.assert_not_called()
-    accounting._process_report_data.assert_not_called()
-    accounting.process_extra_data.assert_not_called()
-    assert accounting._slot_threshold == 0, 'cycle must not advance, so the next cycle retries'
-    assert 'Keys API service returned incorrect number of keys' in caplog.text
+    # Assert: the lost 32 ETH is in neither TVL term of the report that goes on-chain.
+    assert report_data.cl_validators_balance_gwei == _VALIDATOR_BALANCE
+    assert report_data.cl_pending_balance_gwei == _DEPOSIT_AMOUNT

--- a/tests/web3py/test_lido_validators_deposit_reconciliation.py
+++ b/tests/web3py/test_lido_validators_deposit_reconciliation.py
@@ -19,12 +19,19 @@ Keys API response, so nothing here is attributable to a KAPI defect:
   * key 1 -- valid 32 ETH deposit to Lido WC     -> *pending*
   * key 2 -- the variable under test
 
-The three tests that state the write-off requirement **fail on this branch**, deliberately and
-without an ``xfail`` marker. ``LidoValidatorsProvider._validate_total_validators_count`` requires
-``active + pending == depositedValidators``, which equates "ether still owned on the CL" with
-"ether ever sent to the deposit contract" and so forbids the write-off outright. Marking them
-expected-failures would turn the suite green and report no problem, which is the opposite of what
-they exist for. They pass unchanged once that check stops blocking the report.
+Four tests state the write-off requirement and **all four fail on this branch**, deliberately and
+without an ``xfail`` marker -- marking them expected-failures would turn the suite green and report
+no problem, which is the opposite of what they exist for. They fail for two independent reasons:
+
+1. Three of them are blocked by ``LidoValidatorsProvider._validate_total_validators_count``, which
+   requires ``active + pending == depositedValidators`` -- an equality between "ether still owned on
+   the CL" and "ether ever sent to the deposit contract", and so a prohibition on the write-off.
+   Introduced by the branch under review; these pass unchanged once it stops blocking the report.
+
+2. ``test_report_balances__frontrun_validator_created_on_cl__lost_ether_stays_out_of_tvl`` fails for
+   a different and pre-existing reason: no withdrawal-credential check exists on the active path at
+   all, so the write-off silently reverses the moment the CL creates the front-run validator. See
+   that test's docstring for the measured figures.
 """
 
 from unittest.mock import Mock
@@ -268,33 +275,40 @@ def test_get_active_lido_validators__garbage_signature_then_lido_deposit__reconc
     assert _pubkey(_SUBJECT_KEY) in pending
 
 
+# ---- the write-off must not reverse once the CL creates the validator ---------------------------
+
+
 @pytest.mark.unit
-def test_get_active_lido_validators__frontrun_validator_created_on_cl__balance_re_enters_tvl(lido_protocol, accounting):
-    """Once the CL creates the front-run validator, its balance is credited to Lido again.
+def test_report_balances__frontrun_validator_created_on_cl__lost_ether_stays_out_of_tvl(lido_protocol, accounting):
+    """The front-run write-off currently lasts only while the deposit sits in the CL queue.
 
-    `compute_lido_validators` matches CL validators to Lido keys by pubkey only, and nothing on the
-    active path consults `get_lido_wc_list` -- it is checked for pending deposits and in
-    `abnormal_cl_rebase`, never for active validators. So a validator holding the operator's own
-    withdrawal credentials contributes its full balance to `clValidatorsBalance` even though only
-    the operator can withdraw it, which is the same "lost ether in TVL" this file is about.
+    `_collect_valid_pending_deposits` drops a front-run pubkey, but that only governs *new*
+    validators: its `filter_pubkeys` is the set of Lido keys not yet on the CL. Once the CL creates
+    the validator, the exclusion is bypassed twice over --
 
-    Documented as the current behaviour rather than asserted as correct: the write-off above lasts
-    only as long as the deposit sits in the CL queue, and this is where it silently reverses.
+      * `compute_lido_validators` matches CL validators to Lido keys by pubkey alone, and nothing
+        on the active path consults `get_lido_wc_list` (it is checked for pending deposits and in
+        `abnormal_cl_rebase`, never for active validators), so the validator's balance lands in
+        `clValidatorsBalance`; and
+      * `get_active_lido_validators` builds `deposits_by_pubkey` from *every* pending deposit, with
+        no withdrawal-credential filter and no `filter_pubkeys`, so Lido's own queued deposit for
+        that pubkey returns as a `pending_topup` and lands in `clPendingBalance`.
+
+    Measured on this branch: `clValidatorsBalance` 64.2 ETH and `clPendingBalance` 64.0 ETH, i.e.
+    64.1 ETH attributed to a key only the operator can withdraw from. This test states that it must
+    be excluded instead, and fails today on the first assertion.
     """
-    # Arrange: the front-run validator now exists on the CL with the operator's own credentials.
+    # Arrange: the front-run validator now exists on the CL with the operator's own credentials,
+    # and Lido's own deposit for the same pubkey is still queued -- now a top-up, not a new deposit.
     lido_protocol.set_cl_validators((_ACTIVE_KEY, _LIDO_WC), (_SUBJECT_KEY, _OPERATOR_WC))
     lido_protocol.set_pending_deposits(
         _deposit(_PENDING_KEY, _LIDO_WC),
         _deposit(_SUBJECT_KEY, _LIDO_WC),
     )
 
-    # Act
-    active = lido_protocol.web3.lido_validators.get_active_lido_validators(ref_bs)
-
-    # Assert
-    assert len(active) == 2
-    assert _OPERATOR_WC in {v.validator.withdrawal_credentials for v in active}
-    assert accounting._get_cl_validators_balance(ref_bs) == 2 * _VALIDATOR_BALANCE
+    # Assert: only the honest validator and the honest pending deposit may be reported.
+    assert accounting._get_cl_validators_balance(ref_bs) == _VALIDATOR_BALANCE
+    assert accounting._get_cl_pending_validators_balance(ref_bs) == _DEPOSIT_AMOUNT
 
 
 # ---- the two states where a used key is neither active nor pending -----------------------------

--- a/tests/web3py/test_lido_validators_deposit_reconciliation.py
+++ b/tests/web3py/test_lido_validators_deposit_reconciliation.py
@@ -19,10 +19,12 @@ Keys API response, so nothing here is attributable to a KAPI defect:
   * key 1 -- valid 32 ETH deposit to Lido WC     -> *pending*
   * key 2 -- the variable under test
 
-The tests that state the write-off requirement are marked ``xfail(strict=True)``: they fail today
-because ``LidoValidatorsProvider._validate_total_validators_count`` requires
+The three tests that state the write-off requirement **fail on this branch**, deliberately and
+without an ``xfail`` marker. ``LidoValidatorsProvider._validate_total_validators_count`` requires
 ``active + pending == depositedValidators``, which equates "ether still owned on the CL" with
-"ether ever sent to the deposit contract" and so forbids the write-off outright.
+"ether ever sent to the deposit contract" and so forbids the write-off outright. Marking them
+expected-failures would turn the suite green and report no problem, which is the opposite of what
+they exist for. They pass unchanged once that check stops blocking the report.
 """
 
 from unittest.mock import Mock
@@ -52,7 +54,6 @@ from src.services.deposit_signature_verification import (
 from src.types import Gwei, NodeOperatorId, SlotNumber
 from src.utils.cache import clear_global_cache
 from src.utils.types import hex_str_to_bytes
-from src.web3py.extensions.lido_validators import CountOfKeysDiffersException
 from tests.factory.blockstamp import ReferenceBlockStampFactory
 from tests.factory.no_registry import (
     LidoKeyFactory,
@@ -220,7 +221,7 @@ def accounting(lido_protocol) -> Accounting:
 
 # ---- baselines: states with nothing to write off ------------------------------------------------
 #
-# Without these, the xfailing tests below would prove nothing -- they could be failing because the
+# Without these, the failing tests below would prove nothing -- they could be failing because the
 # fixture is wired wrong rather than because of the state under test.
 
 
@@ -303,19 +304,12 @@ def test_get_active_lido_validators__frontrun_validator_created_on_cl__balance_r
 # carries the loss -- `clValidatorsBalance` and `clPendingBalance` are the only CL-side TVL inputs
 # the contract has (`ReportSimulationPayload`), and `depositedValidators` is not one of them.
 #
-# These tests state that requirement. They fail today because
-# `_validate_total_validators_count` demands `active + pending == depositedValidators`, which is an
-# equality between "ether still owned on the CL" and "ether ever sent to the deposit contract" --
-# so it forbids the write-off. `strict=True` makes them fail loudly once the check is relaxed,
-# which is the signal to drop the marker.
-
-_WRITE_OFF_FORBIDDEN = pytest.mark.xfail(
-    raises=CountOfKeysDiffersException,
-    strict=True,
-    reason='_validate_total_validators_count requires active + pending == depositedValidators, '
-    'which forbids writing a lost deposit out of TVL. Remove this marker once the check no '
-    'longer blocks the report.',
-)
+# These tests state that requirement, and they FAIL on this branch. That is the point: they are
+# left red rather than marked xfail, because the check they contradict is still under review and a
+# green suite would report no problem at all. `_validate_total_validators_count` demands
+# `active + pending == depositedValidators` -- an equality between "ether still owned on the CL"
+# and "ether ever sent to the deposit contract" -- and so forbids the write-off. They go green
+# once that check stops blocking the report; nothing else about them needs to change.
 
 
 def _assert_lost_deposit_excluded_from_tvl(accounting: Accounting) -> None:
@@ -331,7 +325,6 @@ def _assert_lost_deposit_excluded_from_tvl(accounting: Accounting) -> None:
 
 
 @pytest.mark.unit
-@_WRITE_OFF_FORBIDDEN
 def test_report_balances__operator_frontran_own_key__lost_deposit_excluded_from_tvl(lido_protocol, accounting):
     """A key owner redirects its own deposit, so that ether must leave TVL.
 
@@ -353,7 +346,6 @@ def test_report_balances__operator_frontran_own_key__lost_deposit_excluded_from_
 
 
 @pytest.mark.unit
-@_WRITE_OFF_FORBIDDEN
 def test_report_balances__cl_discarded_the_deposit__lost_deposit_excluded_from_tvl(lido_protocol, accounting):
     """The CL can drop a deposit permanently, and TVL has to follow.
 
@@ -376,7 +368,6 @@ def test_report_balances__cl_discarded_the_deposit__lost_deposit_excluded_from_t
 
 
 @pytest.mark.unit
-@_WRITE_OFF_FORBIDDEN
 def test_calculate_report__operator_frontran_own_key__report_is_built(lido_protocol, accounting):
     """A written-off deposit must not stop the frame from being reported at all.
 

--- a/tests/web3py/test_lido_validators_deposit_reconciliation.py
+++ b/tests/web3py/test_lido_validators_deposit_reconciliation.py
@@ -1,0 +1,376 @@
+"""Reconciliation of Keys API used keys against Lido's on-chain ``depositedValidators`` counter.
+
+``LidoValidatorsProvider._validate_total_validators_count`` requires
+
+    len(active_lido_validators) + len(pending_lido_validators) == lido.depositedValidators
+
+These tests build the protocol states that break that equality while the Keys API response is
+*complete and correct*, so any failure is attributable to the reconciliation rule itself rather
+than to a KAPI defect.
+
+Deposit signatures are produced with real BLS keys and checked by the production verifier
+(``src.services.deposit_signature_verification``). Both failure modes below hinge on whether a
+signature actually verifies, so mocking the verifier away would make the tests vacuous.
+
+Shared fixture state (see ``lido_protocol``): one staking module, one node operator with
+``total_deposited_validators == 3``, and three used keys at indexes 0/1/2:
+
+  * key 0 -- already a validator on the CL       -> counted as *active*
+  * key 1 -- valid 32 ETH deposit to Lido WC     -> counted as *pending*
+  * key 2 -- the variable under test
+"""
+
+from unittest.mock import Mock
+
+import blst
+import pytest
+from eth_typing import HexStr
+
+from src.constants import DOMAIN_DEPOSIT_TYPE, ETH1_ADDRESS_WITHDRAWAL_PREFIX
+from src.modules.oracles.accounting.accounting import Accounting
+from src.modules.oracles.accounting.types import BeaconStat
+from src.providers.consensus.types import PendingDeposit
+from src.services.deposit_signature_verification import (
+    _POP_DST,
+    DepositMessage,
+    compute_domain,
+    compute_signing_root,
+)
+from src.types import Gwei, NodeOperatorId, SlotNumber
+from src.utils.cache import clear_global_cache
+from src.utils.types import hex_str_to_bytes
+from src.web3py.extensions.lido_validators import CountOfKeysDiffersException
+from tests.factory.blockstamp import ReferenceBlockStampFactory
+from tests.factory.no_registry import (
+    LidoKeyFactory,
+    NodeOperatorFactory,
+    StakingModuleFactory,
+    ValidatorFactory,
+    ValidatorStateFactory,
+)
+
+
+DEPOSITED_VALIDATORS = 3
+
+# Seeds for deterministic BLS keys. Seed N is the key at operator key index N.
+_ACTIVE_KEY = 1
+_PENDING_KEY = 2
+_SUBJECT_KEY = 3
+
+_LIDO_WITHDRAWAL_VAULT = '0x' + 'ab' * 20
+_OPERATOR_OWN_VAULT = '0x' + 'cd' * 20
+
+_GENESIS_FORK_VERSION = HexStr('0x10000038')
+_DEPOSIT_AMOUNT = Gwei(32 * 10**9)
+_DEPOSIT_SLOT = SlotNumber(1)
+
+# 96-byte value that is well-formed for `blst.P2_Affine` but verifies against nothing.
+_GARBAGE_SIGNATURE = HexStr('0x' + 'c0' + '00' * 95)
+
+
+def _withdrawal_credentials(vault_address: str) -> HexStr:
+    """Mirror `LidoValidatorsProvider.get_lido_wc_list` 0x01 credential layout."""
+    return HexStr(ETH1_ADDRESS_WITHDRAWAL_PREFIX + '0' * 22 + vault_address[2:].lower())
+
+
+_LIDO_WC = _withdrawal_credentials(_LIDO_WITHDRAWAL_VAULT)
+_OPERATOR_WC = _withdrawal_credentials(_OPERATOR_OWN_VAULT)
+
+
+def _secret_key(seed: int) -> blst.SecretKey:
+    secret_key = blst.SecretKey()
+    secret_key.keygen(seed.to_bytes(32, 'big'))
+    return secret_key
+
+
+def _pubkey(seed: int) -> HexStr:
+    return HexStr('0x' + blst.P1(_secret_key(seed)).compress().hex())
+
+
+def _proof_of_possession(seed: int, withdrawal_credentials: HexStr) -> HexStr:
+    """Produce a genuinely valid deposit signature.
+
+    Only the holder of the validator's secret key can sign a deposit for an arbitrary
+    withdrawal credential -- which is exactly why the "front run" branch in
+    `_collect_valid_pending_deposits` describes a malicious *key owner*, not an outsider.
+    """
+    message = DepositMessage(
+        pubkey=hex_str_to_bytes(_pubkey(seed)),
+        withdrawal_credentials=hex_str_to_bytes(withdrawal_credentials),
+        amount=_DEPOSIT_AMOUNT,
+    )
+    signing_root = compute_signing_root(
+        message, compute_domain(DOMAIN_DEPOSIT_TYPE, hex_str_to_bytes(_GENESIS_FORK_VERSION))
+    )
+    signature = blst.P2().hash_to(signing_root, _POP_DST).sign_with(_secret_key(seed)).compress()
+    return HexStr('0x' + signature.hex())
+
+
+def _deposit(seed: int, withdrawal_credentials: HexStr, signature: HexStr | None = None) -> PendingDeposit:
+    return PendingDeposit(
+        pubkey=_pubkey(seed),
+        withdrawal_credentials=withdrawal_credentials,
+        amount=_DEPOSIT_AMOUNT,
+        signature=signature if signature is not None else _proof_of_possession(seed, withdrawal_credentials),
+        slot=_DEPOSIT_SLOT,
+    )
+
+
+ref_bs = ReferenceBlockStampFactory.build()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_global_cache():
+    clear_global_cache()
+    yield
+    clear_global_cache()
+
+
+@pytest.fixture
+def lido_protocol(web3):
+    """Wire a minimal but complete protocol state around the real `LidoValidatorsProvider`.
+
+    Only the provider's collaborators (CL, EL contracts, Keys API) are mocked -- every method
+    under test runs for real, including BLS verification.
+    """
+    staking_module = StakingModuleFactory.build()
+    operator = NodeOperatorFactory.build(
+        id=NodeOperatorId(0),
+        staking_module=staking_module,
+        total_deposited_validators=DEPOSITED_VALIDATORS,
+    )
+
+    lido_keys = [
+        LidoKeyFactory.build(
+            index=index,
+            key=_pubkey(seed),
+            operator_index=operator.id,
+            module_address=staking_module.staking_module_address,
+            used=True,
+        )
+        for index, seed in enumerate((_ACTIVE_KEY, _PENDING_KEY, _SUBJECT_KEY))
+    ]
+
+    # Keys API response is complete: indexes 0..2 for the only operator, all used.
+    web3.kac.get_used_lido_keys = Mock(return_value=lido_keys)
+
+    web3.lido_contracts.lido.get_beacon_stat = Mock(
+        return_value=BeaconStat(deposited_validators=DEPOSITED_VALIDATORS, beacon_validators=1, beacon_balance=0)
+    )
+    web3.lido_contracts.lido_locator.withdrawal_vault = Mock(return_value=_LIDO_WITHDRAWAL_VAULT)
+    web3.lido_contracts.staking_router.get_staking_modules = Mock(return_value=[staking_module])
+    web3.lido_contracts.staking_router.get_all_node_operator_digests = Mock(return_value=[operator])
+
+    web3.cc.get_genesis = Mock(return_value=Mock(genesis_fork_version=_GENESIS_FORK_VERSION))
+    web3.cc.get_pending_consolidations = Mock(return_value=[])
+    web3.cc.get_pending_deposits = Mock(return_value=[])
+
+    def set_cl_validators(*seeds_with_wc: tuple[int, HexStr]) -> None:
+        validators = [
+            ValidatorFactory.build(
+                index=index,
+                validator=ValidatorStateFactory.build(pubkey=_pubkey(seed), withdrawal_credentials=wc),
+            )
+            for index, (seed, wc) in enumerate(seeds_with_wc)
+        ]
+        web3.cc.get_validators = Mock(return_value=validators)
+        web3.cc.get_validators_by_indexes = Mock(return_value={v.index: v for v in validators})
+
+    # Key 0 is live on the CL with Lido withdrawal credentials.
+    set_cl_validators((_ACTIVE_KEY, _LIDO_WC))
+
+    def set_pending_deposits(*deposits: PendingDeposit) -> None:
+        web3.cc.get_pending_deposits = Mock(return_value=list(deposits))
+
+    return Mock(
+        web3=web3,
+        keys=lido_keys,
+        operator=operator,
+        staking_module=staking_module,
+        set_cl_validators=set_cl_validators,
+        set_pending_deposits=set_pending_deposits,
+    )
+
+
+# ---- baseline: the reconciliation must hold on a healthy state ----------------------------------
+#
+# Without this test the failing ones below would prove nothing -- they could be failing because the
+# fixture is wired wrong rather than because of the state under test.
+
+
+@pytest.mark.unit
+def test_get_active_lido_validators__every_used_key_active_or_pending__reconciles(lido_protocol):
+    # Arrange: keys 1 and 2 both have valid 32 ETH deposits to the Lido withdrawal vault.
+    lido_protocol.set_pending_deposits(
+        _deposit(_PENDING_KEY, _LIDO_WC),
+        _deposit(_SUBJECT_KEY, _LIDO_WC),
+    )
+
+    # Act
+    active = lido_protocol.web3.lido_validators.get_active_lido_validators(ref_bs)
+    pending = lido_protocol.web3.lido_validators.get_pending_lido_validators(ref_bs)
+
+    # Assert
+    assert len(active) == 1
+    assert len(pending) == 2
+    assert len(active) + len(pending) == DEPOSITED_VALIDATORS
+
+
+@pytest.mark.unit
+def test_get_active_lido_validators__garbage_signature_then_lido_deposit__reconciles(lido_protocol):
+    """An outsider cannot grief the reconciliation.
+
+    Anyone may queue a deposit for a known Lido pubkey, but without the secret key the signature
+    cannot verify. `_collect_valid_pending_deposits` skips such a deposit without blacklisting the
+    pubkey, so Lido's own deposit behind it still counts as pending -- and the CL likewise ignores
+    the unverifiable deposit when creating the validator.
+    """
+    # Arrange
+    lido_protocol.set_pending_deposits(
+        _deposit(_PENDING_KEY, _LIDO_WC),
+        _deposit(_SUBJECT_KEY, _OPERATOR_WC, signature=_GARBAGE_SIGNATURE),
+        _deposit(_SUBJECT_KEY, _LIDO_WC),
+    )
+
+    # Act
+    active = lido_protocol.web3.lido_validators.get_active_lido_validators(ref_bs)
+    pending = lido_protocol.web3.lido_validators.get_pending_lido_validators(ref_bs)
+
+    # Assert
+    assert len(active) + len(pending) == DEPOSITED_VALIDATORS
+    assert _pubkey(_SUBJECT_KEY) in pending
+
+
+# ---- failure mode 1: node operator front-runs its own key --------------------------------------
+
+
+@pytest.mark.unit
+def test_get_active_lido_validators__operator_frontran_own_key__blocks_reporting(lido_protocol):
+    """A key owner can stall the reconciliation on demand.
+
+    The operator signs a deposit for its own pubkey with its own withdrawal credentials and lands
+    it ahead of Lido's. `_collect_valid_pending_deposits` deliberately drops that pubkey entirely
+    ("Ignoring key. Possible front run attack") so its balance is not credited to Lido -- which is
+    the conservative, intended behaviour. `depositedValidators` was already incremented on the EL,
+    so the key is now counted in neither `active` nor `pending` and the equality cannot hold.
+    """
+    # Arrange
+    lido_protocol.set_pending_deposits(
+        _deposit(_PENDING_KEY, _LIDO_WC),
+        _deposit(_SUBJECT_KEY, _OPERATOR_WC),  # front run, validly signed by the key owner
+        _deposit(_SUBJECT_KEY, _LIDO_WC),  # Lido's own deposit, right behind it
+    )
+
+    # Act / Assert: the front-run key is excluded from pending, so 1 + 1 != 3
+    pending = lido_protocol.web3.lido_validators.get_pending_lido_validators(ref_bs)
+    assert _pubkey(_SUBJECT_KEY) not in pending
+    assert len(pending) == 1
+
+    with pytest.raises(CountOfKeysDiffersException, match=r'\(2\).*does not match deposited validators count \(3\)'):
+        lido_protocol.web3.lido_validators.get_active_lido_validators(ref_bs)
+
+
+@pytest.mark.unit
+def test_get_active_lido_validators__frontrun_validator_created_on_cl__reconciles_again(lido_protocol):
+    """The stall above lasts exactly as long as the deposit sits in the CL queue.
+
+    Once the CL creates the validator, `compute_lido_validators` matches it by pubkey regardless of
+    its withdrawal credentials, so it counts as active and the equality holds again. This bounds
+    the outage to the pending-deposit queue delay -- but the operator can repeat it per key.
+    """
+    # Arrange: the front-run validator now exists on the CL with the operator's own credentials.
+    lido_protocol.set_cl_validators((_ACTIVE_KEY, _LIDO_WC), (_SUBJECT_KEY, _OPERATOR_WC))
+    lido_protocol.set_pending_deposits(
+        _deposit(_PENDING_KEY, _LIDO_WC),
+        _deposit(_SUBJECT_KEY, _LIDO_WC),
+    )
+
+    # Act
+    active = lido_protocol.web3.lido_validators.get_active_lido_validators(ref_bs)
+
+    # Assert
+    assert len(active) == 2
+    assert len(active) + len(lido_protocol.web3.lido_validators.get_pending_lido_validators(ref_bs)) == 3
+
+
+# ---- failure mode 2: the CL discarded the deposit ----------------------------------------------
+
+
+@pytest.mark.unit
+def test_get_active_lido_validators__cl_discarded_the_deposit__blocks_reporting_permanently(lido_protocol):
+    """A used key can be absent from both the validator registry and the deposit queue, forever.
+
+    Per Electra `apply_pending_deposit`, a deposit for an unknown pubkey creates a validator only
+    if `is_valid_deposit_signature` passes; otherwise it is ignored. `process_pending_deposits`
+    pops the entry either way, so an invalid-signature deposit leaves no trace on the CL. Lido's
+    `depositedValidators` counter was incremented at deposit time on the EL and never decreases,
+    so `active + pending == depositedValidators` is violated for the lifetime of the protocol.
+
+    Deposit signatures are supplied by node operators and are not validated on-chain; the DSM
+    guardians check them off-chain, which makes this a process guarantee rather than a protocol one.
+    """
+    # Arrange: key 2 is used and deposited, but the CL has neither a validator nor a queued deposit.
+    lido_protocol.set_pending_deposits(_deposit(_PENDING_KEY, _LIDO_WC))
+
+    # Act / Assert
+    with pytest.raises(CountOfKeysDiffersException, match=r'\(2\).*does not match deposited validators count \(3\)'):
+        lido_protocol.web3.lido_validators.get_active_lido_validators(ref_bs)
+
+
+# ---- the same states, driven through the accounting oracle --------------------------------------
+
+
+@pytest.fixture
+def accounting(lido_protocol) -> Accounting:
+    return Accounting(lido_protocol.web3)
+
+
+@pytest.fixture
+def _frontrun_state(lido_protocol):
+    lido_protocol.set_pending_deposits(
+        _deposit(_PENDING_KEY, _LIDO_WC),
+        _deposit(_SUBJECT_KEY, _OPERATOR_WC),
+        _deposit(_SUBJECT_KEY, _LIDO_WC),
+    )
+    return lido_protocol
+
+
+@pytest.mark.unit
+def test_calculate_report__frontrun_key__aborts_before_any_report_data(accounting, _frontrun_state):
+    """`_calculate_report` reads the CL balance second, so the whole report build dies there."""
+    # Arrange
+    accounting.get_consensus_version = Mock(return_value=4)
+
+    # Act / Assert
+    with pytest.raises(CountOfKeysDiffersException):
+        accounting.build_report(ref_bs)
+
+
+@pytest.mark.unit
+def test_daemon_cycle__frontrun_key__no_report_submitted_and_cycle_retries(accounting, _frontrun_state, caplog):
+    """Operational consequence: the daemon does not crash -- it silently stops reporting.
+
+    `OracleModule.exception_handler` catches `CountOfKeysDiffersException`, so the cycle is
+    abandoned and `_slot_threshold` is left untouched, i.e. the next cycle retries the same
+    reference slot. For a state that never resolves (see `cl_discarded_the_deposit`) that is an
+    indefinite reporting outage visible only in the logs.
+    """
+    # Arrange
+    accounting._receive_last_finalized_slot = Mock(return_value=ref_bs)
+    accounting.refresh_contracts_if_address_change = Mock()
+    accounting.get_blockstamp_for_report = Mock(return_value=ref_bs)
+    accounting._check_compatibility = Mock(return_value=True)
+    accounting.get_consensus_version = Mock(return_value=4)
+    accounting._process_report_hash = Mock()
+    accounting._process_report_data = Mock()
+    accounting.process_extra_data = Mock()
+
+    # Act: a full daemon cycle, with only the report-frame selection and submission stubbed out.
+    accounting._cycle()
+
+    # Assert
+    accounting._process_report_hash.assert_not_called()
+    accounting._process_report_data.assert_not_called()
+    accounting.process_extra_data.assert_not_called()
+    assert accounting._slot_threshold == 0, 'cycle must not advance, so the next cycle retries'
+    assert 'Keys API service returned incorrect number of keys' in caplog.text

--- a/tests/web3py/test_lido_validators_deposit_reconciliation.py
+++ b/tests/web3py/test_lido_validators_deposit_reconciliation.py
@@ -29,9 +29,10 @@ no problem, which is the opposite of what they exist for. They fail for two inde
    Introduced by the branch under review; these pass unchanged once it stops blocking the report.
 
 2. ``test_report_balances__frontrun_validator_created_on_cl__lost_ether_stays_out_of_tvl`` fails for
-   a different and pre-existing reason: no withdrawal-credential check exists on the active path at
-   all, so the write-off silently reverses the moment the CL creates the front-run validator. See
-   that test's docstring for the measured figures.
+   a different and pre-existing reason: which CL validators count as Lido's is decided by pubkey
+   alone, with no check that their withdrawal credentials are Lido's, so the write-off silently
+   reverses the moment the CL creates the front-run validator. One gap, but it shows up in both
+   reported balances. See that test's docstring for the measured figures.
 """
 
 from unittest.mock import Mock
@@ -282,21 +283,27 @@ def test_get_active_lido_validators__garbage_signature_then_lido_deposit__reconc
 def test_report_balances__frontrun_validator_created_on_cl__lost_ether_stays_out_of_tvl(lido_protocol, accounting):
     """The front-run write-off currently lasts only while the deposit sits in the CL queue.
 
-    `_collect_valid_pending_deposits` drops a front-run pubkey, but that only governs *new*
+    `_collect_valid_pending_deposits` drops a front-run pubkey, but that governs only *new*
     validators: its `filter_pubkeys` is the set of Lido keys not yet on the CL. Once the CL creates
-    the validator, the exclusion is bypassed twice over --
+    the validator the pubkey leaves that set, and nothing downstream reinstates the exclusion --
+    `compute_lido_validators` decides which CL validators are Lido's **by pubkey alone**, and no
+    caller consults `get_lido_wc_list` on the active path (it is checked for pending deposits and in
+    `abnormal_cl_rebase`, never for active validators).
 
-      * `compute_lido_validators` matches CL validators to Lido keys by pubkey alone, and nothing
-        on the active path consults `get_lido_wc_list` (it is checked for pending deposits and in
-        `abnormal_cl_rebase`, never for active validators), so the validator's balance lands in
-        `clValidatorsBalance`; and
-      * `get_active_lido_validators` builds `deposits_by_pubkey` from *every* pending deposit, with
-        no withdrawal-credential filter and no `filter_pubkeys`, so Lido's own queued deposit for
-        that pubkey returns as a `pending_topup` and lands in `clPendingBalance`.
+    That single gap contaminates both TVL terms, which are each computed correctly over the wrong
+    set. Note that summing them is *not* double counting: a `pending_topup` is ether that has left
+    the deposit contract but is not yet in `validator.balance`, and the two contributions to
+    `clPendingBalance` are disjoint by construction -- `new_validators_pending` comes from keys not
+    on the CL, `topups_pending` from keys that are.
+
+      * the validator's own balance lands in `clValidatorsBalance`;
+      * Lido's still-queued deposit for that pubkey is reclassified from a new-validator deposit
+        into a `pending_topup` and lands in `clPendingBalance`.
 
     Measured on this branch: `clValidatorsBalance` 64.2 ETH and `clPendingBalance` 64.0 ETH, i.e.
-    64.1 ETH attributed to a key only the operator can withdraw from. This test states that it must
-    be excluded instead, and fails today on the first assertion.
+    64.1 ETH attributed to a key only the operator can withdraw from. Excluding the validator from
+    the Lido set fixes both terms at once, which is why this test asserts on the reported balances
+    rather than prescribing where the check goes.
     """
     # Arrange: the front-run validator now exists on the CL with the operator's own credentials,
     # and Lido's own deposit for the same pubkey is still queued -- now a top-up, not a new deposit.

--- a/tests/web3py/test_lido_validators_deposit_reconciliation.py
+++ b/tests/web3py/test_lido_validators_deposit_reconciliation.py
@@ -71,6 +71,7 @@ from src.services.deposit_signature_verification import (
 from src.types import Gwei, NodeOperatorId, SlotNumber
 from src.utils.cache import clear_global_cache
 from src.utils.types import hex_str_to_bytes
+from src.web3py.extensions.lido_validators import ForeignWithdrawalCredentialsException
 from tests.factory.blockstamp import ReferenceBlockStampFactory
 from tests.factory.no_registry import (
     LidoKeyFactory,
@@ -328,7 +329,7 @@ def test_report__frontrun_validator_created_on_cl__reporting_is_refused(lido_pro
     )
 
     # Act / Assert: the balance must not be handed to the report at all.
-    with pytest.raises(Exception) as raised:  # noqa: B017, PT011 -- see docstring
+    with pytest.raises(ForeignWithdrawalCredentialsException) as raised:
         accounting._get_cl_validators_balance(ref_bs)
 
     # And the operator has to be able to find out which key is at fault.

--- a/tests/web3py/test_lido_validators_deposit_reconciliation.py
+++ b/tests/web3py/test_lido_validators_deposit_reconciliation.py
@@ -1,15 +1,23 @@
-"""A deposit the protocol lost must drop out of TVL.
+"""Ether Lido paid for but cannot withdraw must never be reported as TVL.
 
-Ether that Lido sent to the deposit contract but can no longer withdraw -- redirected by a node
-operator's front run, or discarded outright by the CL -- must not be reported as TVL. The oracle is
-what carries that write-off: ``clValidatorsBalance`` and ``clPendingBalance`` are the only CL-side
-TVL inputs the contract takes (``ReportSimulationPayload``), and ``depositedValidators`` is not one
-of them -- deposits are tracked on-chain by nonce (``BalanceStats``). So a lost key simply falling
-out of both the active and the pending set *is* the mechanism by which the loss reaches TVL.
+``clValidatorsBalance`` and ``clPendingBalance`` are the only CL-side TVL inputs the contract takes
+(``ReportSimulationPayload``); ``depositedValidators`` is not one of them, since deposits are tracked
+on-chain by nonce (``BalanceStats``). So whatever the oracle leaves out of the active and pending
+sets is what leaves TVL -- the oracle is the only thing that can carry such a loss.
+
+Two different outcomes are required, depending on whether anyone holds the credentials:
+
+* **Write off** when the ether is simply gone and nobody can reach it -- the CL discarded the
+  deposit, or a front run is still sitting in the deposit queue. Dropping the key out of both sets
+  is the whole mechanism, and the report must still be produced.
+* **Refuse to report** when a counterparty holds the withdrawal credentials for ether Lido paid
+  for, i.e. a used key whose CL validator has non-Lido credentials. Writing that off silently would
+  disguise a captured deposit as an ordinary loss; it needs a human, not an adjustment.
 
 Deposit signatures are produced with real BLS keys and checked by the production verifier
-(``src.services.deposit_signature_verification``). Both loss scenarios turn on whether a signature
-actually verifies, so mocking the verifier away would make these tests vacuous.
+(``src.services.deposit_signature_verification``). The scenarios turn on whether a signature
+actually verifies -- only the key's owner can sign a deposit onto foreign credentials -- so mocking
+the verifier away would make these tests vacuous.
 
 Shared fixture state (see ``lido_protocol``): one staking module, one node operator with
 ``total_deposited_validators == 3``, and three used keys at indexes 0/1/2 -- a complete, correct
@@ -19,7 +27,7 @@ Keys API response, so nothing here is attributable to a KAPI defect:
   * key 1 -- valid 32 ETH deposit to Lido WC     -> *pending*
   * key 2 -- the variable under test
 
-Four tests state the write-off requirement and **all four fail on this branch**, deliberately and
+Four tests state these requirements and **all four fail on this branch**, deliberately and
 without an ``xfail`` marker -- marking them expected-failures would turn the suite green and report
 no problem, which is the opposite of what they exist for. They fail for two independent reasons:
 
@@ -28,11 +36,12 @@ no problem, which is the opposite of what they exist for. They fail for two inde
    the CL" and "ether ever sent to the deposit contract", and so a prohibition on the write-off.
    Introduced by the branch under review; these pass unchanged once it stops blocking the report.
 
-2. ``test_report_balances__frontrun_validator_created_on_cl__lost_ether_stays_out_of_tvl`` fails for
-   a different and pre-existing reason: which CL validators count as Lido's is decided by pubkey
-   alone, with no check that their withdrawal credentials are Lido's, so the write-off silently
-   reverses the moment the CL creates the front-run validator. One gap, but it shows up in both
-   reported balances. See that test's docstring for the measured figures.
+2. ``test_report__frontrun_validator_created_on_cl__reporting_is_refused`` fails for a different and
+   pre-existing reason: which CL validators count as Lido's is decided by pubkey alone, with no
+   check that their withdrawal credentials are Lido's. A used key sitting on a validator with
+   someone else's credentials must **refuse the report and name the key**, not be quietly written
+   out of TVL -- an operator holding the credentials for ether Lido paid for needs a human, not an
+   adjustment. See that test's docstring for the measured figures and for the permanence caveat.
 """
 
 from unittest.mock import Mock
@@ -276,34 +285,39 @@ def test_get_active_lido_validators__garbage_signature_then_lido_deposit__reconc
     assert _pubkey(_SUBJECT_KEY) in pending
 
 
-# ---- the write-off must not reverse once the CL creates the validator ---------------------------
+# ---- a used key on a validator with non-Lido credentials must be refused, not written off -------
 
 
 @pytest.mark.unit
-def test_report_balances__frontrun_validator_created_on_cl__lost_ether_stays_out_of_tvl(lido_protocol, accounting):
-    """The front-run write-off currently lasts only while the deposit sits in the CL queue.
+def test_report__frontrun_validator_created_on_cl__reporting_is_refused(lido_protocol, accounting, caplog):
+    """A used Lido key whose CL validator holds non-Lido withdrawal credentials must stop the report.
 
-    `_collect_valid_pending_deposits` drops a front-run pubkey, but that governs only *new*
-    validators: its `filter_pubkeys` is the set of Lido keys not yet on the CL. Once the CL creates
-    the validator the pubkey leaves that set, and nothing downstream reinstates the exclusion --
-    `compute_lido_validators` decides which CL validators are Lido's **by pubkey alone**, and no
-    caller consults `get_lido_wc_list` on the active path (it is checked for pending deposits and in
-    `abnormal_cl_rebase`, never for active validators).
+    Refused rather than filtered out of TVL: silently writing the ether off would drop TVL with no
+    explanation and let a captured deposit pass as an ordinary loss. This state means a node
+    operator holds the credentials for ether Lido paid for, and it needs a human, not an adjustment.
 
-    That single gap contaminates both TVL terms, which are each computed correctly over the wrong
-    set. Note that summing them is *not* double counting: a `pending_topup` is ether that has left
-    the deposit contract but is not yet in `validator.balance`, and the two contributions to
-    `clPendingBalance` are disjoint by construction -- `new_validators_pending` comes from keys not
-    on the CL, `topups_pending` from keys that are.
+    Nothing detects it today. `_collect_valid_pending_deposits` drops a front-run pubkey, but that
+    governs only *new* validators -- its `filter_pubkeys` is the set of Lido keys not yet on the CL.
+    Once the CL creates the validator the pubkey leaves that set, and nothing downstream reinstates
+    the exclusion: `compute_lido_validators` decides which CL validators are Lido's **by pubkey
+    alone**, and no caller consults `get_lido_wc_list` on the active path (it is checked for pending
+    deposits and in `abnormal_cl_rebase`, never for active validators).
 
-      * the validator's own balance lands in `clValidatorsBalance`;
-      * Lido's still-queued deposit for that pubkey is reclassified from a new-validator deposit
-        into a `pending_topup` and lands in `clPendingBalance`.
+    So the ether is reported as Lido's through both TVL terms -- measured here, 64.2 ETH in
+    `clValidatorsBalance` and 64.0 ETH in `clPendingBalance`, i.e. 64.1 ETH attributed to a key only
+    the operator can withdraw from. Note that summing the two is *not* double counting: a
+    `pending_topup` is ether that has left the deposit contract but is not yet in `validator.balance`,
+    and the two contributions to `clPendingBalance` are disjoint by construction. One gap, two
+    contaminated terms.
 
-    Measured on this branch: `clValidatorsBalance` 64.2 ETH and `clPendingBalance` 64.0 ETH, i.e.
-    64.1 ETH attributed to a key only the operator can withdraw from. Excluding the validator from
-    the Lido set fixes both terms at once, which is why this test asserts on the reported balances
-    rather than prescribing where the check goes.
+    Caveat for whoever implements this: `0x01` withdrawal credentials are immutable, so unlike a
+    front run still sitting in the deposit queue, this state never resolves on its own. Without a
+    way for operators to acknowledge a known pubkey, the refusal is permanent and accounting stops
+    reporting for good.
+
+    The exception type is deliberately not pinned -- none exists yet, and inventing an import here
+    would only break collection. What is pinned is the contract that matters: no report data is
+    produced, and the offending pubkey is named so an operator can act on it.
     """
     # Arrange: the front-run validator now exists on the CL with the operator's own credentials,
     # and Lido's own deposit for the same pubkey is still queued -- now a top-up, not a new deposit.
@@ -313,9 +327,14 @@ def test_report_balances__frontrun_validator_created_on_cl__lost_ether_stays_out
         _deposit(_SUBJECT_KEY, _LIDO_WC),
     )
 
-    # Assert: only the honest validator and the honest pending deposit may be reported.
-    assert accounting._get_cl_validators_balance(ref_bs) == _VALIDATOR_BALANCE
-    assert accounting._get_cl_pending_validators_balance(ref_bs) == _DEPOSIT_AMOUNT
+    # Act / Assert: the balance must not be handed to the report at all.
+    with pytest.raises(Exception) as raised:  # noqa: B017, PT011 -- see docstring
+        accounting._get_cl_validators_balance(ref_bs)
+
+    # And the operator has to be able to find out which key is at fault.
+    assert _pubkey(_SUBJECT_KEY) in str(raised.value) + caplog.text, (
+        'the offending pubkey must be reported in the error or the logs'
+    )
 
 
 # ---- the two states where a used key is neither active nor pending -----------------------------


### PR DESCRIPTION
## Description

Tests for #978, targeting `feat/tight-kapi-checks`, plus the created-validator half of the front-run check.

Merged the base after `f3457c68` (`FrontRunAttackError`, `!=` → `<`). **Conflicts resolved in favour of the base's naming**: `ForeignWithdrawalCredentialsException` is gone and `_validate_withdrawal_credentials` now raises `FrontRunAttackError`. Two exception types for two halves of one attack was duplication — `_collect_valid_pending_deposits` catches the front run while its deposit is queued, `_validate_withdrawal_credentials` catches it once the validator exists and that filter no longer applies. Same condition, same required response, one type, one handler. `oracle_module.py` taken from the base wholesale: its handler re-raises so the daemon restarts and clears caches, which is better than the swallow-and-stall this branch had, and my separate handler became redundant.

`tests/web3py/test_lido_validators_deposit_reconciliation.py` — 6 tests, **5 pass, 1 fails deliberately**.

Two tests were converted from write-off to refusal: the base now raises on a queued front run, which is the same decision that motivated the created-validator check, so continuing to assert a write-off there would have re-opened a settled question through tests.

### The one open question

`test_report_balances__cl_discarded_the_deposit__lost_deposit_excluded_from_tvl` fails, and it is the only thing in this PR I am not resolving unilaterally.

That state is **not** a captured deposit. Per Electra `apply_pending_deposit`, a deposit for an unknown pubkey creates a validator only if `is_valid_deposit_signature` passes; `process_pending_deposits` pops the entry either way. So an invalid-signature deposit leaves neither a validator nor a queue entry — the ether is beyond *everyone's* reach, there is no counterparty to name and nothing to escalate. `depositedValidators` was incremented on the EL and never decreases, so the state is permanent.

`_validate_total_validators_count` rejects `active + pending < depositedValidators`, which is exactly the shape of that write-off. So today this permanently blocks accounting. Deposit signatures come from node operators and are not validated on-chain — the DSM guardians check them off-chain, which makes this a process guarantee rather than a protocol one.

The test is here to force the decision, not to assert I am right about it. If blocking is the intended answer, delete the test and say so in the code.

### Front runs: refused at both points

### The requirement

Ether Lido paid for but cannot withdraw must never be reported as TVL. Two outcomes are required, depending on whether anyone holds the credentials:

- **write off** when the ether is simply unreachable — the CL discarded the deposit, or a front run is still sitting in the deposit queue — and still produce the report;
- **refuse to report** when a counterparty holds the withdrawal credentials, i.e. a used key whose CL validator has non-Lido credentials.

The oracle is what carries that write-off. `clValidatorsBalance` and `clPendingBalance` are the only CL-side TVL inputs the contract takes (`ReportSimulationPayload`); `depositedValidators` is not one of them, since deposits are tracked on-chain by nonce (`BalanceStats.deposited_since_last_report` / `deposited_for_current_report`). After this PR `get_beacon_stat` is read only by the sanity checks in `lido_validators.py` and by nothing in the report path. So a lost key falling out of both the active and the pending set **is** the mechanism by which the loss reaches TVL — and `_collect_valid_pending_deposits` already does exactly that for the front-run case.

`_validate_total_validators_count` requires `active + pending == depositedValidators`, which equates *ether still owned on the CL* with *ether ever sent to the deposit contract*. The right-hand side is monotonic and includes losses, so the equality forbids the write-off.

### The two loss scenarios

**A node operator front-runs its own key.** The operator signs a deposit for its own pubkey with its own withdrawal credentials and lands it ahead of Lido's. Only the holder of the secret key can produce that proof of possession, which is why the existing `'Ignoring key. Possible front run attack'` branch is about a malicious *key owner*, not an outsider. The ether is no longer withdrawable by the protocol, so crediting it would overstate TVL.

**The CL discarded the deposit.** Per Electra `apply_pending_deposit`, a deposit for an unknown pubkey creates a validator only if `is_valid_deposit_signature` passes; `process_pending_deposits` pops the entry either way. An invalid-signature deposit leaves neither a validator nor a queue entry, while `depositedValidators` never decreases — so the state, and the write-off, are permanent. Deposit signatures come from node operators and are not validated on-chain; the DSM guardians check them off-chain, which makes this a process guarantee rather than a protocol one.

#### The created-validator half (this PR)

`_collect_valid_pending_deposits` drops a front-run pubkey, but that governs only *new* validators — its `filter_pubkeys` is the set of Lido keys not yet on the CL. Once the CL creates the validator the pubkey leaves that set, and nothing downstream reinstates the exclusion.

**One gap, not two.** `compute_lido_validators` decides which CL validators are Lido's **by pubkey alone**, with no check that their withdrawal credentials are Lido's — `get_lido_wc_list` is consulted for pending deposits and in `abnormal_cl_rebase`, never for active validators. Both TVL terms are then computed *correctly* over the wrong set:

- the validator's own balance lands in `clValidatorsBalance`;
- Lido's still-queued deposit for that pubkey is reclassified from a new-validator deposit into a `pending_topup` and lands in `clPendingBalance`.

To be explicit, since it looks like double counting and is not: summing `validator.balance` and a queued `pending_topup` is correct — a top-up is ether that has left the deposit contract but is not yet reflected in `validator.balance`. The two contributions to `clPendingBalance` are disjoint by construction: `new_validators_pending` comes from keys not on the CL, `topups_pending` from keys that are. Excluding the validator from the Lido set fixes both terms at once.

Measured on this branch, with the front-run validator created and Lido's deposit still queued:

```
active validators = 2
  idx=0  wc=Lido       bal=32.100 ETH  topups=[]
  idx=1  wc=OPERATOR   bal=32.100 ETH  topups=[32.000 ETH]   <- front run

_get_cl_validators_balance = 64.200 ETH
_get_cl_pending_balance    = 64.000 ETH
```

64.1 ETH attributed to a key only the operator can withdraw from.

#### Implemented in this PR

`_validate_withdrawal_credentials` + `ForeignWithdrawalCredentialsException` in `src/web3py/extensions/lido_validators.py`, called from `_get_lido_validators_with_keys` so **every** consumer is covered (accounting, ejector, bunker, CSM/CM), not just accounting. It **refuses** rather than filters: silently dropping the balance would disguise a captured deposit as an ordinary loss.

- **one error line per affected key**, carrying its pubkey, its actual credentials and the expected ones — no truncation, since credentials are immutable and every key needs handling individually. A summary line with the count comes first, so a flood of per-key lines is self-explanatory (a misconfigured locator would put every Lido validator in there). The exception message carries the count and points at the log;
- `OracleModule.exception_handler` reports that reporting is blocked and cannot clear on its own;
- accepted credentials are both the `0x01` and `0x02` forms of the withdrawal vault (`get_lido_wc_list`), covered by a parametrized test.

Why `get_lido_wc_list` is the right set for KAPI keys: staking-vault validators are matched from the **full CL validator set** (`accounting.py:478` passes `cc.get_validators`) against vault credentials, not from KAPI keys, so they do not pass through this check. `StakingModule.withdrawal_credentials_type` exists in the dataclass but is read nowhere in the codebase — worth confirming against the StakingRouter before this ships, since a module using credentials other than the withdrawal vault's would trip the check.

**Before this runs on mainnet:** `0x01` credentials are immutable, so unlike a front run still sitting in the deposit queue, this state never resolves on its own. Without a way for operators to acknowledge a known pubkey, a single captured key stops accounting for good. I'd pair the check with an explicit acknowledgement list; I did not add one, since that is a policy call.

**Caveat for whoever implements it:** `0x01` withdrawal credentials are immutable, so unlike a front run still sitting in the deposit queue, this state never resolves on its own. Without a way for operators to acknowledge a known pubkey, the refusal is permanent and accounting stops reporting for good. Worth pairing the check with an explicit acknowledgement list.

Exposure requires the DSM guardians to have failed. But `_collect_valid_pending_deposits`' front-run branch exists precisely because the team does not want to rely on DSM alone, and that branch covers only half the path.

### These tests fail on this branch, on purpose

The one remaining failure is not marked `xfail`: a green suite would report no problem at all, which is the opposite of what the test exists for.

```
CountOfKeysDiffersException: Active (1) + pending (1) validators count (2)
does not match deposited validators count (3) from Staking Router
```

An earlier revision of this branch marked them `xfail(strict=True)`, which made the suite green — and a green suite reports no problem, which is the opposite of what these tests exist for. A revision before that asserted `pytest.raises(CountOfKeysDiffersException)` — that encoded the defect as the expectation, passed only while the check was wrong, and would have had to be rewritten by whoever fixed it.

Verified in the other direction: with `_validate_total_validators_count` no longer rejecting `<`, the write-off test goes green with no change to the test.

### Baselines

- healthy state — every used key is active or pending;
- an outsider's unverifiable deposit for a known Lido pubkey — handled correctly, the pubkey is not blacklisted and Lido's own deposit behind it still counts as pending;

Only the provider's collaborators (CL, EL contracts, Keys API) are mocked; `LidoValidatorsProvider` runs for real throughout, including BLS verification against real keys — both scenarios turn on whether a signature actually verifies, so mocking the verifier would make the tests vacuous.

## How Has This Been Tested?

- [X] Local tests (`pytest`)
- [X] Manual testing — read-only mainnet report rebuild, see below
- [ ] Not tested

### Mainnet dry run

Rebuilt the accounting report read-only at ref slot **14853599** (mainnet, EL block 25616825) on this branch via `scripts/gather_ao_report.py gather`. The new check **does not fire**, and that is not an inference from the absence of an error — instrumenting the check to dump what it saw gives:

```
validators        461222
allowed_wc        ['0x010000000000000000000000b9d7934878b5fb9610b3fe8a5e441e8fad7e293f',
                   '0x020000000000000000000000b9d7934878b5fb9610b3fe8a5e441e8fad7e293f']
distinct_wc_seen  1
distribution      [('0x0100...b9d7934878b5fb9610b3fe8a5e441e8fad7e293f', 461222)]
foreign           0
```

All 461,222 matched Lido validators carry exactly one credential, and it is in the allowed set — so `get_lido_wc_list` is the right set for KAPI keys in practice, and there are no false positives to fear today. The instrumentation was reverted and is not part of the branch.

The same run also shows `_validate_total_validators_count` passing on this frame: active 461,222 + pending 23,253 = 484,475 used keys. That is expected — the states this PR's tests describe are rare, not routine — but worth recording that the check is not firing spuriously.

Report figures for the record: `clValidatorsBalanceGwei` 8,588,344.422 ETH over 461,222 validators; `clPendingBalanceGwei` 744,096.000 ETH over 23,253 keys; 0 rejected Lido-key pending deposits (`foreign_wc`, `invalid_signature`, `counted_as_topup` all zero).

Current state: **1 failed, 1509 passed** — intentionally red, see above. `ruff format`, `ruff check` and `pyright src` clean.

Two tests in `test_lido_validators.py` now feed `get_lido_wc_list` from the credentials of the validators they build, instead of relying on a factory default, so the new check runs for real in them rather than being mocked out.

With `_validate_total_validators_count` demoted to a warning, all remaining failures go green unchanged.

The commit dropping the markers used `--no-verify`: the repo's pre-commit hook runs the unit suite, and here the failure is the deliverable.

Not done: `tests/fork/test_lido_oracle_cycle.py` was not run against an anvil fork — it needs an archive RPC, and neither an invalid signature nor a front run can be injected into a fork without a devnet deposit. The offline path covers the same code chain.

Unrelated: under random ordering, 7 pre-existing tests in `tests/modules/accounting/staking_vault/test_fee_calculation.py` fail (leaking `decimal` context). Reproduces without this file.

## Checklist

- [ ] Documentation updated (if required)
- [X] New tests added (if applicable)







