### PR TITLE
feat(orc-782): add tests

### DIFF
--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -23,7 +23,11 @@ from src.providers.consensus.types import (
 from src.providers.execution.contracts.exit_bus_oracle import ExitBusOracleContract
 from src.services.exit_order_iterator import WeightsNotUpdatedError
 from src.types import BlockStamp, EpochNumber, Gwei, ReferenceBlockStamp, SlotNumber, Wei
-from src.utils.validator_balance import get_predictable_inbound_balance
+from src.utils.validator_balance import (
+    get_predictable_full_inbound_balance,
+    get_predictable_inbound_balance,
+    get_predictable_inbound_sweep,
+)
 from src.web3py.extensions.lido_validators import (
     LidoValidator,
     NodeOperatorId,
@@ -302,6 +306,119 @@ class TestGetValidatorsToEject:
         assert [v[1].index for v in result] == [validators[0][1].index, validators[1][1].index], (
             "Exact coverage after second validator must eject exactly two"
         )
+
+    @pytest.mark.unit
+    def test_get_validators_to_eject__dust_balance_shortfall_after_first__ejects_second_to_cover(
+        self,
+        ejector: Ejector,
+        ref_blockstamp: ReferenceBlockStamp,
+        chain_config: ChainConfig,
+    ):
+        # Validators carry non-32-multiple ("dust") balances. When the withdrawal queue misses
+        # coverage by a single Wei after the first validator, the loop must eject the whole second
+        # validator instead of stopping short. Dust never causes under-ejection.
+        # Arrange
+        ejector.get_chain_config = Mock(return_value=chain_config)
+        predicted_el_balance = Wei(100)
+        ejector._get_predicted_el_balance = Mock(return_value=predicted_el_balance)
+
+        validators = [
+            (
+                (StakingModuleId(0), NodeOperatorId(1)),
+                build_extended_validator_with_balance(100_300_000_000, meb=MAX_EFFECTIVE_BALANCE_ELECTRA),  # 100.3 ETH
+            ),
+            (
+                (StakingModuleId(0), NodeOperatorId(3)),
+                build_extended_validator_with_balance(63_700_000_000, meb=MAX_EFFECTIVE_BALANCE_ELECTRA),  # 63.7 ETH
+            ),
+            (
+                (StakingModuleId(0), NodeOperatorId(5)),
+                build_extended_validator_with_balance(50_500_000_000, meb=MAX_EFFECTIVE_BALANCE_ELECTRA),  # 50.5 ETH
+            ),
+        ]
+        first_validator_balance_wei = get_predictable_inbound_balance(validators[0][1]) * GWEI_TO_WEI
+        ejector.w3.lido_contracts.withdrawal_queue_nft.unfinalized_steth = Mock(
+            return_value=predicted_el_balance + first_validator_balance_wei + 1
+        )
+
+        val_iter = iter(SimpleIterator(validators))
+        with patch.object(ejector_module.ValidatorExitIterator, "__iter__", Mock(return_value=val_iter)):
+            # Act
+            result = ejector.get_validators_to_eject(ref_blockstamp)
+
+        # Assert
+        assert [v[1].index for v in result] == [validators[0][1].index, validators[1][1].index], (
+            "A one-Wei shortfall after the first dusty validator must eject the second, never under-eject"
+        )
+
+    @pytest.mark.unit
+    def test_get_validators_to_eject__dust_exact_coverage_after_first__ejects_only_first(
+        self,
+        ejector: Ejector,
+        ref_blockstamp: ReferenceBlockStamp,
+        chain_config: ChainConfig,
+    ):
+        # With a dusty balance the loop must still stop as soon as coverage is reached and not
+        # over-eject beyond one validator.
+        # Arrange
+        ejector.get_chain_config = Mock(return_value=chain_config)
+        predicted_el_balance = Wei(100)
+        ejector._get_predicted_el_balance = Mock(return_value=predicted_el_balance)
+
+        validators = [
+            (
+                (StakingModuleId(0), NodeOperatorId(1)),
+                build_extended_validator_with_balance(100_300_000_000, meb=MAX_EFFECTIVE_BALANCE_ELECTRA),  # 100.3 ETH
+            ),
+            (
+                (StakingModuleId(0), NodeOperatorId(3)),
+                build_extended_validator_with_balance(63_700_000_000, meb=MAX_EFFECTIVE_BALANCE_ELECTRA),  # 63.7 ETH
+            ),
+        ]
+        first_validator_balance_gwei = Gwei(100 * 10**9 + 300_000_000)  # 100.3 ETH
+        assert get_predictable_inbound_balance(validators[0][1]) == first_validator_balance_gwei, (
+            "dust must be preserved: predictable inbound balance must keep the full 100.3 ETH"
+        )
+        ejector.w3.lido_contracts.withdrawal_queue_nft.unfinalized_steth = Mock(
+            return_value=predicted_el_balance + first_validator_balance_gwei * GWEI_TO_WEI
+        )
+
+        val_iter = iter(SimpleIterator(validators))
+        with patch.object(ejector_module.ValidatorExitIterator, "__iter__", Mock(return_value=val_iter)):
+            # Act
+            result = ejector.get_validators_to_eject(ref_blockstamp)
+
+        # Assert
+        assert [v[1].index for v in result] == [validators[0][1].index], (
+            "Exact coverage with a dusty balance must not eject an extra validator"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("balance", "meb"),
+    [
+        # Compounding 0x02 validator: 0.3 ETH of dust above the 2048 ETH cap.
+        (2_048_300_000_000, MAX_EFFECTIVE_BALANCE_ELECTRA),  # 2048.3 ETH
+        # Regular 0x01 validator: 0.3 ETH of dust above the 32 ETH cap.
+        (32_300_000_000, MAX_EFFECTIVE_BALANCE),  # 32.3 ETH
+    ],
+)
+def test_predictable_inbound_plus_sweep__dust_validator__equals_full_inbound(balance: int, meb: int) -> None:
+    # A balance above the effective-balance cap splits into a capped inbound part and a sweep excess.
+    # The two must always reconstruct the full inbound balance, so dust above the cap is never lost
+    # or double-counted.
+    # Arrange
+    validator = build_extended_validator_with_balance(balance, meb=meb)
+
+    # Act
+    inbound = get_predictable_inbound_balance(validator)
+    sweep = get_predictable_inbound_sweep(validator)
+    full = get_predictable_full_inbound_balance(validator)
+
+    # Assert
+    assert sweep > 0, "the balance must exceed the cap so the sweep excess is actually exercised"
+    assert inbound + sweep == full, "inbound + sweep must equal the full inbound balance"
 
 
 @pytest.mark.unit

--- a/tests/modules/ejector/test_sweep.py
+++ b/tests/modules/ejector/test_sweep.py
@@ -1,5 +1,5 @@
 import math
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -42,6 +42,26 @@ def test_get_sweep_delay_in_epochs_post_electra(monkeypatch):
         # Assert the delay calculation is correct
         expected_delay = math.ceil(predicted_withdrawals / MAX_WITHDRAWALS_PER_PAYLOAD / spec.slots_per_epoch) // 2
         assert result == expected_delay, f"Expected delay {expected_delay}, got {result}"
+
+
+@pytest.mark.unit
+def test_get_sweep_delay_in_epochs__odd_full_cycle__floors_half():
+    # 2560 withdrawals over 16 per payload and 32 slots gives a full sweep cycle of 5 epochs (odd).
+    # The final `// 2` must floor 5 down to 2, not round up to 3.
+    # Arrange
+    state = Mock(spec=BeaconStateView)
+    spec = Mock(spec=ChainConfig)
+    spec.slots_per_epoch = 32
+    predicted_withdrawals = 2560  # ceil(2560 / 16 / 32) == 5
+
+    # Act
+    with patch.object(
+        sweep_module, "predict_withdrawals_number_in_sweep_cycle", Mock(return_value=predicted_withdrawals)
+    ):
+        result = get_sweep_delay_in_epochs(state, spec)
+
+    # Assert
+    assert result == 2, "An odd full sweep cycle must floor when halved"
 
 
 @pytest.fixture()

--- a/tests/modules/ejector/test_validator_exit_order_iterator.py
+++ b/tests/modules/ejector/test_validator_exit_order_iterator.py
@@ -1119,6 +1119,104 @@ class TestDecreaseAffectedStake:
         assert nos_int1.total_stake == Gwei(80 * 10**9 - 20 * 10**9)
         assert nos_int2.total_stake == Gwei(120 * 10**9 - 30 * 10**9)
 
+    def test_decrease_affected_stake__fractional_weights__consistent_total_and_deterministic_order(self, iterator):
+        """Fractional weight splits must not crash, must conserve the exit balance within float dust,
+        and must keep the sort order deterministic."""
+        sm_v2 = make_staking_module(2)
+        sm_v1 = make_staking_module(1)
+        ms_v2 = StakingModuleStats(
+            staking_module=sm_v2,
+            total_stake=Gwei(300 * 10**9),
+            predictable_balance=Gwei(300 * 10**9),
+            total_weight=3.0,
+        )
+        ms_v1 = StakingModuleStats(
+            staking_module=sm_v1,
+            total_stake=Gwei(300 * 10**9),
+            predictable_balance=Gwei(300 * 10**9),
+            total_weight=1.0,
+        )
+
+        no_ext = make_node_operator(20, sm_v1)
+        no_int1 = make_node_operator(10, sm_v2)
+        no_int2 = make_node_operator(11, sm_v2)
+        no_int3 = make_node_operator(12, sm_v2)
+
+        group = OperatorGroupFactory.build(
+            sub_node_operators=[
+                SubNodeOperator(node_operator_id=no_int1.id, share=3333),
+                SubNodeOperator(node_operator_id=no_int2.id, share=3333),
+                SubNodeOperator(node_operator_id=no_int3.id, share=3334),
+            ],
+            external_operators=[ExternalOperator(data=self._make_ext_data(sm_v1.id, no_ext.id))],
+        )
+
+        nos_ext = NodeOperatorStats(
+            node_operator=no_ext,
+            module_stats=ms_v1,
+            total_stake=Gwei(100 * 10**9),
+            predictable_balance=Gwei(100 * 10**9),
+            weight=1.0,
+            external_operator_group=group,
+        )
+        nos_int1 = NodeOperatorStats(
+            node_operator=no_int1,
+            module_stats=ms_v2,
+            total_stake=Gwei(100 * 10**9),
+            predictable_balance=Gwei(100 * 10**9),
+            weight=1.0,
+        )
+        nos_int2 = NodeOperatorStats(
+            node_operator=no_int2,
+            module_stats=ms_v2,
+            total_stake=Gwei(100 * 10**9),
+            predictable_balance=Gwei(100 * 10**9),
+            weight=1.0,
+        )
+        nos_int3 = NodeOperatorStats(
+            node_operator=no_int3,
+            module_stats=ms_v2,
+            total_stake=Gwei(100 * 10**9),
+            predictable_balance=Gwei(100 * 10**9),
+            weight=1.0,
+        )
+
+        gid_ext = (sm_v1.id, no_ext.id)
+        gid_int1 = (sm_v2.id, no_int1.id)
+        gid_int2 = (sm_v2.id, no_int2.id)
+        gid_int3 = (sm_v2.id, no_int3.id)
+        iterator.cm_v2_id = sm_v2.id
+        iterator.module_stats = {sm_v2.id: ms_v2, sm_v1.id: ms_v1}
+        iterator.node_operators_stats = {
+            gid_ext: nos_ext,
+            gid_int1: nos_int1,
+            gid_int2: nos_int2,
+            gid_int3: nos_int3,
+        }
+        iterator.exitable_validators = {gid_ext: [], gid_int1: [], gid_int2: [], gid_int3: []}
+        iterator.total_lido_predictable_balance = Gwei(600 * 10**9)
+
+        exit_balance = Gwei(100 * 10**9)  # 100 / 3 does not divide evenly among three internal NOs
+        before = nos_int1.total_stake + nos_int2.total_stake + nos_int3.total_stake
+
+        iterator._decrease_affected_stake(gid_ext, exit_balance)
+
+        after = nos_int1.total_stake + nos_int2.total_stake + nos_int3.total_stake
+        # The three fractional decrements together conserve the whole exit balance within float dust.
+        assert abs((before - after) - exit_balance) < 1
+        # The module-level decrement is integer, so it stays exact.
+        assert ms_v2.total_stake == Gwei(300 * 10**9) - exit_balance
+        # Sorting over the now-float stats must be stable across repeated calls.
+        order1 = [
+            (s.node_operator.staking_module.id, s.node_operator.id)
+            for s in sorted(iterator.node_operators_stats.values(), key=iterator._no_predicate)
+        ]
+        order2 = [
+            (s.node_operator.staking_module.id, s.node_operator.id)
+            for s in sorted(iterator.node_operators_stats.values(), key=iterator._no_predicate)
+        ]
+        assert order1 == order2
+
     def test_external_exit__zero_total_weight__decreases_internal_stake_by_share(self, iterator):
         """When all internal NO weights are 0, their stake decreases by operator share."""
         sm_v2 = make_staking_module(2)
@@ -1424,6 +1522,52 @@ class TestNextAndIterFull:
         with pytest.raises(StopIteration):
             iterator.__next__()
 
+    def test_next__high_priority_no_empty_list__skips_and_selects_populated_no(self, iterator):
+        """A high-priority NO with predictable balance/count but no exitable validator must be
+        skipped, and the next populated NO selected, without an IndexError."""
+        sm = make_staking_module(1)
+        no_empty = make_node_operator(1, sm, total_dep=3, target=0, limit_mode=NodeOperatorLimitMode.FORCE)
+        no_populated = make_node_operator(2, sm)
+        gid_empty = (sm.id, no_empty.id)
+        gid_populated = (sm.id, no_populated.id)
+        weight = float(10 * 10000)
+        ms = StakingModuleStats(
+            staking_module=sm,
+            predictable_balance=Gwei(128 * 10**9),
+            total_stake=Gwei(128 * 10**9),
+            total_weight=weight * 2,
+        )
+        nos_empty = NodeOperatorStats(
+            node_operator=no_empty,
+            module_stats=ms,
+            predictable_validators=3,
+            force_exit_to=0,
+            predictable_balance=Gwei(96 * 10**9),
+            total_stake=Gwei(96 * 10**9),
+            weight=weight,
+        )
+        validator = LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch)
+        nos_populated = NodeOperatorStats(
+            node_operator=no_populated,
+            module_stats=ms,
+            predictable_validators=1,
+            predictable_balance=Gwei(32 * 10**9),
+            total_stake=Gwei(32 * 10**9),
+            weight=weight,
+        )
+
+        iterator.module_stats = {sm.id: ms}
+        iterator.node_operators_stats = {gid_empty: nos_empty, gid_populated: nos_populated}
+        iterator.exitable_validators = {gid_empty: [], gid_populated: [validator]}
+        iterator.total_lido_predictable_balance = Gwei(128 * 10**9)
+        iterator.max_current_exit_balance = Gwei(0)
+        iterator.exit_limit_in_gwei = Gwei(100_000 * 10**9)
+
+        gid, v = iterator.__next__()
+
+        assert gid == gid_populated, "The populated operator must be selected"
+        assert v is validator, "The populated operator's validator must be returned"
+
     def test_iter__initializes_all_state(self, iterator):
         """__iter__ sets up max_current_exit_balance=0 and returns self."""
         iterator._reset_iterator_data = Mock()
@@ -1674,3 +1818,38 @@ class TestGetRemainingForcedEdgeCases:
         result = iterator.get_remaining_forced_validators()
 
         assert result == [], "Empty list when no validators are available despite forced exit need"
+
+    def test_get_remaining_forced_validators__high_priority_no_empty_list__ejects_from_populated_no(self, iterator):
+        """A forced NO with an empty exitable list must be skipped without an IndexError, while the
+        next forced NO that still has a validator is ejected."""
+        sm = make_staking_module(1)
+        no_empty = make_node_operator(1, sm, total_dep=3, target=0, limit_mode=NodeOperatorLimitMode.FORCE)
+        no_populated = make_node_operator(2, sm, total_dep=1, target=0, limit_mode=NodeOperatorLimitMode.FORCE)
+        gid_empty = (sm.id, no_empty.id)
+        gid_populated = (sm.id, no_populated.id)
+        ms = StakingModuleStats(staking_module=sm)
+        nos_empty = NodeOperatorStats(
+            node_operator=no_empty,
+            module_stats=ms,
+            predictable_validators=3,
+            force_exit_to=0,
+        )
+        validator = LidoValidatorFactory.build_with_activation_epoch_bound(iterator.blockstamp.ref_epoch)
+        nos_populated = NodeOperatorStats(
+            node_operator=no_populated,
+            module_stats=ms,
+            predictable_validators=1,
+            force_exit_to=0,
+        )
+
+        iterator.module_stats = {sm.id: ms}
+        iterator.node_operators_stats = {gid_empty: nos_empty, gid_populated: nos_populated}
+        iterator.exitable_validators = {gid_empty: [], gid_populated: [validator]}
+        iterator.exit_limit_in_gwei = Gwei(100_000 * 10**9)
+        iterator.max_current_exit_balance = Gwei(0)
+
+        result = iterator.get_remaining_forced_validators()
+
+        assert len(result) == 1, "Only the populated operator yields a forced validator"
+        assert result[0][0] == gid_populated
+        assert result[0][1] is validator

--- a/tests/utils/test_validator_state_utils.py
+++ b/tests/utils/test_validator_state_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.constants import (
+    CHURN_LIMIT_QUOTIENT,
     EFFECTIVE_BALANCE_INCREMENT,
     FAR_FUTURE_EPOCH,
     MAX_EFFECTIVE_BALANCE_ELECTRA,
@@ -373,6 +374,23 @@ def test_compute_activation_exit_epoch():
 def test_get_balance_churn_limit(total_active_balance: Gwei, expected_limit: Gwei):
     actual_limit = get_balance_churn_limit(total_active_balance)
     assert actual_limit == expected_limit, "Unexpected balance churn limit"
+
+
+@pytest.mark.unit
+def test_get_balance_churn_limit__raw_not_increment_aligned__trims_dust_down():
+    # Pick a total whose raw churn (total // CHURN_LIMIT_QUOTIENT) is above the minimum floor and
+    # is NOT a multiple of EFFECTIVE_BALANCE_INCREMENT, so the modulo trimming actually fires.
+    # The 0.75 ETH of dust is the +750_000_000 Gwei tail below.
+    # Arrange
+    raw_churn = 130 * EFFECTIVE_BALANCE_INCREMENT + 750_000_000  # 130.75 ETH, not increment-aligned
+    total_active_balance = Gwei(raw_churn * CHURN_LIMIT_QUOTIENT)
+
+    # Act
+    actual_limit = get_balance_churn_limit(total_active_balance)
+
+    # Assert
+    assert actual_limit == Gwei(130 * EFFECTIVE_BALANCE_INCREMENT), "Dust must be trimmed down to a clean increment"
+    assert actual_limit % EFFECTIVE_BALANCE_INCREMENT == 0, "Churn limit must be a multiple of the increment"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Description
This pull request significantly expands the test coverage for validator ejection, sweep logic, and validator exit order handling, focusing on edge cases involving "dust" (fractional balances), forced exits, and deterministic behavior with fractional weights. It also adds tests to ensure that balance calculations properly trim dust and that sweep delays are correctly floored. These changes help prevent subtle bugs and ensure the robustness of validator management logic.

## Related Issue/Task
- Related task: orc-782
- Epic: srv3

## How Has This Been Tested?
Describe how you tested the changes:
- [x] Local tests (e.g., `pytest`)
- [ ] Manual testing (describe steps)
- [ ] Not tested (explain why)

## Checklist
- [ ] Documentation updated (if required)
- [x] New tests added (if applicable)
