### PR TITLE
fix(gloas): read EIP-8061 churn parameters from the CL config spec

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -31,8 +31,10 @@ CHURN_LIMIT_QUOTIENT = 2**16
 # https://github.com/ethereum/consensus-specs/blob/master/specs/electra/beacon-chain.md#validator-cycle
 MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA = Gwei(2**7 * 10**9)
 MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT = Gwei(2**8 * 10**9)
-# EIP-8061 (Glamsterdam): the exit churn limit loses its cap and the quotient is halved.
-CHURN_LIMIT_QUOTIENT_GLOAS = 2**15
+# EIP-8061 (Glamsterdam) halves the churn quotient and uncaps the exit churn limit. Its parameters
+# are deliberately NOT mirrored here: they are network configuration, differ between presets, and may
+# still be retuned before mainnet activation. They are read from /eth/v1/config/spec instead —
+# see BeaconSpecResponse.gloas_exit_churn_params.
 # https://github.com/ethereum/consensus-specs/blob/master/specs/phase0/beacon-chain.md#time-parameters
 SLOTS_PER_HISTORICAL_ROOT = 2**13  # 8192
 # https://github.com/ethereum/consensus-specs/blob/master/specs/altair/beacon-chain.md#sync-committee

--- a/src/modules/oracles/ejector/ejector.py
+++ b/src/modules/oracles/ejector/ejector.py
@@ -322,7 +322,8 @@ class Ejector(OracleModule[Web3]):
             # EIP-8061 removes the cap on the exit churn limit and halves the quotient. Using the old
             # capped formula post-fork overestimates withdrawal_epoch, which makes the ejector
             # under-request exits (the unsafe direction).
-            per_epoch_churn = get_exit_churn_limit(total_active_balance)
+            min_per_epoch_churn, churn_limit_quotient = self.w3.cc.get_config_spec().gloas_exit_churn_params()
+            per_epoch_churn = get_exit_churn_limit(total_active_balance, min_per_epoch_churn, churn_limit_quotient)
         else:
             per_epoch_churn = get_activation_exit_churn_limit(total_active_balance)
         # New epoch for exits.

--- a/src/providers/consensus/types.py
+++ b/src/providers/consensus/types.py
@@ -33,8 +33,17 @@ class BeaconSpecResponse(Nested, FromResponse):
     # ejector paths stay inactive on pre-fork networks. Exact spec constant name to be confirmed
     # against the final consensus-specs config before mainnet activation.
     GLOAS_FORK_EPOCH: EpochNumber = EpochNumber(2**64 - 1)
+    # EIP-8061 exit churn parameters. Network configuration rather than oracle constants: they differ
+    # between presets (mainnet 128 ETH / 2**15, minimal 64 ETH / 2**4) and may still be retuned before
+    # mainnet activation, so they are never compiled in. 0 means "this node does not announce it",
+    # which every pre-Gloas client does — see gloas_exit_churn_params for the post-fork requirement.
+    MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA: Gwei = Gwei(0)
+    CHURN_LIMIT_QUOTIENT_GLOAS: int = 0
 
     class NeitherSlotDurationFieldPresent(Exception):
+        pass
+
+    class MissingGloasChurnParams(Exception):
         pass
 
     class UnsupportedSlotDuration(Exception):
@@ -79,6 +88,31 @@ class BeaconSpecResponse(Nested, FromResponse):
 
         if self.SECONDS_PER_SLOT == 0:
             self.SECONDS_PER_SLOT = self.SLOT_DURATION_MS // 1000
+
+    def gloas_exit_churn_params(self) -> tuple[Gwei, int]:
+        """Return (MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA, CHURN_LIMIT_QUOTIENT_GLOAS) for get_exit_churn_limit.
+
+        Raises if the node does not announce both. Every Gloas-capable client does, so an absent key
+        means the parameter was renamed or dropped upstream and any compiled-in fallback is stale.
+        Guessing would silently mis-project the exit queue — and therefore the withdrawal epoch,
+        the future liquidity and the final exit count — so the ejector stops instead. The failure is
+        a client-version property, hence loud and identical for every oracle member rather than a
+        single member submitting a divergent report.
+        """
+        missing = [
+            name
+            for name, value in (
+                ('MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA', self.MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA),
+                ('CHURN_LIMIT_QUOTIENT_GLOAS', self.CHURN_LIMIT_QUOTIENT_GLOAS),
+            )
+            if not value
+        ]
+        if missing:
+            raise BeaconSpecResponse.MissingGloasChurnParams(
+                f"CL spec response does not announce {', '.join(missing)}, "
+                f"required to compute the EIP-8061 exit churn limit after the Gloas fork."
+            )
+        return self.MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA, self.CHURN_LIMIT_QUOTIENT_GLOAS
 
 
 @dataclass

--- a/src/utils/validator_state.py
+++ b/src/utils/validator_state.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 
 from src.constants import (
     CHURN_LIMIT_QUOTIENT,
-    CHURN_LIMIT_QUOTIENT_GLOAS,
     COMPOUNDING_WITHDRAWAL_PREFIX,
     EFFECTIVE_BALANCE_INCREMENT,
     ETH1_ADDRESS_WITHDRAWAL_PREFIX,
@@ -134,10 +133,16 @@ def get_balance_churn_limit(total_active_balance: Gwei) -> Gwei:
 
 
 # EIP-8061 (Glamsterdam): uncapped exit churn limit with a halved quotient. Unlike
-# get_activation_exit_churn_limit there is no MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT cap, so at
-# ~40M ETH total active stake this yields ~1220 ETH/epoch (~5x the pre-fork capped value).
-def get_exit_churn_limit(total_active_balance: Gwei) -> Gwei:
-    churn = max(MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA, total_active_balance // CHURN_LIMIT_QUOTIENT_GLOAS)
+# get_activation_exit_churn_limit there is no MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT cap, so on
+# mainnet parameters at ~40M ETH total active stake this yields ~1220 ETH/epoch (~5x the pre-fork
+# capped value). Both parameters are network configuration and come from the CL config snapshot —
+# see BeaconSpecResponse.gloas_exit_churn_params.
+def get_exit_churn_limit(
+    total_active_balance: Gwei,
+    min_per_epoch_churn_limit: Gwei,
+    churn_limit_quotient: int,
+) -> Gwei:
+    churn = max(min_per_epoch_churn_limit, total_active_balance // churn_limit_quotient)
     return Gwei(churn - churn % EFFECTIVE_BALANCE_INCREMENT)
 
 

--- a/tests/factory/configs.py
+++ b/tests/factory/configs.py
@@ -47,6 +47,9 @@ class BeaconSpecResponseFactory(Web3DataclassFactory[BeaconSpecResponse]):
     SLOTS_PER_HISTORICAL_ROOT = 8192
     # Default to "Gloas never active" so factory-built specs are pre-fork unless a test sets it.
     GLOAS_FORK_EPOCH = 2**64 - 1
+    # Mainnet-preset churn parameters, as announced by every Gloas-capable client.
+    MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA = 128 * 10**9
+    CHURN_LIMIT_QUOTIENT_GLOAS = 2**15
 
 
 class SlotAttestationCommitteeFactory(Web3DataclassFactory[SlotAttestationCommittee]):

--- a/tests/modules/ejector/test_ejector.py
+++ b/tests/modules/ejector/test_ejector.py
@@ -32,7 +32,7 @@ from src.web3py.extensions.lido_validators import (
 from src.web3py.types import Web3
 from tests.factory.base_oracle import EjectorProcessingStateFactory
 from tests.factory.blockstamp import BlockStampFactory, ReferenceBlockStampFactory
-from tests.factory.configs import ChainConfigFactory
+from tests.factory.configs import BeaconSpecResponseFactory, ChainConfigFactory
 from tests.factory.no_registry import LidoValidatorFactory
 
 
@@ -374,7 +374,12 @@ class TestPredictedWithdrawableEpoch:
     @pytest.fixture(autouse=True)
     def _patch_ejector(self, ejector: Ejector):
         ejector.w3.cc = Mock()
-        ejector.w3.cc.get_config_spec = Mock(return_value=Mock(ELECTRA_FORK_EPOCH=0))
+        # A real pre-fork spec, not a bare Mock: the factory defaults GLOAS_FORK_EPOCH to "never", so
+        # these cases stay on the Electra churn path instead of being pulled onto the EIP-8061 one by
+        # a Mock's truthy is_gloas. Gloas coverage lives in test_gloas_ejector.py.
+        spec = BeaconSpecResponseFactory.build()
+        ejector.w3.cc.get_config_spec = Mock(return_value=spec)
+        ejector.w3.cc.is_gloas = Mock(side_effect=lambda epoch: epoch >= spec.GLOAS_FORK_EPOCH)
 
 
 @pytest.mark.unit

--- a/tests/modules/ejector/test_gloas_ejector.py
+++ b/tests/modules/ejector/test_gloas_ejector.py
@@ -3,33 +3,161 @@
 from unittest.mock import Mock
 
 import pytest
+from web3 import Web3
 
 import src.modules.oracles.ejector.sweep as sweep_module
+from src.constants import MAX_SEED_LOOKAHEAD
 from src.modules.common.types import ChainConfig
+from src.modules.oracles.ejector.ejector import Ejector
 from src.modules.oracles.ejector.sweep import get_sweep_delay_in_epochs, predict_withdrawals_number_in_sweep_cycle
-from src.types import Gwei
+from src.providers.consensus.types import BeaconSpecResponse, BeaconStateView
+from src.types import EpochNumber, Gwei
 from src.utils.validator_state import get_activation_exit_churn_limit, get_exit_churn_limit
+from tests.factory.blockstamp import ReferenceBlockStampFactory
+from tests.factory.configs import BeaconSpecResponseFactory
 
 
 ETH = 10**9  # Gwei
 FORTY_MILLION_ETH = Gwei(40_000_000 * ETH)
 
+# /eth/v1/config/spec values, not oracle constants — see BeaconSpecResponse.gloas_exit_churn_params.
+MAINNET_CHURN_PARAMS = (Gwei(128 * ETH), 2**15)
+MINIMAL_CHURN_PARAMS = (Gwei(64 * ETH), 2**4)
+
 
 @pytest.mark.unit
 class TestExitChurnLimitEip8061:
-    def test_get_exit_churn_limit__at_40m_eth__is_about_1220_eth(self):
-        # ~40M ETH total active stake -> ~1220 ETH/epoch (uncapped, halved quotient).
-        assert get_exit_churn_limit(FORTY_MILLION_ETH) == Gwei(1220 * ETH)
+    @pytest.mark.parametrize(
+        ("total_active_balance", "params", "expected"),
+        [
+            # Mainnet preset. 40M ETH // 2**15 = 1220.703125 ETH -> floored to the increment.
+            pytest.param(FORTY_MILLION_ETH, MAINNET_CHURN_PARAMS, Gwei(1220 * ETH), id="mainnet-rounds-down"),
+            # Exact multiple of the quotient: nothing to floor off.
+            pytest.param(Gwei(1220 * ETH * 2**15), MAINNET_CHURN_PARAMS, Gwei(1220 * ETH), id="mainnet-exact"),
+            # Exactly at the floor: quotient term equals MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA.
+            pytest.param(Gwei(128 * ETH * 2**15), MAINNET_CHURN_PARAMS, Gwei(128 * ETH), id="mainnet-at-floor"),
+            # One Gwei below the floor boundary: the floor wins.
+            pytest.param(Gwei(128 * ETH * 2**15 - 1), MAINNET_CHURN_PARAMS, Gwei(128 * ETH), id="mainnet-below-floor"),
+            # Minimal preset: same stake, a very different limit — the parameters are not interchangeable.
+            pytest.param(FORTY_MILLION_ETH, MINIMAL_CHURN_PARAMS, Gwei(2_500_000 * ETH), id="minimal-exact"),
+            # 1048 ETH // 2**4 = 65.5 ETH -> floored to 65 ETH.
+            pytest.param(Gwei(1048 * ETH), MINIMAL_CHURN_PARAMS, Gwei(65 * ETH), id="minimal-rounds-down"),
+            # Below the minimal floor of 64 ETH: 1000 ETH // 2**4 = 62.5 ETH.
+            pytest.param(Gwei(1000 * ETH), MINIMAL_CHURN_PARAMS, Gwei(64 * ETH), id="minimal-below-floor"),
+        ],
+    )
+    def test_get_exit_churn_limit__preset_vectors__match_spec_formula(self, total_active_balance, params, expected):
+        assert get_exit_churn_limit(total_active_balance, *params) == expected
 
     def test_get_exit_churn_limit__uncapped_is_about_5x_activation_limit(self):
         # The pre-fork activation/exit churn is capped (256 ETH/epoch); EIP-8061 removes the cap.
-        exit_churn = get_exit_churn_limit(FORTY_MILLION_ETH)
+        exit_churn = get_exit_churn_limit(FORTY_MILLION_ETH, *MAINNET_CHURN_PARAMS)
         activation_churn = get_activation_exit_churn_limit(FORTY_MILLION_ETH)
         assert activation_churn == Gwei(256 * ETH)
         assert 4.5 < exit_churn / activation_churn < 5.0
 
-    def test_get_exit_churn_limit__is_multiple_of_effective_balance_increment(self):
-        assert get_exit_churn_limit(FORTY_MILLION_ETH) % ETH == 0
+
+@pytest.mark.unit
+class TestGloasChurnParamsFromConfigSpec:
+    @staticmethod
+    def _spec(**overrides) -> BeaconSpecResponse:
+        # String values mirror the real /eth/v1/config/spec response shape.
+        return BeaconSpecResponse.from_response(
+            DEPOSIT_CHAIN_ID="1",
+            SLOTS_PER_EPOCH="32",
+            DEPOSIT_CONTRACT_ADDRESS="0x00",
+            SLOTS_PER_HISTORICAL_ROOT="8192",
+            SECONDS_PER_SLOT="12",
+            **overrides,
+        )
+
+    def test_gloas_exit_churn_params__announced_by_node__returns_coerced_values(self):
+        # Arrange: the values a Glamsterdam devnet node announces, as strings.
+        spec = self._spec(MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA="128000000000", CHURN_LIMIT_QUOTIENT_GLOAS="32768")
+
+        # Act / Assert
+        assert spec.gloas_exit_churn_params() == (128 * ETH, 2**15)
+
+    @pytest.mark.parametrize(
+        ("overrides", "missing"),
+        [
+            ({"CHURN_LIMIT_QUOTIENT_GLOAS": "32768"}, "MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA"),
+            ({"MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA": "128000000000"}, "CHURN_LIMIT_QUOTIENT_GLOAS"),
+        ],
+    )
+    def test_gloas_exit_churn_params__param_not_announced__raises(self, overrides, missing):
+        spec = self._spec(**overrides)
+
+        with pytest.raises(BeaconSpecResponse.MissingGloasChurnParams, match=missing):
+            spec.gloas_exit_churn_params()
+
+
+@pytest.mark.unit
+class TestEjectorChurnUsesConfigSpec:
+    """The projected exit epoch must follow the node's churn parameters, not compiled-in values."""
+
+    EXITING_BALANCE = Gwei(5_000 * ETH)
+
+    @pytest.fixture
+    def ejector(self, web3: Web3) -> Ejector:
+        web3.lido_contracts.validators_exit_bus_oracle.get_consensus_version = Mock(return_value=1)
+        ejector = Ejector(web3)
+        ejector._get_total_active_balance = Mock(return_value=FORTY_MILLION_ETH)
+        return ejector
+
+    @staticmethod
+    def _exit_epoch(ejector: Ejector, spec: BeaconSpecResponse) -> EpochNumber:
+        blockstamp = ReferenceBlockStampFactory.build(ref_epoch=1000)
+        ejector.w3.cc = Mock()
+        ejector.w3.cc.get_config_spec = Mock(return_value=spec)
+        ejector.w3.cc.is_gloas = Mock(side_effect=lambda epoch: epoch >= spec.GLOAS_FORK_EPOCH)
+        state = BeaconStateView(
+            slot=blockstamp.slot_number,
+            validators=[],
+            balances=[],
+            earliest_exit_epoch=blockstamp.ref_epoch,
+            exit_balance_to_consume=Gwei(0),
+            slashings=[],
+        )
+        return ejector.compute_exit_epoch_and_update_churn(
+            state, TestEjectorChurnUsesConfigSpec.EXITING_BALANCE, blockstamp
+        )
+
+    def test_compute_exit_epoch__mainnet_params__queues_behind_the_1220_eth_churn(self, ejector: Ejector):
+        # Arrange: 1220 ETH/epoch of churn, so a 5000 ETH exit spills over 4 further epochs.
+        spec = BeaconSpecResponseFactory.build(GLOAS_FORK_EPOCH=0)
+
+        # Act
+        exit_epoch = self._exit_epoch(ejector, spec)
+
+        # Assert
+        assert exit_epoch == 1000 + (1 + MAX_SEED_LOOKAHEAD) + 4
+
+    def test_compute_exit_epoch__minimal_params__fits_in_the_first_epoch(self, ejector: Ejector):
+        # Arrange: the minimal preset churns 2.5M ETH/epoch, so the same exit spills over nothing.
+        # A compiled-in mainnet quotient would push this out by 4 epochs.
+        min_per_epoch_churn, quotient = MINIMAL_CHURN_PARAMS
+        spec = BeaconSpecResponseFactory.build(
+            GLOAS_FORK_EPOCH=0,
+            MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA=min_per_epoch_churn,
+            CHURN_LIMIT_QUOTIENT_GLOAS=quotient,
+        )
+
+        # Act
+        exit_epoch = self._exit_epoch(ejector, spec)
+
+        # Assert
+        assert exit_epoch == 1000 + (1 + MAX_SEED_LOOKAHEAD)
+
+    def test_compute_exit_epoch__gloas_active_but_params_not_announced__raises(self, ejector: Ejector):
+        # Arrange: a node that activates Gloas without announcing the churn parameters.
+        spec = BeaconSpecResponseFactory.build(
+            GLOAS_FORK_EPOCH=0, MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA=0, CHURN_LIMIT_QUOTIENT_GLOAS=0
+        )
+
+        # Act / Assert: refuse to project the exit queue with guessed parameters.
+        with pytest.raises(BeaconSpecResponse.MissingGloasChurnParams):
+            self._exit_epoch(ejector, spec)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Glamsterdam: read the EIP-8061 churn parameters from the CL config spec

Stacked on #965 (`feat/gloas-ejector`) — review that one first. Single concern: **where the churn
parameters come from.** #965 introduces the EIP-8061 formula and gates it on the fork; this PR only
changes its two inputs from compiled-in constants to values read off the node.

### Why

`MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA` and `CHURN_LIMIT_QUOTIENT_GLOAS` are network configuration, not
oracle constants:

- they differ between presets — mainnet `128 ETH` / `2**15`, minimal `64 ETH` / `2**4`;
- EIP-8061 is still a Glamsterdam candidate and may be retuned before mainnet activation.

Compiled in, they are correct only for the configuration they were copied from. A wrong churn value
silently moves the predicted exit queue, the withdrawal epoch, the future liquidity and the final
exit count — so this is worth getting structurally right rather than re-checking by hand at each
devnet.

### What changes

- `BeaconSpecResponse` gains `MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA` and `CHURN_LIMIT_QUOTIENT_GLOAS`,
  plus `gloas_exit_churn_params()` which returns the pair. Living on the response rather than on
  `ConsensusClient` means the cassette client in `tests/scenarios/replay.py` gets it for free.
- `get_exit_churn_limit(total_active_balance, min_per_epoch_churn_limit, churn_limit_quotient)` —
  the parameters are passed in, so `src/utils/validator_state.py` stays a pure module (importing
  `BeaconSpecResponse` there would be circular).
- `CHURN_LIMIT_QUOTIENT_GLOAS` is removed from `src/constants.py`, with a comment recording why it
  is not there. The pre-fork `CHURN_LIMIT_QUOTIENT` stays — `get_balance_churn_limit` still uses it.

**No behaviour change on mainnet or on the devnet under test.** Verified against the recorded
Glamsterdam devnet spec in `tests/cassettes/glamsterdam-kurtosis-7/`, whose `/eth/v1/config/spec`
announces exactly these keys with exactly the values that were hardcoded:

```
MIN_PER_EPOCH_CHURN_LIMIT_ELECTRA = 128000000000
CHURN_LIMIT_QUOTIENT_GLOAS        = 32768
```

### The one judgement call to push back on

Once Gloas is active, a missing parameter raises `MissingGloasChurnParams` rather than falling back
to the mainnet value. Reasoning: an absent key means the parameter was renamed or dropped upstream,
so any compiled-in fallback is stale by definition, and silently mis-projecting the exit queue is
the exact failure this PR removes. It is a client-version property, so it fails loudly and
identically for every oracle member instead of one member submitting a divergent report.

The cost is real — it is a liveness stop on the module that funds withdrawals. If the preference is
a mainnet-value fallback plus a warning log, that is a one-line change in `gloas_exit_churn_params`.

### Testing

- Mainnet and minimal preset vectors at the rounding and floor boundaries.
- Spec parsing from the real string-typed `/eth/v1/config/spec` shape, and `MissingGloasChurnParams`
  when either parameter is absent.
- Ejector-level assertions that the projected exit epoch follows *the node's* parameters: minimal
  params fit a 5000 ETH exit into the first epoch where mainnet params spill it over four. A
  compiled-in quotient fails these.
- `TestPredictedWithdrawableEpoch` built its consensus client as a bare `Mock`, whose truthy
  `is_gloas()` pulled those pre-fork cases onto the EIP-8061 branch. Their assertions held either
  way — at 2048 ETH total stake both formulas hit the 128 ETH floor — but they were not pinning the
  branch they name. The fixture now builds a real pre-fork spec.
- Full unit suite green, cassette scenarios green, `ruff` + `pyright` clean.

Base: `feat/gloas-ejector`.
