### PR TITLE
fix: correct the swept-rewards and deposit-reserve terms in the ejector's balance estimate

### DIFF
--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -253,57 +253,18 @@ class Ejector(OracleModule[Web3]):
         future_rewards = time_to_last_withdrawal_in_epoch * rewards_speed_per_epoch
         logger.info({'msg': 'Calculate future rewards.', 'value': future_rewards})
 
-        # The balance validators hold above their effective-balance cap — rewards earned but not yet
-        # swept — is deliberately NOT a term here, neither added nor used as a floor.
-        #
-        # `future_rewards` already covers it exactly. Over a horizon H, the sweep reaches a fraction
-        # H/cycle of the set, and each validator it reaches hands over a whole cycle's worth of
-        # accrual (what it was holding, plus what it accrues while waiting its turn). Those cancel to
-        # rate * H regardless of where each validator sits in the sweep order — so in steady state
-        # rate * H is the exact inflow, not an approximation. Adding the unswept pile on top counts
-        # the same ETH twice, which is what issue #993 was about.
-        #
-        # It is not kept as a lower bound either: a pile of ETH is a stock and this term is a flow,
-        # so `max()` between them compares different units. It also would not have helped where it
-        # looks like it should. A negative rebase only zeroes the rate when losses outrun the rewards
-        # of the whole prediction window; a milder one leaves `rate * H` the larger of the two, so
-        # `max()` would keep picking the stale event-based average and discard the fresh measurement.
-        #
-        # Consequence: when the rate prediction does degenerate — no `ETHDistributed` in the window,
-        # or losses large enough to trip the clamp in `RewardsPredictionService` — the estimated
-        # inflow is 0 instead of the pile's size. The estimate then reads low and the ejector requests
-        # more exits than needed. Those exits are irreversible, unlike the delay in the opposite
-        # direction, so the degenerate cases belong in the rate prediction, not behind a floor here.
+        # The balance above the cap is already inside `future_rewards`: the sweep pays H/cycle of the
+        # set a full cycle of accrual each, i.e. rate * H. Adding it double counts (#993); a floor
+        # would compare a stock to a flow. So a degenerate rate over-ejects — fix that in prediction.
         withdrawable_principal = self._get_withdrawable_principal(withdrawal_epoch, blockstamp)
         logger.info({'msg': 'Calculate withdrawable principal.', 'value': withdrawable_principal})
 
         deposit_lock = self._get_deposit_lock_amount(time_to_last_withdrawal_in_epoch, blockstamp)
         logger.info({'msg': 'Calculate deposit lock.', 'value': deposit_lock})
 
-        # Only half of the deposit reserve is charged against the withdrawal queue.
-        #
-        # Why less than all of it: the reserve is refilled by new stake, and fresh deposits are not a
-        # term in this formula at all. While deposits keep up with `getDepositsReserveTarget()` — the
-        # normal case — the reserve is funded out of that inflow, not out of ETH the queue was
-        # counting on. Subtracting the whole lock while omitting the inflow that pays for it charges
-        # the queue twice for the same ETH and biases the estimate low, which over-ejects.
-        #
-        # Why not none of it: "deposits cover the reserve" is an empirical expectation about demand,
-        # not an invariant, and it fails exactly when it matters — stETH demand collapsing, or the
-        # staking router paused. Then the reserve really does come out of the buffer. Halving keeps a
-        # margin for that case instead of betting the whole term on the assumption holding.
-        #
-        # The 1/2 is a deliberate judgment call, not a derived figure: it splits the difference
-        # between modelling both flows and modelling neither. Deposit-inflow telemetry is what would
-        # justify moving it — toward 0 if inflow reliably covers the reserve, back toward the full
-        # lock if it does not.
-        #
-        # Consequence versus charging the full lock: the estimate reads higher by `deposit_lock // 2`,
-        # so the loop in `get_validators_to_eject` stops earlier and requests fewer exits. That is the
-        # under-ejection direction — withdrawal requests stay unfinalized longer. It is a delay, not a
-        # loss: no funds are at risk, and the next frame (~5h) re-estimates from fresh state and ejects
-        # the shortfall once the buffer actually drains. The error is bounded by half of what the lock
-        # contributes, i.e. it grows with the withdrawal horizon and is capped per accounting frame.
+        # Half: new stake refills the reserve, and that inflow is not a term here, so the full lock
+        # bills the queue twice. Charging none would bet on stETH demand, which fails when it matters.
+        # The 1/2 is a judgment call. Costs at most `lock // 2` of under-ejection, corrected next frame.
         charged_deposit_lock = deposit_lock // 2
         logger.info({'msg': 'Charge half of the deposit lock.', 'value': charged_deposit_lock})
 
@@ -317,10 +278,7 @@ class Ejector(OracleModule[Web3]):
 
     @lru_cache(maxsize=1)
     def _sweepable_validators(self, blockstamp: BlockStamp) -> list[LidoValidator]:
-        """Active Lido validators the sweep will actually pay out.
-
-        A consolidation source is excluded: its balance goes to the target validator, not to the vault.
-        """
+        """Active Lido validators the sweep pays out. A consolidation source pays its target, not the vault."""
         return [
             v
             for v in self.w3.lido_validators.get_active_lido_validators(blockstamp=blockstamp)
@@ -329,12 +287,8 @@ class Ejector(OracleModule[Web3]):
 
     @lru_cache(maxsize=1)
     def _get_withdrawable_principal(self, on_epoch: EpochNumber, blockstamp: BlockStamp) -> Wei:
-        """Principal — the staked 32 (or 2048) ETH — coming back from validators exiting by `on_epoch`.
-
-        Principal is not income, it is Lido's own ETH moving back from the CL, so the rewards rate
-        does not contain it: on exit the same amount leaves `postCLBalance` and enters
-        `withdrawalsWithdrawn`, cancelling out. That is why it is added on top instead of merged in.
-        """
+        """Staked ETH returning from validators exiting by `on_epoch`. Added on top of the rate, not
+        merged in: principal is not income, so it cancels out of the rate."""
         result = Gwei(0)
 
         for v in self._sweepable_validators(blockstamp):

--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -66,7 +66,7 @@ class Ejector(OracleModule[Web3]):
             - Rewards expected to reach the EL until the last validator is withdrawn
             - Staked ETH coming back from validators that finish exiting in the meantime
             - Current balance on EL
-            - Minus the ETH reserved for new deposits over the same period
+            - Minus half the ETH reserved for new deposits over the same period
         4. If the sum is already enough to cover WR, exit the loop.
         5. Get the next validator to eject.
 
@@ -271,12 +271,39 @@ class Ejector(OracleModule[Web3]):
         deposit_lock = self._get_deposit_lock_amount(time_to_last_withdrawal_in_epoch, blockstamp)
         logger.info({'msg': 'Calculate deposit lock.', 'value': deposit_lock})
 
+        # Only half of the deposit reserve is charged against the withdrawal queue.
+        #
+        # Why less than all of it: the reserve is refilled by new stake, and fresh deposits are not a
+        # term in this formula at all. While deposits keep up with `getDepositsReserveTarget()` — the
+        # normal case — the reserve is funded out of that inflow, not out of ETH the queue was
+        # counting on. Subtracting the whole lock while omitting the inflow that pays for it charges
+        # the queue twice for the same ETH and biases the estimate low, which over-ejects.
+        #
+        # Why not none of it: "deposits cover the reserve" is an empirical expectation about demand,
+        # not an invariant, and it fails exactly when it matters — stETH demand collapsing, or the
+        # staking router paused. Then the reserve really does come out of the buffer. Halving keeps a
+        # margin for that case instead of betting the whole term on the assumption holding.
+        #
+        # The 1/2 is a deliberate judgment call, not a derived figure: it splits the difference
+        # between modelling both flows and modelling neither. Deposit-inflow telemetry is what would
+        # justify moving it — toward 0 if inflow reliably covers the reserve, back toward the full
+        # lock if it does not.
+        #
+        # Consequence versus charging the full lock: the estimate reads higher by `deposit_lock // 2`,
+        # so the loop in `get_validators_to_eject` stops earlier and requests fewer exits. That is the
+        # under-ejection direction — withdrawal requests stay unfinalized longer. It is a delay, not a
+        # loss: no funds are at risk, and the next frame (~5h) re-estimates from fresh state and ejects
+        # the shortfall once the buffer actually drains. The error is bounded by half of what the lock
+        # contributes, i.e. it grows with the withdrawal horizon and is capped per accounting frame.
+        charged_deposit_lock = deposit_lock // 2
+        logger.info({'msg': 'Charge half of the deposit lock.', 'value': charged_deposit_lock})
+
         return Wei(
             future_inflow
             + withdrawable_principal
             + total_available_balance
             + gwei_to_wei(going_to_withdraw_balance_gwei)
-            - deposit_lock,
+            - charged_deposit_lock,
         )
 
     @lru_cache(maxsize=1)

--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -253,32 +253,22 @@ class Ejector(OracleModule[Web3]):
         future_rewards = time_to_last_withdrawal_in_epoch * rewards_speed_per_epoch
         logger.info({'msg': 'Calculate future rewards.', 'value': future_rewards})
 
-        # The balance above the cap is already inside `future_rewards`: the sweep pays H/cycle of the
-        # set a full cycle of accrual each, i.e. rate * H. Adding it double counts (#993); a floor
-        # would compare a stock to a flow. So a degenerate rate over-ejects — fix that in prediction.
         withdrawable_principal = self._get_withdrawable_principal(withdrawal_epoch, blockstamp)
         logger.info({'msg': 'Calculate withdrawable principal.', 'value': withdrawable_principal})
 
         deposit_lock = self._get_deposit_lock_amount(time_to_last_withdrawal_in_epoch, blockstamp)
         logger.info({'msg': 'Calculate deposit lock.', 'value': deposit_lock})
 
-        # Half: new stake refills the reserve, and that inflow is not a term here, so the full lock
-        # bills the queue twice. Charging none would bet on stETH demand, which fails when it matters.
-        # The 1/2 is a judgment call. Costs at most `lock // 2` of under-ejection, corrected next frame.
-        charged_deposit_lock = deposit_lock // 2
-        logger.info({'msg': 'Charge half of the deposit lock.', 'value': charged_deposit_lock})
-
         return Wei(
             future_rewards
             + withdrawable_principal
             + total_available_balance
             + gwei_to_wei(going_to_withdraw_balance_gwei)
-            - charged_deposit_lock,
+            - deposit_lock,
         )
 
     @lru_cache(maxsize=1)
     def _sweepable_validators(self, blockstamp: BlockStamp) -> list[LidoValidator]:
-        """Active Lido validators the sweep pays out. A consolidation source pays its target, not the vault."""
         return [
             v
             for v in self.w3.lido_validators.get_active_lido_validators(blockstamp=blockstamp)
@@ -287,8 +277,17 @@ class Ejector(OracleModule[Web3]):
 
     @lru_cache(maxsize=1)
     def _get_withdrawable_principal(self, on_epoch: EpochNumber, blockstamp: BlockStamp) -> Wei:
-        """Staked ETH returning from validators exiting by `on_epoch`. Added on top of the rate, not
-        merged in: principal is not income, so it cancels out of the rate."""
+        """
+        Staked ETH returning from validators exiting by `on_epoch`. Added on top of the rewards rate
+        rather than merged into it: principal is not income, so it cancels out of the rate.
+
+        Principal only. The balance validators hold above their effective-balance cap is deliberately
+        left out, because the projected rewards already cover it: over a horizon H the sweep reaches
+        H/cycle of the set and hands each one a full cycle of accrual, summing to rate * H. Counting
+        it here as well double counts (#993), and keeping it as a lower bound would compare a stock to
+        a flow. A degenerate rate therefore under-counts this term; that belongs in the rewards
+        prediction, not here.
+        """
         result = Gwei(0)
 
         for v in self._sweepable_validators(blockstamp):
@@ -363,7 +362,14 @@ class Ejector(OracleModule[Web3]):
 
     def _get_deposit_lock_amount(self, epoches_number: int, blockstamp: ReferenceBlockStamp) -> Wei:
         """
-        Calculates the amount of ETH locked for depositing for a given epoches_number.
+        ETH the balance estimate charges as locked for depositing over `epoches_number` — half of the
+        reserve actually locked.
+
+        Only half is charged because the reserve is refilled by new stake, and that inflow is not a
+        term in the estimate at all, so charging the full lock bills the withdrawal queue twice for
+        the same ETH. Charging nothing instead bets on stETH demand, which fails exactly when it
+        matters. The 1/2 is a judgment call: it costs at most half a lock of under-ejection, corrected
+        on the next frame.
         """
         deposit_per_frame = self.w3.lido_contracts.lido.get_deposits_reserve_target(blockstamp.block_hash)
         max_wr_wei = self.w3.lido_contracts.withdrawal_queue_nft.max_steth_withdrawal_amount(blockstamp.block_hash)
@@ -390,4 +396,4 @@ class Ejector(OracleModule[Web3]):
         # would over-count by adding a reserve for a partial / already-accounted frame.
         ao_frames = epoches_number // ao_frame_size
 
-        return Wei(ao_frames * reserve_per_frame)
+        return Wei(ao_frames * reserve_per_frame // 2)

--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -65,7 +65,7 @@ class Ejector(OracleModule[Web3]):
             - Rewards expected to reach the EL until the last validator is withdrawn
             - Staked ETH coming back from validators that finish exiting in the meantime
             - Current balance on EL
-            - Minus half the ETH reserved for new deposits over the same period
+            - Minus the ETH we expect new deposits to consume over the same period
         4. If the sum is already enough to cover WR, exit the loop.
         5. Get the next validator to eject.
 
@@ -278,15 +278,10 @@ class Ejector(OracleModule[Web3]):
     @lru_cache(maxsize=1)
     def _get_withdrawable_principal(self, on_epoch: EpochNumber, blockstamp: BlockStamp) -> Wei:
         """
-        Staked ETH returning from validators exiting by `on_epoch`. Added on top of the rewards rate
-        rather than merged into it: principal is not income, so it cancels out of the rate.
+        Staked ETH coming back from validators that become fully withdrawable by `on_epoch`.
 
-        Principal only. The balance validators hold above their effective-balance cap is deliberately
-        left out, because the projected rewards already cover it: over a horizon H the sweep reaches
-        H/cycle of the set and hands each one a full cycle of accrual, summing to rate * H. Counting
-        it here as well double counts (#993), and keeping it as a lower bound would compare a stock to
-        a flow. A degenerate rate therefore under-counts this term; that belongs in the rewards
-        prediction, not here.
+        Principal only. The balance above the effective-balance cap is not counted here: the
+        projected rewards already include it, so adding it again would double count it (#993).
         """
         result = Gwei(0)
 
@@ -362,14 +357,11 @@ class Ejector(OracleModule[Web3]):
 
     def _get_deposit_lock_amount(self, epoches_number: int, blockstamp: ReferenceBlockStamp) -> Wei:
         """
-        ETH the balance estimate charges as locked for depositing over `epoches_number` — half of the
-        reserve actually locked.
+        ETH we expect new deposits to consume over `epoches_number`.
 
-        Only half is charged because the reserve is refilled by new stake, and that inflow is not a
-        term in the estimate at all, so charging the full lock bills the withdrawal queue twice for
-        the same ETH. Charging nothing instead bets on stETH demand, which fails exactly when it
-        matters. The 1/2 is a judgment call: it costs at most half a lock of under-ejection, corrected
-        on the next frame.
+        Every accounting frame reserves `reserve_per_frame` for deposits, but new stake refills most
+        of that reserve. `// 2` is the average case we expect deposits to actually take away from the
+        ETH the withdrawal queue could otherwise use.
         """
         deposit_per_frame = self.w3.lido_contracts.lido.get_deposits_reserve_target(blockstamp.block_hash)
         max_wr_wei = self.w3.lido_contracts.withdrawal_queue_nft.max_steth_withdrawal_amount(blockstamp.block_hash)

--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -33,7 +33,6 @@ from src.utils.cache import global_lru_cache as lru_cache
 from src.utils.units import gwei_to_wei
 from src.utils.validator_balance import (
     get_predictable_inbound_balance,
-    get_predictable_inbound_sweep,
 )
 from src.utils.validator_state import (
     compute_activation_exit_epoch,
@@ -254,17 +253,27 @@ class Ejector(OracleModule[Web3]):
         future_rewards = time_to_last_withdrawal_in_epoch * rewards_speed_per_epoch
         logger.info({'msg': 'Calculate future rewards.', 'value': future_rewards})
 
-        unswept_rewards = self._get_unswept_rewards(blockstamp)
-        logger.info({'msg': 'Calculate unswept rewards.', 'value': unswept_rewards})
-
-        # Everything above the cap gets swept to the EL sooner or later, and the rewards rate already
-        # counts it arriving. Adding it again would count the same ETH twice. It is kept only as a
-        # floor, for when the rate has nothing to go on: no events in the window, or a negative
-        # rebase clamped it to zero.
-        # The floor is loose: the pile drains over a full sweep cycle, which can outlast the horizon.
-        future_inflow = max(future_rewards, unswept_rewards)
-        logger.info({'msg': 'Calculate future EL inflow.', 'value': future_inflow})
-
+        # The balance validators hold above their effective-balance cap — rewards earned but not yet
+        # swept — is deliberately NOT a term here, neither added nor used as a floor.
+        #
+        # `future_rewards` already covers it exactly. Over a horizon H, the sweep reaches a fraction
+        # H/cycle of the set, and each validator it reaches hands over a whole cycle's worth of
+        # accrual (what it was holding, plus what it accrues while waiting its turn). Those cancel to
+        # rate * H regardless of where each validator sits in the sweep order — so in steady state
+        # rate * H is the exact inflow, not an approximation. Adding the unswept pile on top counts
+        # the same ETH twice, which is what issue #993 was about.
+        #
+        # It is not kept as a lower bound either: a pile of ETH is a stock and this term is a flow,
+        # so `max()` between them compares different units. It also would not have helped where it
+        # looks like it should. A negative rebase only zeroes the rate when losses outrun the rewards
+        # of the whole prediction window; a milder one leaves `rate * H` the larger of the two, so
+        # `max()` would keep picking the stale event-based average and discard the fresh measurement.
+        #
+        # Consequence: when the rate prediction does degenerate — no `ETHDistributed` in the window,
+        # or losses large enough to trip the clamp in `RewardsPredictionService` — the estimated
+        # inflow is 0 instead of the pile's size. The estimate then reads low and the ejector requests
+        # more exits than needed. Those exits are irreversible, unlike the delay in the opposite
+        # direction, so the degenerate cases belong in the rate prediction, not behind a floor here.
         withdrawable_principal = self._get_withdrawable_principal(withdrawal_epoch, blockstamp)
         logger.info({'msg': 'Calculate withdrawable principal.', 'value': withdrawable_principal})
 
@@ -299,7 +308,7 @@ class Ejector(OracleModule[Web3]):
         logger.info({'msg': 'Charge half of the deposit lock.', 'value': charged_deposit_lock})
 
         return Wei(
-            future_inflow
+            future_rewards
             + withdrawable_principal
             + total_available_balance
             + gwei_to_wei(going_to_withdraw_balance_gwei)
@@ -317,19 +326,6 @@ class Ejector(OracleModule[Web3]):
             for v in self.w3.lido_validators.get_active_lido_validators(blockstamp=blockstamp)
             if not v.consolidating_as_source
         ]
-
-    @lru_cache(maxsize=1)
-    def _get_unswept_rewards(self, blockstamp: BlockStamp) -> Wei:
-        """Rewards already earned but not swept yet: whatever the validators hold above their cap.
-
-        A snapshot at `blockstamp`. It does not depend on how far ahead the report looks.
-        """
-        result = Gwei(0)
-
-        for v in self._sweepable_validators(blockstamp):
-            result += get_predictable_inbound_sweep(v)
-
-        return gwei_to_wei(result)
 
     @lru_cache(maxsize=1)
     def _get_withdrawable_principal(self, on_epoch: EpochNumber, blockstamp: BlockStamp) -> Wei:

--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -32,7 +32,6 @@ from src.types import BlockStamp, EpochNumber, Gwei, NodeOperatorGlobalIndex, Re
 from src.utils.cache import global_lru_cache as lru_cache
 from src.utils.units import gwei_to_wei
 from src.utils.validator_balance import (
-    get_predictable_full_inbound_balance,
     get_predictable_inbound_balance,
     get_predictable_inbound_sweep,
 )
@@ -64,9 +63,10 @@ class Ejector(OracleModule[Web3]):
         3. Check whether the sum of the following components will be enough to cover all WR:
             - Exiting validators’ balances
             - Validators’ balances in the "to eject" list
-            - Predicted rewards
-            - Predicted validator top-ups
+            - Rewards expected to reach the EL until the last validator is withdrawn
+            - Staked ETH coming back from validators that finish exiting in the meantime
             - Current balance on EL
+            - Minus the ETH reserved for new deposits over the same period
         4. If the sum is already enough to cover WR, exit the loop.
         5. Get the next validator to eject.
 
@@ -254,34 +254,69 @@ class Ejector(OracleModule[Web3]):
         future_rewards = time_to_last_withdrawal_in_epoch * rewards_speed_per_epoch
         logger.info({'msg': 'Calculate future rewards.', 'value': future_rewards})
 
-        future_withdrawals = self._get_withdrawable_lido_validators_balance(withdrawal_epoch, blockstamp)
-        logger.info({'msg': 'Calculate future withdrawals sum.', 'value': future_withdrawals})
+        unswept_rewards = self._get_unswept_rewards(blockstamp)
+        logger.info({'msg': 'Calculate unswept rewards.', 'value': unswept_rewards})
+
+        # Everything above the cap gets swept to the EL sooner or later, and the rewards rate already
+        # counts it arriving. Adding it again would count the same ETH twice. It is kept only as a
+        # floor, for when the rate has nothing to go on: no events in the window, or a negative
+        # rebase clamped it to zero.
+        # The floor is loose: the pile drains over a full sweep cycle, which can outlast the horizon.
+        future_inflow = max(future_rewards, unswept_rewards)
+        logger.info({'msg': 'Calculate future EL inflow.', 'value': future_inflow})
+
+        withdrawable_principal = self._get_withdrawable_principal(withdrawal_epoch, blockstamp)
+        logger.info({'msg': 'Calculate withdrawable principal.', 'value': withdrawable_principal})
 
         deposit_lock = self._get_deposit_lock_amount(time_to_last_withdrawal_in_epoch, blockstamp)
         logger.info({'msg': 'Calculate deposit lock.', 'value': deposit_lock})
 
         return Wei(
-            future_rewards
-            + future_withdrawals
+            future_inflow
+            + withdrawable_principal
             + total_available_balance
             + gwei_to_wei(going_to_withdraw_balance_gwei)
             - deposit_lock,
         )
 
     @lru_cache(maxsize=1)
-    def _get_withdrawable_lido_validators_balance(self, on_epoch: EpochNumber, blockstamp: BlockStamp) -> Wei:
-        lido_validators = self.w3.lido_validators.get_active_lido_validators(blockstamp=blockstamp)
+    def _sweepable_validators(self, blockstamp: BlockStamp) -> list[LidoValidator]:
+        """Active Lido validators the sweep will actually pay out.
 
+        A consolidation source is excluded: its balance goes to the target validator, not to the vault.
+        """
+        return [
+            v
+            for v in self.w3.lido_validators.get_active_lido_validators(blockstamp=blockstamp)
+            if not v.consolidating_as_source
+        ]
+
+    @lru_cache(maxsize=1)
+    def _get_unswept_rewards(self, blockstamp: BlockStamp) -> Wei:
+        """Rewards already earned but not swept yet: whatever the validators hold above their cap.
+
+        A snapshot at `blockstamp`. It does not depend on how far ahead the report looks.
+        """
         result = Gwei(0)
 
-        for v in lido_validators:
-            if v.consolidating_as_source:
-                continue
+        for v in self._sweepable_validators(blockstamp):
+            result += get_predictable_inbound_sweep(v)
 
+        return gwei_to_wei(result)
+
+    @lru_cache(maxsize=1)
+    def _get_withdrawable_principal(self, on_epoch: EpochNumber, blockstamp: BlockStamp) -> Wei:
+        """Principal — the staked 32 (or 2048) ETH — coming back from validators exiting by `on_epoch`.
+
+        Principal is not income, it is Lido's own ETH moving back from the CL, so the rewards rate
+        does not contain it: on exit the same amount leaves `postCLBalance` and enters
+        `withdrawalsWithdrawn`, cancelling out. That is why it is added on top instead of merged in.
+        """
+        result = Gwei(0)
+
+        for v in self._sweepable_validators(blockstamp):
             if is_fully_withdrawable_validator(v.validator, v.balance, on_epoch):
-                result += get_predictable_full_inbound_balance(v)
-            else:
-                result += get_predictable_inbound_sweep(v)
+                result += get_predictable_inbound_balance(v)
 
         return gwei_to_wei(result)
 

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -448,13 +448,7 @@ def test_is_contract_reportable(ejector: Ejector, blockstamp: BlockStamp) -> Non
 
 
 class TestGetPredictedElBalance:
-    """
-    Covers the going-to-exit balance leg of `_get_predicted_el_balance`: validators recently
-    requested to exit but not yet exiting must contribute only their capped (sweep-excluded)
-    balance, both to the returned EL balance and to the churn/withdrawal-epoch prediction —
-    otherwise the excess above the effective balance cap (which is separately swept) gets
-    double-counted.
-    """
+    """Going-to-exit validators count only their capped balance — the excess is swept separately."""
 
     @pytest.fixture(autouse=True)
     def mock_common(self, ejector: Ejector, chain_config: ChainConfig, ref_blockstamp: ReferenceBlockStamp) -> None:
@@ -511,13 +505,7 @@ class TestGetPredictedElBalance:
 
 @pytest.mark.unit
 class TestPredictedElBalanceChargesHalfDepositLock:
-    """
-    Only half the deposit reserve is charged against the withdrawal queue: the reserve is refilled by
-    new stake, which this formula does not model as an inflow, so charging all of it counts the same
-    ETH twice. Charging none of it would bet the whole term on deposits always covering the reserve.
-
-    Charging more than half over-ejects; charging less under-ejects. Both directions are pinned here.
-    """
+    """Exactly half the deposit reserve is charged: more over-ejects, less under-ejects."""
 
     @pytest.fixture(autouse=True)
     def mock_terms(self, ejector: Ejector, chain_config: ChainConfig, ref_blockstamp: ReferenceBlockStamp) -> None:
@@ -773,10 +761,7 @@ def test_get_predicted_el_balance__unswept_balance_above_cap__not_added_on_top(
     ref_blockstamp: ReferenceBlockStamp,
     chain_config: ChainConfig,
 ) -> None:
-    # Projecting the rewards rate over the horizon already covers the balance waiting above the cap
-    # for the next sweep: the sweep reaches H/cycle of the set and each validator it reaches hands
-    # over a full cycle of accrual, which comes to rate * H. Counting that balance again would
-    # inflate the predicted EL balance and under-eject. This is issue #993.
+    # rate * H already covers the balance waiting above the cap; counting it again under-ejects (#993).
     # Arrange
     _mock_predicted_el_balance_terms(ejector, chain_config)
     ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(3))
@@ -800,10 +785,7 @@ def test_get_predicted_el_balance__rate_prediction_degenerate__no_floor_from_uns
     ref_blockstamp: ReferenceBlockStamp,
     chain_config: ChainConfig,
 ) -> None:
-    # A zero rate means the predictor had nothing to go on (no events in the window, or losses large
-    # enough to trip the clamp), NOT that the unswept balance may stand in for it: a pile is a stock
-    # and this term is a flow. The estimate reads low, so the ejector requests more exits — the
-    # recoverable direction. Fixing a degenerate rate belongs in RewardsPredictionService.
+    # A zero rate means the predictor had no data, not that the unswept pile may stand in for it.
     # Arrange
     _mock_predicted_el_balance_terms(ejector, chain_config)
     ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(0))

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -512,6 +512,75 @@ class TestGetPredictedElBalance:
         ejector._get_predicted_withdrawable_epoch.assert_called_once_with(capped_balance + to_exit_gwei, ref_blockstamp)
 
 
+@pytest.mark.unit
+class TestPredictedElBalanceChargesHalfDepositLock:
+    """
+    Only half the deposit reserve is charged against the withdrawal queue: the reserve is refilled by
+    new stake, which this formula does not model as an inflow, so charging all of it counts the same
+    ETH twice. Charging none of it would bet the whole term on deposits always covering the reserve.
+
+    Charging more than half over-ejects; charging less under-ejects. Both directions are pinned here.
+    """
+
+    @pytest.fixture(autouse=True)
+    def mock_terms(self, ejector: Ejector, chain_config: ChainConfig, ref_blockstamp: ReferenceBlockStamp) -> None:
+        ejector.get_chain_config = Mock(return_value=chain_config)
+        ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
+        ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
+        ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
+        # Distinct powers of ten, so a missing or duplicated term shows up in the total.
+        ejector._get_total_el_balance = Mock(return_value=Wei(10_000))
+        ejector._get_unswept_rewards = Mock(return_value=Wei(1_000))
+        ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(0))
+        ejector._get_withdrawable_principal = Mock(return_value=Wei(100))
+
+    def test_get_predicted_el_balance__deposit_lock_set__only_half_subtracted(
+        self,
+        ejector: Ejector,
+        ref_blockstamp: ReferenceBlockStamp,
+    ) -> None:
+        # Arrange
+        ejector._get_deposit_lock_amount = Mock(return_value=Wei(400))
+
+        # Act
+        result = ejector._get_predicted_el_balance(Gwei(0), ref_blockstamp)
+
+        # Assert
+        assert result == Wei(10_000 + 1_000 + 100 - 200), (
+            "Exactly half the deposit lock must be subtracted: charging all of it double-charges the "
+            "queue for ETH that new deposits refill, charging none of it keeps no margin"
+        )
+
+    def test_get_predicted_el_balance__odd_deposit_lock__rounds_the_charge_down(
+        self,
+        ejector: Ejector,
+        ref_blockstamp: ReferenceBlockStamp,
+    ) -> None:
+        # Arrange: an odd wei amount must not produce a fractional Wei.
+        ejector._get_deposit_lock_amount = Mock(return_value=Wei(401))
+
+        # Act
+        result = ejector._get_predicted_el_balance(Gwei(0), ref_blockstamp)
+
+        # Assert
+        assert result == Wei(10_000 + 1_000 + 100 - 200), "The charge must floor to an integer number of wei"
+        assert isinstance(result, int)
+
+    def test_get_predicted_el_balance__deposit_lock_zero__nothing_subtracted(
+        self,
+        ejector: Ejector,
+        ref_blockstamp: ReferenceBlockStamp,
+    ) -> None:
+        # Arrange
+        ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
+
+        # Act
+        result = ejector._get_predicted_el_balance(Gwei(0), ref_blockstamp)
+
+        # Assert
+        assert result == Wei(10_000 + 1_000 + 100)
+
+
 class TestPredictedWithdrawableEpoch:
     @pytest.fixture
     def ref_blockstamp(self) -> ReferenceBlockStamp:

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -201,7 +201,8 @@ class TestGetValidatorsToEject:
         ejector._get_total_el_balance = Mock(return_value=Wei(50))
         ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
         ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch + 1)
-        ejector._get_withdrawable_lido_validators_balance = Mock(return_value=Wei(10))
+        ejector._get_unswept_rewards = Mock(return_value=Wei(0))
+        ejector._get_withdrawable_principal = Mock(return_value=Wei(10))
         ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
 
         with monkeypatch.context() as m:
@@ -230,7 +231,8 @@ class TestGetValidatorsToEject:
         ejector._get_total_el_balance = Mock(return_value=Wei(100))
         ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
 
-        ejector._get_withdrawable_lido_validators_balance = Mock(return_value=Wei(0))
+        ejector._get_unswept_rewards = Mock(return_value=Wei(0))
+        ejector._get_withdrawable_principal = Mock(return_value=Wei(0))
         ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch + 50)
         ejector._get_predicted_withdrawable_balance = Mock(return_value=Wei(50))
         ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
@@ -463,7 +465,8 @@ class TestGetPredictedElBalance:
         ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
         ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(0))
         ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
-        ejector._get_withdrawable_lido_validators_balance = Mock(return_value=Wei(0))
+        ejector._get_unswept_rewards = Mock(return_value=Wei(0))
+        ejector._get_withdrawable_principal = Mock(return_value=Wei(0))
         ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
 
     @pytest.mark.unit
@@ -662,32 +665,109 @@ def test_get_total_active_balance(ejector: Ejector) -> None:
 
 
 @pytest.mark.unit
-def test_get_withdrawable_lido_validators_balance(
+def test_get_unswept_rewards__counts_every_balance_above_the_cap(
+    ejector: Ejector,
+    ref_blockstamp: ReferenceBlockStamp,
+) -> None:
+    # Whatever sits above the effective balance cap is a reward waiting for the sweep — for every
+    # validator, whether or not it is about to become withdrawable.
+    # Arrange
+    ejector.w3.lido_validators.get_active_lido_validators = Mock(
+        return_value=[
+            build_extended_validator_with_balance(Gwei(32_300_000_000)),  # 0.3 ETH above the cap
+            build_extended_validator_with_balance(Gwei(33_000_000_000)),  # 1 ETH above the cap
+            build_extended_validator_with_balance(Gwei(31_000_000_000)),  # nothing to sweep
+        ]
+    )
+
+    # Act
+    result = ejector._get_unswept_rewards(ref_blockstamp)
+
+    # Assert
+    assert result == Gwei(1_300_000_000) * GWEI_TO_WEI
+
+
+@pytest.mark.unit
+def test_get_withdrawable_principal__only_fully_withdrawable_validators_count(
     ejector: Ejector,
     ref_blockstamp: ReferenceBlockStamp,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    ejector.w3.lido_validators.get_active_lido_validators = Mock(
-        return_value=[
-            build_extended_validator(balance="0"),
-            build_extended_validator(balance="0"),
-            build_extended_validator(balance="31"),
-            build_extended_validator(balance="42"),
-        ]
-    )
+    # Principal comes back only from validators that are fully withdrawable by the horizon, and only
+    # up to the cap — the excess is already accounted for as unswept rewards.
+    # Arrange
+    withdrawable = build_extended_validator_with_balance(Gwei(33_000_000_000))
+    staying = build_extended_validator_with_balance(Gwei(32_300_000_000))
+
+    ejector.w3.lido_validators.get_active_lido_validators = Mock(return_value=[withdrawable, staying])
 
     with monkeypatch.context() as m:
         m.setattr(
             ejector_module,
             "is_fully_withdrawable_validator",
-            Mock(side_effect=lambda _1, b, _2: b > 32),
+            Mock(side_effect=lambda _1, balance, _2: balance == withdrawable.balance),
         )
 
-        result = ejector._get_withdrawable_lido_validators_balance(42, ref_blockstamp)
-        assert result == 42 * GWEI_TO_WEI, "Unexpected withdrawable amount"
+        # Act
+        result = ejector._get_withdrawable_principal(EpochNumber(ref_blockstamp.ref_epoch + 2), ref_blockstamp)
 
-        ejector._get_withdrawable_lido_validators_balance(42, ref_blockstamp)
-        ejector.w3.lido_validators.get_active_lido_validators.assert_called_once()
+    # Assert
+    assert result == Gwei(MIN_ACTIVATION_BALANCE) * GWEI_TO_WEI
+
+
+def _mock_predicted_el_balance_terms(ejector: Ejector, chain_config: ChainConfig) -> None:
+    """Neutralise every term of `_get_predicted_el_balance` except the ones under test."""
+    ejector.get_chain_config = Mock(return_value=chain_config)
+    ejector._get_total_el_balance = Mock(return_value=Wei(0))
+    ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
+    ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
+    ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
+
+
+@pytest.mark.unit
+def test_get_predicted_el_balance__prediction_above_unswept__unswept_not_added_on_top(
+    ejector: Ejector,
+    ref_blockstamp: ReferenceBlockStamp,
+    chain_config: ChainConfig,
+) -> None:
+    # The rewards rate is measured on the EL side, so projecting it over the horizon already covers
+    # the rewards that are waiting on the CL for the next sweep. Counting the unswept balance again
+    # would inflate the predicted EL balance and under-eject.
+    # Arrange
+    _mock_predicted_el_balance_terms(ejector, chain_config)
+    ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(3))
+    ejector._get_predicted_withdrawable_epoch = Mock(return_value=EpochNumber(ref_blockstamp.ref_epoch + 10))
+    ejector._get_unswept_rewards = Mock(return_value=Wei(7))
+    ejector._get_withdrawable_principal = Mock(return_value=Wei(5))
+
+    # Act
+    result = ejector._get_predicted_el_balance(Gwei(0), ref_blockstamp)
+
+    # Assert
+    assert result == Wei(10 * 3 + 5), "Predicted rewards must absorb the unswept balance, not be summed with it"
+
+
+@pytest.mark.unit
+def test_get_predicted_el_balance__prediction_below_unswept__unswept_used_as_lower_bound(
+    ejector: Ejector,
+    ref_blockstamp: ReferenceBlockStamp,
+    chain_config: ChainConfig,
+) -> None:
+    # With no rewards prediction to project (no events in the window, or a negative rebase clamped it
+    # to zero) the balance sitting above the effective balance cap is still observed on-chain and
+    # still gets swept, so it must not be dropped.
+    # Arrange
+    _mock_predicted_el_balance_terms(ejector, chain_config)
+    ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(0))
+    ejector._get_predicted_withdrawable_epoch = Mock(return_value=EpochNumber(ref_blockstamp.ref_epoch + 10))
+    ejector._get_unswept_rewards = Mock(return_value=Wei(7))
+    ejector._get_withdrawable_principal = Mock(return_value=Wei(5))
+
+    # Act
+    result = ejector._get_predicted_el_balance(Gwei(0), ref_blockstamp)
+
+    # Assert
+    assert result == Wei(7 + 5), "The unswept balance is a lower bound of what the sweep will deliver"
 
 
 @pytest.mark.unit
@@ -886,7 +966,8 @@ def test_get_validators_to_eject__forced_validators_present__included_in_result(
     ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
     ejector._get_total_el_balance = Mock(return_value=Wei(0))
     ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
-    ejector._get_withdrawable_lido_validators_balance = Mock(return_value=Wei(0))
+    ejector._get_unswept_rewards = Mock(return_value=Wei(0))
+    ejector._get_withdrawable_principal = Mock(return_value=Wei(0))
     ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
     ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
 
@@ -921,7 +1002,8 @@ def test_get_validators_to_eject__forced_validators_present__included_without_wr
     ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
     ejector._get_total_el_balance = Mock(return_value=Wei(0))
     ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
-    ejector._get_withdrawable_lido_validators_balance = Mock(return_value=Wei(0))
+    ejector._get_unswept_rewards = Mock(return_value=Wei(0))
+    ejector._get_withdrawable_principal = Mock(return_value=Wei(0))
     ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
     ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
 
@@ -956,7 +1038,8 @@ def test_get_validators_to_eject__no_wq_pressure__no_validator_ejections(
     ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
     ejector._get_total_el_balance = Mock(return_value=Wei(0))
     ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
-    ejector._get_withdrawable_lido_validators_balance = Mock(return_value=Wei(0))
+    ejector._get_unswept_rewards = Mock(return_value=Wei(0))
+    ejector._get_withdrawable_principal = Mock(return_value=Wei(0))
     ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
     ejector._get_deposit_lock_amount = Mock(return_value=Wei(1000 * 10**18))
 
@@ -977,29 +1060,22 @@ def test_get_validators_to_eject__no_wq_pressure__no_validator_ejections(
 
 
 @pytest.mark.unit
-def test_get_withdrawable_lido_validators_balance__consolidating_as_source__excluded(
+def test_sweepable_validators__consolidating_as_source__excluded(
     ejector: Ejector,
     ref_blockstamp: ReferenceBlockStamp,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    # A consolidation source sends its balance to the target validator, not to the Withdrawal Vault,
+    # so the sweep never sees it.
+    # Arrange
     normal_validator = build_extended_validator_with_balance(Gwei(42))
-    # Mark as consolidation source — this validator should be excluded from withdrawable balance
     consolidating_validator = build_extended_validator_with_balance(Gwei(42), consolidating_as_source=Mock())
 
     ejector.w3.lido_validators.get_active_lido_validators = Mock(
         return_value=[normal_validator, consolidating_validator]
     )
 
-    with monkeypatch.context() as m:
-        m.setattr(
-            ejector_module,
-            "is_fully_withdrawable_validator",
-            Mock(return_value=True),
-        )
-        # Use a different epoch to avoid LRU cache collision with other tests
-        result = ejector._get_withdrawable_lido_validators_balance(
-            EpochNumber(ref_blockstamp.ref_epoch + 1), ref_blockstamp
-        )
+    # Act — a distinct epoch keeps this out of the LRU cache used by other tests
+    result = ejector._sweepable_validators(ref_blockstamp)
 
-    # Only the normal validator contributes; consolidating_as_source is skipped
-    assert result == normal_validator.balance * GWEI_TO_WEI
+    # Assert
+    assert [v.index for v in result] == [normal_validator.index]

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -201,7 +201,6 @@ class TestGetValidatorsToEject:
         ejector._get_total_el_balance = Mock(return_value=Wei(50))
         ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
         ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch + 1)
-        ejector._get_unswept_rewards = Mock(return_value=Wei(0))
         ejector._get_withdrawable_principal = Mock(return_value=Wei(10))
         ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
 
@@ -231,7 +230,6 @@ class TestGetValidatorsToEject:
         ejector._get_total_el_balance = Mock(return_value=Wei(100))
         ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
 
-        ejector._get_unswept_rewards = Mock(return_value=Wei(0))
         ejector._get_withdrawable_principal = Mock(return_value=Wei(0))
         ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch + 50)
         ejector._get_predicted_withdrawable_balance = Mock(return_value=Wei(50))
@@ -465,7 +463,6 @@ class TestGetPredictedElBalance:
         ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
         ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(0))
         ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
-        ejector._get_unswept_rewards = Mock(return_value=Wei(0))
         ejector._get_withdrawable_principal = Mock(return_value=Wei(0))
         ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
 
@@ -526,12 +523,12 @@ class TestPredictedElBalanceChargesHalfDepositLock:
     def mock_terms(self, ejector: Ejector, chain_config: ChainConfig, ref_blockstamp: ReferenceBlockStamp) -> None:
         ejector.get_chain_config = Mock(return_value=chain_config)
         ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
-        ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
+        ejector._get_predicted_withdrawable_epoch = Mock(return_value=EpochNumber(ref_blockstamp.ref_epoch + 10))
         ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
         # Distinct powers of ten, so a missing or duplicated term shows up in the total.
         ejector._get_total_el_balance = Mock(return_value=Wei(10_000))
-        ejector._get_unswept_rewards = Mock(return_value=Wei(1_000))
-        ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(0))
+        # horizon is 10 epochs (sweep delay 0), so this projects to 1_000 of future_rewards
+        ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(100))
         ejector._get_withdrawable_principal = Mock(return_value=Wei(100))
 
     def test_get_predicted_el_balance__deposit_lock_set__only_half_subtracted(
@@ -734,36 +731,13 @@ def test_get_total_active_balance(ejector: Ejector) -> None:
 
 
 @pytest.mark.unit
-def test_get_unswept_rewards__counts_every_balance_above_the_cap(
-    ejector: Ejector,
-    ref_blockstamp: ReferenceBlockStamp,
-) -> None:
-    # Whatever sits above the effective balance cap is a reward waiting for the sweep — for every
-    # validator, whether or not it is about to become withdrawable.
-    # Arrange
-    ejector.w3.lido_validators.get_active_lido_validators = Mock(
-        return_value=[
-            build_extended_validator_with_balance(Gwei(32_300_000_000)),  # 0.3 ETH above the cap
-            build_extended_validator_with_balance(Gwei(33_000_000_000)),  # 1 ETH above the cap
-            build_extended_validator_with_balance(Gwei(31_000_000_000)),  # nothing to sweep
-        ]
-    )
-
-    # Act
-    result = ejector._get_unswept_rewards(ref_blockstamp)
-
-    # Assert
-    assert result == Gwei(1_300_000_000) * GWEI_TO_WEI
-
-
-@pytest.mark.unit
 def test_get_withdrawable_principal__only_fully_withdrawable_validators_count(
     ejector: Ejector,
     ref_blockstamp: ReferenceBlockStamp,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Principal comes back only from validators that are fully withdrawable by the horizon, and only
-    # up to the cap — the excess is already accounted for as unswept rewards.
+    # up to the cap — the excess above it is delivered by the sweep, which the rate already covers.
     # Arrange
     withdrawable = build_extended_validator_with_balance(Gwei(33_000_000_000))
     staying = build_extended_validator_with_balance(Gwei(32_300_000_000))
@@ -794,49 +768,56 @@ def _mock_predicted_el_balance_terms(ejector: Ejector, chain_config: ChainConfig
 
 
 @pytest.mark.unit
-def test_get_predicted_el_balance__prediction_above_unswept__unswept_not_added_on_top(
+def test_get_predicted_el_balance__unswept_balance_above_cap__not_added_on_top(
     ejector: Ejector,
     ref_blockstamp: ReferenceBlockStamp,
     chain_config: ChainConfig,
 ) -> None:
-    # The rewards rate is measured on the EL side, so projecting it over the horizon already covers
-    # the rewards that are waiting on the CL for the next sweep. Counting the unswept balance again
-    # would inflate the predicted EL balance and under-eject.
+    # Projecting the rewards rate over the horizon already covers the balance waiting above the cap
+    # for the next sweep: the sweep reaches H/cycle of the set and each validator it reaches hands
+    # over a full cycle of accrual, which comes to rate * H. Counting that balance again would
+    # inflate the predicted EL balance and under-eject. This is issue #993.
     # Arrange
     _mock_predicted_el_balance_terms(ejector, chain_config)
     ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(3))
     ejector._get_predicted_withdrawable_epoch = Mock(return_value=EpochNumber(ref_blockstamp.ref_epoch + 10))
-    ejector._get_unswept_rewards = Mock(return_value=Wei(7))
     ejector._get_withdrawable_principal = Mock(return_value=Wei(5))
+    # Validators sitting well above the cap: whatever the sweep is holding must not reach the total.
+    ejector.w3.lido_validators.get_active_lido_validators = Mock(
+        return_value=[build_extended_validator_with_balance(Gwei(40_000_000_000))]
+    )
 
     # Act
     result = ejector._get_predicted_el_balance(Gwei(0), ref_blockstamp)
 
     # Assert
-    assert result == Wei(10 * 3 + 5), "Predicted rewards must absorb the unswept balance, not be summed with it"
+    assert result == Wei(10 * 3 + 5), "Only the projected rate and the principal may count, never the unswept pile"
 
 
 @pytest.mark.unit
-def test_get_predicted_el_balance__prediction_below_unswept__unswept_used_as_lower_bound(
+def test_get_predicted_el_balance__rate_prediction_degenerate__no_floor_from_unswept(
     ejector: Ejector,
     ref_blockstamp: ReferenceBlockStamp,
     chain_config: ChainConfig,
 ) -> None:
-    # With no rewards prediction to project (no events in the window, or a negative rebase clamped it
-    # to zero) the balance sitting above the effective balance cap is still observed on-chain and
-    # still gets swept, so it must not be dropped.
+    # A zero rate means the predictor had nothing to go on (no events in the window, or losses large
+    # enough to trip the clamp), NOT that the unswept balance may stand in for it: a pile is a stock
+    # and this term is a flow. The estimate reads low, so the ejector requests more exits — the
+    # recoverable direction. Fixing a degenerate rate belongs in RewardsPredictionService.
     # Arrange
     _mock_predicted_el_balance_terms(ejector, chain_config)
     ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(0))
     ejector._get_predicted_withdrawable_epoch = Mock(return_value=EpochNumber(ref_blockstamp.ref_epoch + 10))
-    ejector._get_unswept_rewards = Mock(return_value=Wei(7))
     ejector._get_withdrawable_principal = Mock(return_value=Wei(5))
+    ejector.w3.lido_validators.get_active_lido_validators = Mock(
+        return_value=[build_extended_validator_with_balance(Gwei(40_000_000_000))]
+    )
 
     # Act
     result = ejector._get_predicted_el_balance(Gwei(0), ref_blockstamp)
 
     # Assert
-    assert result == Wei(7 + 5), "The unswept balance is a lower bound of what the sweep will deliver"
+    assert result == Wei(5), "With a zero rate the inflow estimate must be zero, not the unswept balance"
 
 
 @pytest.mark.unit
@@ -1035,7 +1016,6 @@ def test_get_validators_to_eject__forced_validators_present__included_in_result(
     ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
     ejector._get_total_el_balance = Mock(return_value=Wei(0))
     ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
-    ejector._get_unswept_rewards = Mock(return_value=Wei(0))
     ejector._get_withdrawable_principal = Mock(return_value=Wei(0))
     ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
     ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
@@ -1071,7 +1051,6 @@ def test_get_validators_to_eject__forced_validators_present__included_without_wr
     ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
     ejector._get_total_el_balance = Mock(return_value=Wei(0))
     ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
-    ejector._get_unswept_rewards = Mock(return_value=Wei(0))
     ejector._get_withdrawable_principal = Mock(return_value=Wei(0))
     ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
     ejector._get_deposit_lock_amount = Mock(return_value=Wei(0))
@@ -1107,7 +1086,6 @@ def test_get_validators_to_eject__no_wq_pressure__no_validator_ejections(
     ejector._get_sweep_delay_in_epochs = Mock(return_value=0)
     ejector._get_total_el_balance = Mock(return_value=Wei(0))
     ejector.validators_state_service.get_recently_requested_but_not_exiting_validators = Mock(return_value=[])
-    ejector._get_unswept_rewards = Mock(return_value=Wei(0))
     ejector._get_withdrawable_principal = Mock(return_value=Wei(0))
     ejector._get_predicted_withdrawable_epoch = Mock(return_value=ref_blockstamp.ref_epoch)
     ejector._get_deposit_lock_amount = Mock(return_value=Wei(1000 * 10**18))

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -505,8 +505,8 @@ class TestGetPredictedElBalance:
 
 @pytest.mark.unit
 class TestPredictedElBalanceSubtractsDepositLock:
-    """The charged deposit lock is subtracted from the estimate exactly once. The size of the charge
-    is decided in `_get_deposit_lock_amount` and pinned by `test_get_deposit_lock_amount__*`."""
+    """The deposit lock is subtracted from the estimate exactly once. How large that charge is gets
+    decided in `_get_deposit_lock_amount` and pinned by `test_get_deposit_lock_amount__*`."""
 
     @pytest.fixture(autouse=True)
     def mock_terms(self, ejector: Ejector, chain_config: ChainConfig, ref_blockstamp: ReferenceBlockStamp) -> None:
@@ -961,8 +961,7 @@ def test_get_deposit_lock_amount__capped_by_max_wr_when_smaller(
 @pytest.mark.parametrize(
     ("reserve_per_frame", "expected"),
     [
-        # Exactly half of the locked reserve is charged: charging all of it bills the queue twice for
-        # ETH that new deposits refill, charging none of it keeps no margin against a stake drought.
+        # Half of the reserve is what we expect deposits to consume in the average case.
         (Wei(400), Wei(200)),
         # An odd reserve must floor to a whole number of wei.
         (Wei(401), Wei(200)),

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -504,8 +504,9 @@ class TestGetPredictedElBalance:
 
 
 @pytest.mark.unit
-class TestPredictedElBalanceChargesHalfDepositLock:
-    """Exactly half the deposit reserve is charged: more over-ejects, less under-ejects."""
+class TestPredictedElBalanceSubtractsDepositLock:
+    """The charged deposit lock is subtracted from the estimate exactly once. The size of the charge
+    is decided in `_get_deposit_lock_amount` and pinned by `test_get_deposit_lock_amount__*`."""
 
     @pytest.fixture(autouse=True)
     def mock_terms(self, ejector: Ejector, chain_config: ChainConfig, ref_blockstamp: ReferenceBlockStamp) -> None:
@@ -519,37 +520,21 @@ class TestPredictedElBalanceChargesHalfDepositLock:
         ejector.prediction_service.get_rewards_per_epoch = Mock(return_value=Wei(100))
         ejector._get_withdrawable_principal = Mock(return_value=Wei(100))
 
-    def test_get_predicted_el_balance__deposit_lock_set__only_half_subtracted(
+    def test_get_predicted_el_balance__deposit_lock_set__subtracted_once(
         self,
         ejector: Ejector,
         ref_blockstamp: ReferenceBlockStamp,
     ) -> None:
         # Arrange
-        ejector._get_deposit_lock_amount = Mock(return_value=Wei(400))
+        ejector._get_deposit_lock_amount = Mock(return_value=Wei(200))
 
         # Act
         result = ejector._get_predicted_el_balance(Gwei(0), ref_blockstamp)
 
         # Assert
         assert result == Wei(10_000 + 1_000 + 100 - 200), (
-            "Exactly half the deposit lock must be subtracted: charging all of it double-charges the "
-            "queue for ETH that new deposits refill, charging none of it keeps no margin"
+            "The charged deposit lock must be subtracted from the estimate exactly once"
         )
-
-    def test_get_predicted_el_balance__odd_deposit_lock__rounds_the_charge_down(
-        self,
-        ejector: Ejector,
-        ref_blockstamp: ReferenceBlockStamp,
-    ) -> None:
-        # Arrange: an odd wei amount must not produce a fractional Wei.
-        ejector._get_deposit_lock_amount = Mock(return_value=Wei(401))
-
-        # Act
-        result = ejector._get_predicted_el_balance(Gwei(0), ref_blockstamp)
-
-        # Assert
-        assert result == Wei(10_000 + 1_000 + 100 - 200), "The charge must floor to an integer number of wei"
-        assert isinstance(result, int)
 
     def test_get_predicted_el_balance__deposit_lock_zero__nothing_subtracted(
         self,
@@ -932,14 +917,17 @@ def test_get_deposit_lock_amount__calculates_frames_ceiling__scales_by_reserve(
     mock_consensus.get_frame_config.return_value = Mock(epochs_per_frame=epochs_per_frame)
     ejector.w3.eth.contract = Mock(return_value=mock_consensus)
 
+    # Half of the frame reserve is charged, see `test_get_deposit_lock_amount__reserve_locked__charges_half`
+    charge_per_frame = reserve_per_frame // 2
+
     # 0 epochs → 0 // 10 = 0 frames → 0 locked
     assert ejector._get_deposit_lock_amount(0, ref_blockstamp) == Wei(0)
     # Exactly one frame (10 epochs) → 10 // 10 = 1 frame
-    assert ejector._get_deposit_lock_amount(10, ref_blockstamp) == Wei(reserve_per_frame)
+    assert ejector._get_deposit_lock_amount(10, ref_blockstamp) == Wei(charge_per_frame)
     # One epoch over one frame → 11 // 10 = 1 frame
-    assert ejector._get_deposit_lock_amount(11, ref_blockstamp) == Wei(1 * reserve_per_frame)
+    assert ejector._get_deposit_lock_amount(11, ref_blockstamp) == Wei(1 * charge_per_frame)
     # 2.5 frames → 25 // 10 = 2 frames
-    assert ejector._get_deposit_lock_amount(25, ref_blockstamp) == Wei(2 * reserve_per_frame)
+    assert ejector._get_deposit_lock_amount(25, ref_blockstamp) == Wei(2 * charge_per_frame)
 
     # All on-chain reads must be pinned to the report block, not the chain head
     ejector.w3.lido_contracts.accounting_oracle.get_consensus_contract.assert_called_with(ref_blockstamp.block_hash)
@@ -961,12 +949,42 @@ def test_get_deposit_lock_amount__capped_by_max_wr_when_smaller(
     ejector.w3.eth.contract = Mock(return_value=mock_consensus)
 
     # reserve_per_frame = min(100, 30) = 30 → max_wr_wei is the binding constraint
-    assert ejector._get_deposit_lock_amount(10, ref_blockstamp) == Wei(max_wr_wei)
-    assert ejector._get_deposit_lock_amount(25, ref_blockstamp) == Wei(2 * max_wr_wei)
+    assert ejector._get_deposit_lock_amount(10, ref_blockstamp) == Wei(max_wr_wei // 2)
+    assert ejector._get_deposit_lock_amount(25, ref_blockstamp) == Wei(2 * max_wr_wei // 2)
 
     # All on-chain reads must be pinned to the report block, not the chain head
     ejector.w3.lido_contracts.accounting_oracle.get_consensus_contract.assert_called_with(ref_blockstamp.block_hash)
     mock_consensus.get_frame_config.assert_called_with(ref_blockstamp.block_hash)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("reserve_per_frame", "expected"),
+    [
+        # Exactly half of the locked reserve is charged: charging all of it bills the queue twice for
+        # ETH that new deposits refill, charging none of it keeps no margin against a stake drought.
+        (Wei(400), Wei(200)),
+        # An odd reserve must floor to a whole number of wei.
+        (Wei(401), Wei(200)),
+    ],
+)
+def test_get_deposit_lock_amount__reserve_locked__charges_half(
+    ejector: Ejector, ref_blockstamp: ReferenceBlockStamp, reserve_per_frame: Wei, expected: Wei
+) -> None:
+    epochs_per_frame = 10
+    ejector.w3.lido_contracts.lido.get_deposits_reserve_target = Mock(return_value=reserve_per_frame)
+    ejector.w3.lido_contracts.withdrawal_queue_nft.max_steth_withdrawal_amount = Mock(
+        return_value=Wei(1000 * GWEI_TO_WEI)
+    )
+    ejector.w3.lido_contracts.accounting_oracle.get_consensus_contract = Mock(return_value="0x" + "0" * 40)
+    mock_consensus = Mock()
+    mock_consensus.get_frame_config.return_value = Mock(epochs_per_frame=epochs_per_frame)
+    ejector.w3.eth.contract = Mock(return_value=mock_consensus)
+
+    result = ejector._get_deposit_lock_amount(epochs_per_frame, ref_blockstamp)
+
+    assert result == expected
+    assert isinstance(result, int)
 
 
 class ForcedIterator:


### PR DESCRIPTION
Fixes #993.

Two terms of `_get_predicted_el_balance` were wrong in opposite directions.

```diff
  future_rewards
- + future_withdrawals      # capped balance of exiting validators + everything above the cap
+ + withdrawable_principal  # capped balance of exiting validators only
  + total_available_balance
  + going_to_withdraw
- - deposit_lock
+ - deposit_lock // 2
```

## 1. Swept rewards were counted twice

`future_withdrawals` added the balance validators hold above their effective-balance cap, but
`future_rewards` already covers it: over a horizon `H` the sweep reaches `H/cycle` of the set and
each validator it reaches hands over a full cycle of accrual, summing to `rate * H`. Verified on
mainnet state at ref slot 14924159 — the measured pile of 2 796 ETH over 273 472 Lido validators
equals `rate * epochs_to_sweep` to within 0.2%, where the rate comes independently from TVL and APR.

It is not kept as a lower bound either: a pile is a stock and the term is a flow. It also would not
help where it looks like it should — a negative rebase only zeroes the rate once losses outrun the
rewards of the whole 7-day prediction window, and a milder one leaves `rate * H` larger anyway.

Direction: the old formula over-estimated available ETH, so the ejector requested **too few** exits.

## 2. The deposit reserve was charged in full

The reserve is refilled by new stake, and that inflow is not a term in this formula at all, so
charging the full lock bills the withdrawal queue twice for the same ETH.

Measured on mainnet, 360 days / 361 AO frames / 118 255 `Submitted` events, against
`reserve_per_frame = min(getDepositsReserveTarget()=1500, MAX_STETH_WITHDRAWAL_AMOUNT=1000) = 1000 ETH`:

| daily new stake | min | p1 | p5 | median |
|---|---|---|---|---|
| ETH | 823 | 1 132 | 1 553 | 7 548 |

New stake covered the reserve in **360 of 361 frames** (99.95%). `// 2` corresponds to a daily stake
of 500 ETH — 1.65x below the worst day observed in a year, so it is a deliberately conservative
choice rather than a fitted one. **Open for review:** the data supports a smaller divisor or dropping
the term; `// 2` is a judgment call and I have no objection to changing it.

Direction: opposite to (1) — this raises the estimate.

## Net effect

At ref slot 14924159 the two changes largely offset: −2 796 ETH from (1), +2 000 ETH from (2), net
−797 ETH against an unfinalized queue of 8 458 ETH. Exit counts need a re-run to state precisely.

## Consensus-breaking

The report hash changes on any frame where either term was binding. Quorum is 5 of 9 — needs a
coordinated release, not a rolling upgrade.

## Testing

Regression tests pin both decisions and were mutation-checked (reintroducing the pile, and
`// 1`, `// 3`, `* 0` for the divisor — all caught). Unit suite green, `ruff` clean.
