### PR TITLE
feat(stc-830): add KAPI version to oracle startup telemetry

### DIFF
--- a/src/modules/oracles/common/runtime.py
+++ b/src/modules/oracles/common/runtime.py
@@ -133,7 +133,16 @@ def build_staking_module_web3(module_name: str) -> Web3StakingModule:
 def run_oracle_module(module: OracleModule):
     module.check_contract_configs()
 
-    startup_data = {'delegation_contract_address': variables.DELEGATION_CONTRACT_ADDRESS or None}
+    kapi_version = None
+    try:
+        kapi_version = module.w3.kac.get_status().app_version
+    except Exception:
+        logger.warning({'msg': 'Failed to fetch KAPI version for startup telemetry.'}, exc_info=True)
+
+    startup_data = {
+        'delegation_contract_address': variables.DELEGATION_CONTRACT_ADDRESS or None,
+        'kapi_version': kapi_version,
+    }
 
     try:
         module.w3.telemetry_data_bus.send_telemetry(TelemetryEventId.ORACLE_STARTUP, startup_data)

--- a/src/modules/oracles/common/runtime.py
+++ b/src/modules/oracles/common/runtime.py
@@ -133,15 +133,9 @@ def build_staking_module_web3(module_name: str) -> Web3StakingModule:
 def run_oracle_module(module: OracleModule):
     module.check_contract_configs()
 
-    kapi_version = None
-    try:
-        kapi_version = module.w3.kac.get_status().app_version
-    except Exception:
-        logger.warning({'msg': 'Failed to fetch KAPI version for startup telemetry.'}, exc_info=True)
-
     startup_data = {
         'delegation_contract_address': variables.DELEGATION_CONTRACT_ADDRESS or None,
-        'kapi_version': kapi_version,
+        'kapi_version': module.w3.kac.get_status().app_version,
     }
 
     try:

--- a/src/providers/keys/client.py
+++ b/src/providers/keys/client.py
@@ -105,8 +105,6 @@ class KeysAPIClient(HTTPProvider):
 
         return cast(ModuleOperatorsKeys, data)
 
-    # Cached because the method is used only at oracle startup. Remove the cache if this changes.
-    @lru_cache(maxsize=1)
     def get_status(self) -> KeysApiStatus:
         """Docs: https://keys-api.lido.fi/api/static/index.html#/status/StatusController_get"""
         data, _ = self._get(self.STATUS, validate_response=data_is_dict)

--- a/src/providers/keys/client.py
+++ b/src/providers/keys/client.py
@@ -105,6 +105,8 @@ class KeysAPIClient(HTTPProvider):
 
         return cast(ModuleOperatorsKeys, data)
 
+    # Cached because the method is used only at oracle startup. Remove the cache if this changes.
+    @lru_cache(maxsize=1)
     def get_status(self) -> KeysApiStatus:
         """Docs: https://keys-api.lido.fi/api/static/index.html#/status/StatusController_get"""
         data, _ = self._get(self.STATUS, validate_response=data_is_dict)

--- a/tests/modules/submodules/test_oracle_module.py
+++ b/tests/modules/submodules/test_oracle_module.py
@@ -255,17 +255,3 @@ def test_run_oracle_module__kapi_available__sends_version_in_startup_telemetry()
     event_id, startup_data = module.w3.telemetry_data_bus.send_telemetry.call_args[0]
     assert event_id == TelemetryEventId.ORACLE_STARTUP
     assert startup_data['kapi_version'] == '4.0.4'
-
-
-@pytest.mark.unit
-@patch.object(variables, 'DAEMON', False)
-def test_run_oracle_module__kapi_status_fails__sends_none_version(caplog):
-    module = Mock()
-    module.w3.kac.get_status.side_effect = Exception('KAPI is down')
-
-    run_oracle_module(module)
-
-    event_id, startup_data = module.w3.telemetry_data_bus.send_telemetry.call_args[0]
-    assert event_id == TelemetryEventId.ORACLE_STARTUP
-    assert startup_data['kapi_version'] is None
-    assert 'Failed to fetch KAPI version' in caplog.text

--- a/tests/modules/submodules/test_oracle_module.py
+++ b/tests/modules/submodules/test_oracle_module.py
@@ -21,11 +21,13 @@ from src.metrics.prometheus.basic import (
 from src.modules.common.types import ModuleExecuteDelay
 from src.modules.oracles.common.exceptions import IncompatibleOracleVersion
 from src.modules.oracles.common.oracle_module import OracleModule
+from src.modules.oracles.common.runtime import run_oracle_module
 from src.providers.http_provider import NotOkResponse
 from src.providers.keys.client import KeysOutdatedException
 from src.types import BlockStamp
 from src.utils.slot import InconsistentData, NoSlotsAvailable, SlotNotFinalized
 from src.web3py.extensions.lido_validators import CountOfKeysDiffersException, FrontRunAttackError
+from src.web3py.extensions.telemetry_data_bus import TelemetryEventId
 from tests.factory.blockstamp import ReferenceBlockStampFactory
 from tests.factory.configs import BlockDetailsResponseFactory
 
@@ -239,3 +241,31 @@ def test_cycle__slot_below_threshold__records_success_metric(oracle: OracleModul
 
     assert CYCLE_COUNT.labels(result=CycleResult.SUCCESS.value)._value.get() == success_before + 1
     assert CYCLE_COUNT.labels(result=CycleResult.ERROR.value)._value.get() == error_before
+
+
+@pytest.mark.unit
+@patch.object(variables, 'DAEMON', False)
+def test_run_oracle_module__kapi_available__sends_version_in_startup_telemetry():
+    module = Mock()
+    module.w3.kac.get_status.return_value = Mock(app_version='4.0.4')
+
+    run_oracle_module(module)
+
+    module.w3.kac.get_status.assert_called_once_with()
+    event_id, startup_data = module.w3.telemetry_data_bus.send_telemetry.call_args[0]
+    assert event_id == TelemetryEventId.ORACLE_STARTUP
+    assert startup_data['kapi_version'] == '4.0.4'
+
+
+@pytest.mark.unit
+@patch.object(variables, 'DAEMON', False)
+def test_run_oracle_module__kapi_status_fails__sends_none_version(caplog):
+    module = Mock()
+    module.w3.kac.get_status.side_effect = Exception('KAPI is down')
+
+    run_oracle_module(module)
+
+    event_id, startup_data = module.w3.telemetry_data_bus.send_telemetry.call_args[0]
+    assert event_id == TelemetryEventId.ORACLE_STARTUP
+    assert startup_data['kapi_version'] is None
+    assert 'Failed to fetch KAPI version' in caplog.text


### PR DESCRIPTION
## Description
Add the Keys API version to the OracleStartup telemetry event. The version is fetched once at oracle startup from the existing `KeysAPIClient.get_status()` (`GET /v1/status`, `appVersion` field) and sent as `kapi_version`. If the status request fails, a warning is logged and `kapi_version` is sent as `null`, so startup telemetry is not blocked.

Works for all four oracle modules: `kac` is declared on `Web3Base`, so accounting, ejector, CSM and CM are covered by the same code path.

## Related Issue/Task
- Related task: [STC-830](https://linear.app/lidofi/issue/STC-830/add-kapi-version-to-oracle-telemetry)

## How Has This Been Tested?
- [x] Local tests: `make lint` is clean, new unit tests pass, `tests/web3py` suite passes
- [ ] Manual testing
- [ ] Not tested

## Checklist
- [ ] Documentation updated (if required)
- [x] New tests added (if applicable)
