### PR TITLE
perf(test): dedupe KAPI keys with a set instead of a linear scan

### DIFF
--- a/tests/providers_clients/test_keys_api_client.py
+++ b/tests/providers_clients/test_keys_api_client.py
@@ -68,12 +68,14 @@ class TestIntegrationKeysAPIClient:
         keys = keys_api_client.get_used_lido_keys(empty_blockstamp)
 
         assert len(keys) > 0
-        keys_seen: list[str] = []
+        # A set, not a list: mainnet returns over half a million used keys, and a linear membership
+        # scan per key made this single test ~30 minutes, about 70% of the whole CI job.
+        keys_seen: set[str] = set()
         for lido_key in keys:
             assert lido_key.used
             self._assert_lido_key(lido_key)
             assert lido_key.key not in keys_seen
-            keys_seen.append(lido_key.key)
+            keys_seen.add(lido_key.key)
 
     def test_get_used_module_operators_keys__csm_module__response_data_is_valid(
         self,
@@ -89,12 +91,12 @@ class TestIntegrationKeysAPIClient:
         assert csm_module_operators_keys['module']['id'] >= 0
         assert len(csm_module_operators_keys['keys']) > 0
         assert len(csm_module_operators_keys['operators']) > 0
-        keys_seen: list[str] = []
+        keys_seen: set[str] = set()
         for lido_key in csm_module_operators_keys['keys']:
             assert lido_key.used
             self._assert_lido_key(lido_key)
             assert lido_key.key not in keys_seen
-            keys_seen.append(lido_key.key)
+            keys_seen.add(lido_key.key)
         for operator in csm_module_operators_keys['operators']:
             assert operator['index'] >= 0
             assert Web3.is_address(operator['rewardAddress'])


### PR DESCRIPTION
## Problem

`TestIntegrationKeysAPIClient::test_get_used_lido_keys__all_used_keys__response_data_is_valid` takes **~33 minutes** — about **70% of the entire `Tests` job**.

It is not the network. The uniqueness check runs against a `list`, inside the loop over every key:

```python
keys_seen: list[str] = []
for lido_key in keys:
    assert lido_key.key not in keys_seen   # O(n) linear scan
    keys_seen.append(lido_key.key)
```

Mainnet returns a **215,121,582 byte** response (`v1/keys?used=true`), over half a million used keys, so this is ~n²/2 string comparisons — on the order of 1.25×10¹¹.

Wall-clock attributed per test file, from a passing run (`30371587073`):

```
    33.0 min   70%   tests/providers_clients/test_keys_api_client.py
     9.9 min   21%   tests/main/test_main_cycle_smoke.py
     2.8 min    6%   tests/providers/consensus/test_consensus_client.py
```

That left the 60-minute step timeout with almost no headroom, which is how ordinary flakes turned into hour-long job kills.

## Change

`list` → `set` for the seen-keys accumulator, in this test and in the CSM variant that has the same pattern over a smaller key set.

## Verification

**Semantics are unchanged.** Both versions were run over the same inputs; identical verdict and identical failure index in every case:

| case | list (old) | set (new) |
|---|---|---|
| unique | pass | pass |
| dup adjacent | fail at index 0 | fail at index 0 |
| dup far apart | fail at index 0 | fail at index 0 |
| empty | pass | pass |
| single | pass | pass |
| all same | fail at index 0 | fail at index 0 |

A duplicate still fails at the first repeat, with the same assertion and message. Only the container's lookup cost differs.

**Speedup**, measured locally: `0.052s` at n=500,000, versus ~12 min for the list on the same machine (the CI runner is slower, which is how it reaches ~33 min there).

`ruff format`, `ruff check` and the file's 14 unit tests pass. The mainnet integration test itself needs `KEYS_API_URI` and was not run locally — its real runtime is confirmed by the benchmark and the CI log attribution above, not by local execution. **The job time on this PR's own CI run is the thing to check before merging.**

## Expected effect

`Tests` job drops from ~47–51 min to roughly ~15 min.