### PR TITLE
fix(gloas): identify bunker CL rebase samples by state root

### DIFF
--- a/src/services/bunker_cases/abnormal_cl_rebase.py
+++ b/src/services/bunker_cases/abnormal_cl_rebase.py
@@ -129,10 +129,10 @@ class AbnormalClRebase:
 
         nearest_blockstamp, distant_blockstamp = self._get_nearest_and_distant_blockstamps(blockstamp)
 
-        # dict preserves insertion order and deduplicates by block_number
+        # dict preserves insertion order and deduplicates by state_root
         for bs in {
-            nearest_blockstamp.block_number: nearest_blockstamp,
-            distant_blockstamp.block_number: distant_blockstamp,
+            nearest_blockstamp.state_root: nearest_blockstamp,
+            distant_blockstamp.state_root: distant_blockstamp,
         }.values():
             rebase = self._calculate_cl_rebase_between_blocks(bs, blockstamp)
             logger.info({"msg": f"Intraframe sampled CL rebase: {rebase} Gwei"})
@@ -189,8 +189,8 @@ class AbnormalClRebase:
         Check for these events is enough to account for all withdrawals since the protocol assumes that
         the vault can only be withdrawn at the time of the Oracle report between reference slots.
         """
-        if prev_blockstamp.block_number == ref_blockstamp.block_number:
-            # Can't calculate rebase between the same block
+        if prev_blockstamp.state_root == ref_blockstamp.state_root:
+            # Can't calculate rebase between the same CL state
             return Gwei(0)
 
         (prev_lido_validators, _) = LidoValidatorsProvider.compute_lido_validators(
@@ -258,6 +258,10 @@ class AbnormalClRebase:
                 )
             }
         )
+
+        if prev_blockstamp.block_number >= ref_blockstamp.block_number:
+            logger.info({"msg": "No execution blocks between samples. Vault withdrawals: 0 Gwei."})
+            return Gwei(0)
 
         events = self._get_eth_distributed_events(
             # We added +1 to prev block number because withdrawals from vault

--- a/tests/modules/accounting/bunker/test_bunker_abnormal_cl_rebase.py
+++ b/tests/modules/accounting/bunker/test_bunker_abnormal_cl_rebase.py
@@ -1,13 +1,15 @@
 from unittest.mock import Mock
 
 import pytest
+from eth_typing import HexStr
+from web3.types import Wei
 
 from src.constants import FAR_FUTURE_EPOCH, UINT64_MAX
 from src.modules.oracles.accounting.types import BalanceStats
 from src.providers.consensus.types import Validator, ValidatorState
 from src.services.bunker_cases.abnormal_cl_rebase import AbnormalClRebase
 from src.services.bunker_cases.types import BunkerConfig
-from src.types import EpochNumber, Gwei, SlotNumber, ValidatorIndex
+from src.types import EpochNumber, Gwei, SlotNumber, StateRoot, ValidatorIndex
 from src.web3py.extensions import LidoValidatorsProvider
 from src.web3py.types import Web3
 from tests.factory.blockstamp import ReferenceBlockStampFactory
@@ -364,8 +366,8 @@ def test_calculate_cl_rebase_between_blocks(
     withdrawn_from_vault,
     expected_rebase,
 ):
-    prev_blockstamp = ReferenceBlockStampFactory.build(block_number=8)
-    ref_blockstamp = ReferenceBlockStampFactory.build(block_number=88)
+    prev_blockstamp = ReferenceBlockStampFactory.build(block_number=8, state_root=StateRoot(HexStr('0x08')))
+    ref_blockstamp = ReferenceBlockStampFactory.build(block_number=88, state_root=StateRoot(HexStr('0x88')))
     abnormal_case = AbnormalClRebase(
         web3, ChainConfigFactory.build(), BunkerConfigFactory.build(), FrameConfigFactory.build()
     )
@@ -857,3 +859,91 @@ def test_calculate_normal_cl_rebase(epoch_passed, mean_lido, mean_total, expecte
         epoch_passed,
     )
     assert normal_cl_rebase == expected
+
+
+@pytest.mark.unit
+class TestClSampleIdentityUnderEip7732:
+    """A withheld payload leaves the blockstamp's execution anchor unchanged while CL state moves on,
+    so distinct CL samples can share one execution block. Sample identity is the CL state root."""
+
+    @staticmethod
+    def _abnormal_case(web3, prev_balance: Gwei, ref_balance: Gwei) -> AbnormalClRebase:
+        abnormal_case = AbnormalClRebase(
+            web3, ChainConfigFactory.build(), BunkerConfigFactory.build(), FrameConfigFactory.build()
+        )
+        abnormal_case.lido_keys = Mock()
+        abnormal_case.w3.cc = Mock()
+        abnormal_case.w3.lido_contracts = Mock()
+        abnormal_case.w3.lido_contracts.get_withdrawal_balance_no_cache = Mock(return_value=Wei(0))
+        abnormal_case.w3.lido_contracts.lido.get_contract_version = Mock(return_value=3)
+        abnormal_case._get_last_report_reference_blockstamp = Mock(
+            return_value=ReferenceBlockStampFactory.build(block_number=0)
+        )
+        abnormal_case.lido_validators = simple_validators(0, 0, balance=ref_balance)
+        return abnormal_case
+
+    def test_calculate_cl_rebase_between_blocks__same_el_anchor_different_state__cl_delta_counted(
+        self, web3, monkeypatch
+    ):
+        # Arrange
+        prev_blockstamp = ReferenceBlockStampFactory.build(block_number=42, state_root=StateRoot(HexStr('0xaa')))
+        ref_blockstamp = ReferenceBlockStampFactory.build(block_number=42, state_root=StateRoot(HexStr('0xbb')))
+        abnormal_case = self._abnormal_case(web3, Gwei(32 * 10**9), Gwei(31 * 10**9))
+        monkeypatch.setattr(
+            LidoValidatorsProvider,
+            "compute_lido_validators",
+            Mock(return_value=(simple_validators(0, 0, balance=Gwei(32 * 10**9)), [])),
+        )
+
+        # Act
+        result = abnormal_case._calculate_cl_rebase_between_blocks(prev_blockstamp, ref_blockstamp)
+
+        # Assert
+        assert result == -1 * 10**9
+
+    def test_calculate_cl_rebase_between_blocks__same_state_root__returns_zero(self, web3):
+        # Arrange
+        state_root = StateRoot(HexStr('0xaa'))
+        prev_blockstamp = ReferenceBlockStampFactory.build(block_number=42, state_root=state_root)
+        ref_blockstamp = ReferenceBlockStampFactory.build(block_number=42, state_root=state_root)
+        abnormal_case = self._abnormal_case(web3, Gwei(32 * 10**9), Gwei(31 * 10**9))
+
+        # Act
+        result = abnormal_case._calculate_cl_rebase_between_blocks(prev_blockstamp, ref_blockstamp)
+
+        # Assert
+        assert result == 0
+
+    def test_get_withdrawn_from_vault_between_blocks__same_el_anchor__returns_zero_without_query(self, web3):
+        # Arrange
+        prev_blockstamp = ReferenceBlockStampFactory.build(block_number=42, state_root=StateRoot(HexStr('0xaa')))
+        ref_blockstamp = ReferenceBlockStampFactory.build(block_number=42, state_root=StateRoot(HexStr('0xbb')))
+        abnormal_case = AbnormalClRebase(
+            web3, ChainConfigFactory.build(), BunkerConfigFactory.build(), FrameConfigFactory.build()
+        )
+        abnormal_case._get_eth_distributed_events = Mock()
+
+        # Act
+        result = abnormal_case._get_withdrawn_from_vault_between_blocks(prev_blockstamp, ref_blockstamp)
+
+        # Assert
+        assert result == 0
+        abnormal_case._get_eth_distributed_events.assert_not_called()
+
+    def test_is_negative_specific_cl_rebase__samples_share_el_anchor__both_are_checked(self, web3):
+        # Arrange
+        nearest = ReferenceBlockStampFactory.build(block_number=42, state_root=StateRoot(HexStr('0xaa')))
+        distant = ReferenceBlockStampFactory.build(block_number=42, state_root=StateRoot(HexStr('0xbb')))
+        ref_blockstamp = ReferenceBlockStampFactory.build(block_number=42, state_root=StateRoot(HexStr('0xcc')))
+        abnormal_case = AbnormalClRebase(
+            web3, ChainConfigFactory.build(), BunkerConfigFactory.build(), FrameConfigFactory.build()
+        )
+        abnormal_case._get_nearest_and_distant_blockstamps = Mock(return_value=(nearest, distant))
+        abnormal_case._calculate_cl_rebase_between_blocks = Mock(return_value=Gwei(1))
+
+        # Act
+        result = abnormal_case._is_negative_specific_cl_rebase(ref_blockstamp)
+
+        # Assert
+        assert result is False
+        assert abnormal_case._calculate_cl_rebase_between_blocks.call_count == 2

--- a/tests/modules/submodules/consensus/test_consensus.py
+++ b/tests/modules/submodules/consensus/test_consensus.py
@@ -335,6 +335,77 @@ def test_get_blockstamp_for_report_slot_member_is_not_in_fast_line_ready(web3, c
     assert isinstance(blockstamp, BlockStamp)
 
 
+@pytest.mark.unit
+class TestGetBlockstampForReportWaitsForChild:
+    """Post-EIP-7732 the report is built from ref_slot's child, so a finalized ref_slot is no
+    longer enough — the oracle must wait for a finalized block strictly after it."""
+
+    REF_SLOT = 100
+
+    @pytest.fixture
+    def prepared(self, consensus, set_no_account):
+        member_info = MemberInfoFactory.build(
+            is_report_member=True,
+            is_fast_lane=True,
+            current_frame_ref_slot=self.REF_SLOT,
+        )
+        consensus.get_member_info = Mock(return_value=member_info)
+        consensus._get_latest_blockstamp = Mock(
+            return_value=ReferenceBlockStampFactory.build(slot_number=self.REF_SLOT)
+        )
+        consensus.get_chain_config = Mock(return_value=cast(ChainConfig, ChainConfigFactory.build()))
+        return consensus
+
+    @staticmethod
+    def _post_fork_block(slot: int):
+        """A post-EIP-7732 block: no embedded execution payload, so the child must be resolved."""
+        details = BlockDetailsResponseFactory.build(message={"slot": slot})
+        details.message.body.execution_payload = None
+        return details
+
+    def test_ref_slot_finalized_but_child_is_not__waits(self, prepared, caplog):
+        # Arrange: finalization has reached ref_slot itself and no further.
+        prepared.w3.cc.get_block_details.return_value = self._post_fork_block(self.REF_SLOT)
+        last_finalized = BlockStampFactory.build(slot_number=self.REF_SLOT)
+
+        # Act
+        result = prepared.get_blockstamp_for_report(last_finalized)
+
+        # Assert: no report is built on a ref slot whose child is not finalized yet.
+        assert result is None
+        assert "Reference slot's child is not yet finalized." in caplog.messages[-1]
+
+    def test_child_finalized__builds_report_on_the_child(self, prepared):
+        # Arrange: finalization has moved one slot past ref_slot, and that slot has a block.
+        child_slot = self.REF_SLOT + 1
+        prepared.w3.cc.get_block_details.return_value = self._post_fork_block(child_slot)
+        prepared.w3.cc.get_state_view.return_value.latest_block_hash = "0xaaaa"
+        prepared.w3.eth = Mock(get_block=Mock(return_value={"number": 7, "timestamp": 42}))
+        last_finalized = BlockStampFactory.build(slot_number=child_slot)
+
+        # Act
+        result = prepared.get_blockstamp_for_report(last_finalized)
+
+        # Assert: the report is anchored on the child, not on ref_slot.
+        assert result is not None
+        assert result.ref_slot == self.REF_SLOT
+        assert result.slot_number == child_slot
+
+    def test_pre_fork_ref_slot_finalized__does_not_wait(self, prepared):
+        # Arrange: pre-fork blocks embed their payload, so ref_slot alone is still enough.
+        prepared.w3.cc.get_block_details.return_value = BlockDetailsResponseFactory.build(
+            message={"slot": self.REF_SLOT}
+        )
+        last_finalized = BlockStampFactory.build(slot_number=self.REF_SLOT)
+
+        # Act
+        result = prepared.get_blockstamp_for_report(last_finalized)
+
+        # Assert
+        assert result is not None
+        assert result.slot_number == self.REF_SLOT
+
+
 class ConsensusImpl(ConsensusModule):
     """Consensus module implementation for testing purposes"""
 


### PR DESCRIPTION
## Glamsterdam (Gloas / EIP-7732): bunker CL rebase samples must be identified by CL state, not by execution block

Stacked on #963 (`feat/gloas-blockstamp-infra`), which is where blockstamps start taking their
execution anchor from `state.latest_block_hash`. Independent of #964.

### Problem

`process_withdrawals` returns early when the parent payload is withheld:

```python
# specs/gloas/beacon-chain.md
if state.latest_block_hash != state.latest_execution_payload_bid.block_hash:
    return
```

`state.latest_block_hash` — the blockstamp's execution anchor — does not advance either, while CL
processing continues as normal: attestation rewards, penalties and slashings all still move
balances. So under Gloas several distinct CL states can share one execution block, and the two
identities that coincided before the fork no longer do.

The bunker's intraframe check keyed on the execution block in two places:

- `_calculate_cl_rebase_between_blocks` returned `Gwei(0)` when `prev.block_number == ref.block_number`;
- `_is_negative_specific_cl_rebase` deduplicated the nearest and distant samples by `block_number`.

In a window with no revealed payload, the first reports a zero rebase across balances that actually
moved, and the second collapses two genuinely different samples into one. The negative-rebase
detector then returns a false negative — during exactly the condition it exists to catch. Note the
detector only runs once the frame rebase is already below normal, so the failure is a missed
confirmation of bunker mode, not a spurious one.

### Fix

Both sites now key on `state_root`. Zero is returned only when the two blockstamps are literally the
same CL state — which is still reachable and still correct, since `validate_slot_distance` permits
`rebase_check_nearest_epoch_distance == 0`.

Pre-fork behaviour is unchanged: every beacon block embeds its own payload, so distinct blocks always
have distinct execution blocks and the two keys agree.

`_get_withdrawn_from_vault_between_blocks` needed a guard as well. It builds the event range as
`[prev.block_number + 1, ref.block_number]`, and `get_events_in_range` raises on `l_block > r_block`.
Without the guard, letting the calculation proceed past equal anchors turns a false negative into an
exception. Equal anchors mean no execution block passed, so no `ETHDistributed` could have been
emitted and zero is the correct value.

`_calculate_injected_capital` needs no change — its post-v4 path reads
`get_deposited_for_current_report` at each `block_hash` rather than over a range, so equal anchors
already yield zero.

### Reachability

The trigger needs a whole sampling window without a single revealed payload —
`rebase_check_nearest_epoch_distance` epochs, since execution block numbers advance once per
revealed payload. That is a builder-market collapse, not an ordinary withheld block.

This is filed as robustness rather than an urgent fix: the identity is wrong regardless of how often
it is reachable, the sampling distances are on-chain governance parameters that can change, and the
error direction is the unsafe one.

### Testing

- New `TestClSampleIdentityUnderEip7732` in `tests/modules/accounting/bunker/test_bunker_abnormal_cl_rebase.py`:
  same execution anchor with different state roots counts the CL delta; identical state roots still
  short-circuit to zero; the vault-withdrawal lookup returns zero without querying events; the
  nearest/distant pair sharing an execution anchor is checked twice rather than deduplicated.
- `test_calculate_cl_rebase_between_blocks` now builds its two blockstamps with distinct state roots.
  `ReferenceBlockStampFactory` defaults every blockstamp to one fixed `state_root`, so the samples
  were identical on the field the code now keys on.
- Full unit suite green; `ruff` + `pyright` clean.

Base: `feat/gloas-blockstamp-infra`.
