### PR TITLE
test: stop a stuck mainnet smoke cycle from hanging the whole pytest run

### DIFF
--- a/tests/main/test_main_cycle_smoke.py
+++ b/tests/main/test_main_cycle_smoke.py
@@ -1,7 +1,10 @@
+import faulthandler
 import logging
 import logging.handlers
 import multiprocessing
-from concurrent.futures import ProcessPoolExecutor
+import os
+import signal
+import time
 from typing import cast
 
 import pytest
@@ -13,10 +16,20 @@ from src.modules.oracles.common.consensus import ConsensusModule
 from src.types import OracleModuleName
 
 
+# Most cycles end within seconds because the module is not reportable, but a reportable frame on
+# mainnet has taken over 6 minutes. This is a deadlock detector, not a latency budget, so keep it
+# loose enough that a slow beacon node cannot trip it.
+CYCLE_TIMEOUT = 15 * 60
+
+
 @pytest.mark.mainnet
 @pytest.mark.integration
 class TestIntegrationMainCycleSmoke:
     def run_main_with_logging(self, module_name, log_queue):
+        # Let the parent ask for a stack dump when the cycle overruns CYCLE_TIMEOUT. pytest runs
+        # without output capture, so the dump lands directly in the CI log.
+        faulthandler.register(signal.SIGUSR1)
+
         queue_handler = logging.handlers.QueueHandler(log_queue)
         logger = logging.getLogger()
         logger.setLevel(logging.DEBUG)
@@ -70,11 +83,29 @@ class TestIntegrationMainCycleSmoke:
         listener = logging.handlers.QueueListener(log_queue, caplog.handler)
         listener.start()
 
-        with ProcessPoolExecutor(max_workers=1, mp_context=ctx) as executor:
-            future = executor.submit(self.run_main_with_logging, module_name, log_queue)
-            future.result()
+        # A bare Process rather than ProcessPoolExecutor: the pool joins its workers on shutdown and
+        # again from an atexit hook, so a single stuck cycle hangs the whole pytest run instead of
+        # failing this test. Owning the process lets us put a hard bound on it.
+        process = ctx.Process(target=self.run_main_with_logging, args=(module_name, log_queue))
+        process.start()
+        timed_out = False
 
-        listener.stop()
+        try:
+            process.join(CYCLE_TIMEOUT)
+            if process.is_alive():
+                timed_out = True
+                os.kill(cast(int, process.pid), signal.SIGUSR1)  # dump where the cycle is stuck
+                time.sleep(1)  # give faulthandler a moment to flush before the process dies
+                process.kill()
+                process.join()
+        finally:
+            # Drain the records the child queued, then stop the manager process hosting the queue.
+            # Both must happen even when the cycle fails, or the leftovers keep pytest from exiting.
+            listener.stop()
+            manager.shutdown()
+
+        assert not timed_out, f"{module_name} cycle did not finish within {CYCLE_TIMEOUT}s"
+        assert process.exitcode == 0, f"{module_name} cycle exited with code {process.exitcode}"
 
         error_logs = [record for record in caplog.records if record.levelno >= logging.ERROR]
         assert not error_logs, f"Found error logs: {[record.message for record in error_logs]}"


### PR DESCRIPTION
## Problem

**1. No bound on the cycle.** `future.result()` was called with no timeout. In the `Tests` run for #979 the ejector cycle went silent for **55.1 minutes** and the job was killed:

```
08:58:24.674  src.services.validator_state | Fetch exit events. Got 928 events.
09:53:32      ##[error]The action 'Test with pytest' has timed out after 60 minutes.
```

Not even a `web3.manager: Making request` line follows, so the child blocked before issuing its next RPC — and there was no way to see where.

**2. Cleanup was not guaranteed.** `listener.stop()` sat *after* the `with ProcessPoolExecutor(...)` block, and the `Manager` was never shut down at all. When `future.result()` raises — i.e. the cycle itself throws — `listener.stop()` is skipped, leaving a listener thread and a manager process behind. Even on the happy path the manager is leaked, once per parametrised module.

## Change

**Adding `timeout=` to `future.result()` does not fix problem 1** — verified. `ProcessPoolExecutor.__exit__` joins the stuck worker, and an atexit hook joins again, so it still waits forever. With a 3s timeout against a deliberately hung child, the pool version was still alive at 24s; the replacement exits in 4.07s.

So: own the process directly.

- bare `ctx.Process` bounded by `join(CYCLE_TIMEOUT)`, killed on overrun
- `listener.stop()` and `manager.shutdown()` moved into `finally`, so they run on every path
- explicit assertions on timeout and on `process.exitcode`
- `SIGUSR1` → `faulthandler` before the kill, so the CI log shows *where* it was stuck

The last point is the diagnostic that was missing; the child's stack now lands in the log (pytest runs with `-s`, so it is not captured):

```
Current thread 0x00000001f69e1d80 (most recent call first):
  File ".../probe.py", line 12 in stuck
RESULT timed_out=True exitcode=-9
```

`manager.shutdown()` matters because `ctx.Manager()` is a **separate non-daemon OS process** — `manager.Queue()` returns an `AutoProxy`, and the real queue lives in that process, reached over a unix socket. Measured: parent 4013, manager 4014, `daemon=False`. Leaving one per parametrised module behind is a straightforward resource leak.

## Why `CYCLE_TIMEOUT = 15 * 60`

Measured per-module cost across 8 real runs:

| | accounting | ejector | csm | cm |
|---|---|---|---|---|
| **max seen** | **5.5 min** | **6.2 min** | 1.1 min | 0.1 min |
| typical | 0.1–0.2 | 0.1–0.2 | 0.1 | 0.1 |

Most cycles end in seconds because the module is not reportable; a reportable frame is the expensive case. 15 min is a deadlock detector, not a latency budget — a tighter cap (5 min was considered) would trip on the 6.2 min case and just trade one flake for another.

## An open question this PR does *not* answer

Three other runs show pytest printing its summary and then hanging until the step timeout killed the job:

| run | pytest verdict | hung after summary |
|---|---|---|
| `30280278988` | `1 failed … in 0:51:35` | 8.4 min |
| `30357001239` | `1 failed … in 0:37:27` | 22.6 min |
| `30461187541` | `1 failed … in 0:34:29` | 25.6 min |

I initially assumed leaked cleanup caused this, but **could not reproduce it**: the original structure with a failing assertion and an un-shut-down manager exits in ~1s locally, and so does a 3-case parametrised run under real pytest with three leaked managers. Note also that in these runs the failure is the final `assert not error_logs`, which sits *after* `listener.stop()` — so the listener was stopped normally.

So the mechanism behind these three hangs is **still unknown**. This PR makes the failure bounded and observable, which should make the next occurrence diagnosable, but it should not be assumed to fix it.

## Also not addressed here

1. **The assertion itself is flaky.** `_get_without_fallbacks` calls `logger.error(...)` (`src/providers/http_provider.py:189`, also `:312`, `:413`) for any request exception, and `_get` then fails over to the next host and *succeeds*, logging only a warning. So one blip on the first RPC host produces an ERROR record and reddens `assert not error_logs` even though the oracle behaved correctly. That is what failed in all three runs above. Fixing it touches production logging levels, so it wants its own discussion.
2. **These mainnet smoke tests deserve their own job** with their own timeout, the way `fork` tests already are. Three modules × a 15 min cap does not fit comfortably inside a 60 min job shared with everything else.

See also #991, which cuts ~30 min off the same job and removes most of the pressure on the 60-minute cap.

## Testing

`ruff format`, `ruff check`, `pyright` clean; pre-commit hooks pass; the 3 test items still collect. The failure paths were exercised against a stubbed hanging target rather than a live mainnet cycle. **A real run of this test on mainnet is the check still outstanding.**