### PR TITLE
ci: pass tag input via env before shell

### DIFF
--- a/.github/workflows/ci-prod.yml
+++ b/.github/workflows/ci-prod.yml
@@ -28,14 +28,14 @@ jobs:
 
       - name: Tag name
         id: tag_name
-        run: |
-          if [ '${{ inputs.tag }}' = '' ]; then
-            echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
-          else
-            echo "TAG=$TAG" >> $GITHUB_OUTPUT
-          fi
         env:
           TAG: ${{ inputs.tag }}
+        run: |
+          if [ -z "$TAG" ]; then
+            echo "TAG=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build prod image
         uses: lidofinance/dispatch-workflow@v1

--- a/.github/workflows/create-tag-and-trigger-deploy.yml
+++ b/.github/workflows/create-tag-and-trigger-deploy.yml
@@ -28,20 +28,25 @@ jobs:
           persist-credentials: false
       - name: Get tag value
         id: tag
+        env:
+          MESSAGE: ${{ github.event.head_commit.message }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
-            TAG="${{ inputs.tag }}"
+          if [ "$EVENT_NAME" == "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
           else
             TAG="$(grep -oP '^chore\(release\).*\K(\d+\.\d+\.\d+)' <<< "$MESSAGE")"
           fi
           echo "$TAG"
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-        env:
-          MESSAGE: ${{ github.event.head_commit.message }}
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
       - name: Create and push tag
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git tag ${{ steps.tag.outputs.tag }}
-          git push https://x-access-token:${{ github.token }}@github.com/$GITHUB_REPOSITORY --tags
+          git tag "$TAG"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" --tags
       - name: Create release
         uses: lidofinance/action-gh-release@v1
         with:


### PR DESCRIPTION
## Summary
Release workflows interpolated `inputs.tag` (and the computed tag output) directly into `run:` scripts when resolving and pushing tags. Move those values into `env:` and expand `"$TAG"` / `"$INPUT_TAG"` in the shell instead.

## Test plan
- [ ] `workflow_dispatch` with a tag still creates/pushes that tag
- [ ] `chore(release)` commit path still extracts semver from the message
- [ ] `ci-prod` Tag name step still prefers input tag when set


Made with [Cursor](https://cursor.com)