### PR TITLE
fix(gloas): derive the event lookback cutoff from the reference slot

### DIFF
--- a/src/services/exit_order_iterator.py
+++ b/src/services/exit_order_iterator.py
@@ -179,7 +179,7 @@ class ValidatorExitIterator:
 
     def _prepare_validator_stats(self):
         recently_requested_indexes = self.lvs.get_recently_requested_to_exit_validators_by_node_operator(
-            self.chain_config.seconds_per_slot,
+            self.chain_config,
             self.blockstamp,
         )
         lido_validators = self.w3.lido_validators.get_lido_validators_by_node_operators(self.blockstamp)

--- a/src/services/prediction.py
+++ b/src/services/prediction.py
@@ -38,7 +38,7 @@ class RewardsPredictionService:
             self.w3.lido_contracts.lido.events.TokenRebased,  # type: ignore[arg-type]
             blockstamp,
             prediction_duration_in_slots,
-            chain_configs.seconds_per_slot,
+            chain_configs,
             'reportTimestamp',
         )
 
@@ -46,7 +46,7 @@ class RewardsPredictionService:
             self.w3.lido_contracts.lido.events.ETHDistributed,  # type: ignore[arg-type]
             blockstamp,
             prediction_duration_in_slots,
-            chain_configs.seconds_per_slot,
+            chain_configs,
             'reportTimestamp',
         )
 

--- a/src/services/validator_state.py
+++ b/src/services/validator_state.py
@@ -62,7 +62,7 @@ class LidoValidatorStateService:
         """
         lido_validators_by_operator = self.w3.lido_validators.get_lido_validators_by_node_operators(blockstamp)
         recent_exit_requests = self.get_recently_requested_to_exit_validators_by_node_operator(
-            chain_config.seconds_per_slot,
+            chain_config,
             blockstamp,
         )
 
@@ -91,7 +91,7 @@ class LidoValidatorStateService:
     @lru_cache(maxsize=1)
     def get_recently_requested_to_exit_validators_by_node_operator(
         self,
-        seconds_per_slot: int,
+        chain_config: ChainConfig,
         blockstamp: ReferenceBlockStamp,
     ) -> dict[NodeOperatorGlobalIndex, set[int]]:
         """
@@ -105,7 +105,7 @@ class LidoValidatorStateService:
             self.w3.lido_contracts.validators_exit_bus_oracle.events.ValidatorExitRequest,  # type: ignore[arg-type]
             to_blockstamp=blockstamp,
             for_slots=lookup_window,
-            seconds_per_slot=seconds_per_slot,
+            chain_config=chain_config,
         )
 
         logger.info({'msg': f'Fetch exit events. Got {len(events)} events.'})

--- a/src/utils/events.py
+++ b/src/utils/events.py
@@ -6,6 +6,7 @@ from web3.contract.contract import ContractEvent
 from web3.types import EventData
 
 from src import variables
+from src.modules.common.types import ChainConfig
 from src.providers.execution.exceptions import InconsistentEvents
 from src.types import ReferenceBlockStamp
 
@@ -17,44 +18,32 @@ def get_events_in_past(
     contract_event: ContractEvent,
     to_blockstamp: ReferenceBlockStamp,
     for_slots: int,
-    seconds_per_slot: int,
+    chain_config: ChainConfig,
     timestamp_field_name: str = 'timestamp',
 ):
     """
-    This is protection against missed slots when between 10 and 11 block number could be 5 missed slots.
-    Events should contain Timestamp field.
-    """
-    #   [ ] - slot
-    #   [x] - slot with existed block
-    #   [o] - slot with missed block
-    #    e  - event
-    #
-    #   for_slots = 10 (for example)
-    #   ref_slot = 22
-    #   block_number = 13
-    #
-    # ref_slot_shift = 22 - 18
-    # for_slots_without_missed_blocks = 10 - 4
-    #
-    #                              [-------- Event search block period --------]
-    #                                                  (---- Needed events --------------------]
-    #                           from_block        timeout_border            to_block       ref_slot
-    #                              |                   |                       |               |
-    #      e           e   e       e           e       e       e           e   e               v   e   e
-    #   --[x]-[o]-[x]-[x]-[x]-[x]-[x]-[o]-[o]-[x]-[x]-[x]-[o]-[x]-[x]-[o]-[x]-[x]-[o]-[o]-[o]-[o]-[x]-[x]----> time
-    #      1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24       slot
-    #      1   -   2   3   4   5   6   -   -   7   8   9   -  10  11   -  12  13   -   -   -   -  14  15       block
-    #
-    #   So we should consider events from blocks [10, 12, 13]
-    ref_slot_shift = to_blockstamp.ref_slot - to_blockstamp.slot_number
-    for_slots_without_missed_blocks = for_slots - ref_slot_shift
+    Events emitted in the `for_slots` slots preceding the report's reference slot.
 
-    if for_slots_without_missed_blocks <= 0:
-        # No non-missed slots in current search period
+    The cutoff is the reference slot's own time, so it does not depend on which block the blockstamp
+    physically stands on: pre-EIP-7732 that is the last non-missed slot at or before `ref_slot`,
+    after it the reference slot's child. Events carry timestamps on the same grid — the accounting
+    report timestamp is `GENESIS_TIME + refSlot * SECONDS_PER_SLOT` on the contract side, and an
+    execution block's timestamp is its own slot's.
+
+    The block range is only a coarse pre-filter for the node query. Execution blocks advance at most
+    once per slot, so stepping back as many blocks as there are slots in the window always reaches
+    past the cutoff; the timestamp comparison below is what actually bounds the result.
+
+    Events should contain a timestamp field.
+    """
+    from_timestamp = chain_config.genesis_time + (to_blockstamp.ref_slot - for_slots) * chain_config.seconds_per_slot
+
+    if to_blockstamp.block_timestamp <= from_timestamp:
+        # The execution anchor is already at or before the cutoff, so no event can qualify
         return []
 
-    from_block = max(0, to_blockstamp.block_number - for_slots_without_missed_blocks)
-    from_timestamp = to_blockstamp.block_timestamp - for_slots_without_missed_blocks * seconds_per_slot
+    slots_to_cover = (to_blockstamp.block_timestamp - from_timestamp) // chain_config.seconds_per_slot
+    from_block = max(0, to_blockstamp.block_number - slots_to_cover)
 
     events = get_events_in_range(
         contract_event,

--- a/tests/modules/accounting/test_validator_state.py
+++ b/tests/modules/accounting/test_validator_state.py
@@ -157,14 +157,17 @@ def test_get_recently_requested_validators_by_operator(monkeypatch, web3, valida
         return_value=exit_event_lookback_window
     )
 
-    global_indexes = validator_state.get_recently_requested_to_exit_validators_by_node_operator(12, blockstamp)
+    chain_config = ChainConfig(slots_per_epoch=32, seconds_per_slot=12, genesis_time=0)
+    global_indexes = validator_state.get_recently_requested_to_exit_validators_by_node_operator(
+        chain_config, blockstamp
+    )
     assert global_indexes == {(1, 0): {1, 2}, (1, 1): set()}
     web3.lido_contracts.oracle_daemon_config.exit_events_lookback_window_in_slots.assert_called_once()
     mock_get_events_in_past.assert_called_once_with(
         web3.lido_contracts.validators_exit_bus_oracle.events.ValidatorExitRequest,
         to_blockstamp=blockstamp,
         for_slots=exit_event_lookback_window,
-        seconds_per_slot=12,
+        chain_config=chain_config,
     )
 
 

--- a/tests/modules/submodules/consensus/test_consensus.py
+++ b/tests/modules/submodules/consensus/test_consensus.py
@@ -335,6 +335,77 @@ def test_get_blockstamp_for_report_slot_member_is_not_in_fast_line_ready(web3, c
     assert isinstance(blockstamp, BlockStamp)
 
 
+@pytest.mark.unit
+class TestGetBlockstampForReportWaitsForChild:
+    """Post-EIP-7732 the report is built from ref_slot's child, so a finalized ref_slot is no
+    longer enough — the oracle must wait for a finalized block strictly after it."""
+
+    REF_SLOT = 100
+
+    @pytest.fixture
+    def prepared(self, consensus, set_no_account):
+        member_info = MemberInfoFactory.build(
+            is_report_member=True,
+            is_fast_lane=True,
+            current_frame_ref_slot=self.REF_SLOT,
+        )
+        consensus.get_member_info = Mock(return_value=member_info)
+        consensus._get_latest_blockstamp = Mock(
+            return_value=ReferenceBlockStampFactory.build(slot_number=self.REF_SLOT)
+        )
+        consensus.get_chain_config = Mock(return_value=cast(ChainConfig, ChainConfigFactory.build()))
+        return consensus
+
+    @staticmethod
+    def _post_fork_block(slot: int):
+        """A post-EIP-7732 block: no embedded execution payload, so the child must be resolved."""
+        details = BlockDetailsResponseFactory.build(message={"slot": slot})
+        details.message.body.execution_payload = None
+        return details
+
+    def test_ref_slot_finalized_but_child_is_not__waits(self, prepared, caplog):
+        # Arrange: finalization has reached ref_slot itself and no further.
+        prepared.w3.cc.get_block_details.return_value = self._post_fork_block(self.REF_SLOT)
+        last_finalized = BlockStampFactory.build(slot_number=self.REF_SLOT)
+
+        # Act
+        result = prepared.get_blockstamp_for_report(last_finalized)
+
+        # Assert: no report is built on a ref slot whose child is not finalized yet.
+        assert result is None
+        assert "Reference slot's child is not yet finalized." in caplog.messages[-1]
+
+    def test_child_finalized__builds_report_on_the_child(self, prepared):
+        # Arrange: finalization has moved one slot past ref_slot, and that slot has a block.
+        child_slot = self.REF_SLOT + 1
+        prepared.w3.cc.get_block_details.return_value = self._post_fork_block(child_slot)
+        prepared.w3.cc.get_state_view.return_value.latest_block_hash = "0xaaaa"
+        prepared.w3.eth = Mock(get_block=Mock(return_value={"number": 7, "timestamp": 42}))
+        last_finalized = BlockStampFactory.build(slot_number=child_slot)
+
+        # Act
+        result = prepared.get_blockstamp_for_report(last_finalized)
+
+        # Assert: the report is anchored on the child, not on ref_slot.
+        assert result is not None
+        assert result.ref_slot == self.REF_SLOT
+        assert result.slot_number == child_slot
+
+    def test_pre_fork_ref_slot_finalized__does_not_wait(self, prepared):
+        # Arrange: pre-fork blocks embed their payload, so ref_slot alone is still enough.
+        prepared.w3.cc.get_block_details.return_value = BlockDetailsResponseFactory.build(
+            message={"slot": self.REF_SLOT}
+        )
+        last_finalized = BlockStampFactory.build(slot_number=self.REF_SLOT)
+
+        # Act
+        result = prepared.get_blockstamp_for_report(last_finalized)
+
+        # Assert
+        assert result is not None
+        assert result.slot_number == self.REF_SLOT
+
+
 class ConsensusImpl(ConsensusModule):
     """Consensus module implementation for testing purposes"""
 

--- a/tests/utils/test_events.py
+++ b/tests/utils/test_events.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock
 import pytest
 
 from src import variables
+from src.modules.common.types import ChainConfig
 from src.providers.execution.exceptions import InconsistentEvents
 from src.utils.events import get_events_in_past, get_events_in_range
 from tests.factory.blockstamp import ReferenceBlockStampFactory
@@ -32,7 +33,7 @@ def contract_event(events):
 
 @pytest.mark.unit
 def test_get_contract_events_in_past(contract_event):
-    seconds_per_slot = 10
+    chain_config = ChainConfig(slots_per_epoch=32, seconds_per_slot=10, genesis_time=0)
     bs = ReferenceBlockStampFactory.build(
         slot_number=36,
         block_number=31,
@@ -41,16 +42,16 @@ def test_get_contract_events_in_past(contract_event):
         ref_epoch=0,
     )
 
-    events = get_events_in_past(contract_event, bs, 10, seconds_per_slot)
+    events = get_events_in_past(contract_event, bs, 10, chain_config)
     assert len(events) == 2
-    events = get_events_in_past(contract_event, bs, 15, seconds_per_slot)
+    events = get_events_in_past(contract_event, bs, 15, chain_config)
     assert len(events) == 3
     # 1 block should be filtered by ts
-    events = get_events_in_past(contract_event, bs, 20, seconds_per_slot)
+    events = get_events_in_past(contract_event, bs, 20, chain_config)
     assert len(events) == 3
-    events = get_events_in_past(contract_event, bs, 25, seconds_per_slot)
+    events = get_events_in_past(contract_event, bs, 25, chain_config)
     assert len(events) == 4
-    events = get_events_in_past(contract_event, bs, 31, seconds_per_slot)
+    events = get_events_in_past(contract_event, bs, 31, chain_config)
     assert len(events) == 5
 
 
@@ -94,3 +95,105 @@ def test_get_events_in_range_inconsistent_events():
     event.get_logs = Mock(return_value=[{"blockNumber": 1}])
     with pytest.raises(InconsistentEvents):
         list(get_events_in_range(event, 10, 20))
+
+
+@pytest.mark.unit
+class TestGetEventsInPastCutoff:
+    """The cutoff is the reference slot's time, not the slot the blockstamp physically stands on.
+
+    Under EIP-7732 a report blockstamp is built from the reference slot's child, so `slot_number`
+    runs ahead of `ref_slot` while the execution anchor stays at the reference slot's own payload.
+    """
+
+    CHAIN_CONFIG = ChainConfig(slots_per_epoch=32, seconds_per_slot=10, genesis_time=0)
+
+    @staticmethod
+    def _event_at(block_number: int, timestamp: int) -> Mock:
+        """A contract event mock that honours the queried block range, as the real one does."""
+        log = {'blockNumber': block_number, 'args': {'timestamp': timestamp}}
+
+        def get_logs(from_block, to_block):
+            return [log] if from_block <= block_number <= to_block else []
+
+        return Mock(get_logs=Mock(side_effect=get_logs))
+
+    @pytest.fixture()
+    def boundary_event(self):
+        # ref_slot 63, ten-slot window -> cutoff at slot 53, i.e. timestamp 530.
+        return self._event_at(60, 525)
+
+    def test_get_events_in_past__immediate_child__event_before_cutoff_excluded(self, boundary_event):
+        # Arrange
+        bs = ReferenceBlockStampFactory.build(
+            ref_slot=63, ref_epoch=0, slot_number=64, block_number=63, block_timestamp=630
+        )
+
+        # Act
+        events = get_events_in_past(boundary_event, bs, 10, self.CHAIN_CONFIG)
+
+        # Assert
+        assert events == []
+
+    def test_get_events_in_past__missed_children__event_before_cutoff_still_excluded(self, boundary_event):
+        # Arrange: the child is four slots after the reference slot.
+        bs = ReferenceBlockStampFactory.build(
+            ref_slot=63, ref_epoch=0, slot_number=67, block_number=63, block_timestamp=630
+        )
+
+        # Act
+        events = get_events_in_past(boundary_event, bs, 10, self.CHAIN_CONFIG)
+
+        # Assert
+        assert events == []
+
+    def test_get_events_in_past__pre_fork_missed_ref_slot__cutoff_unchanged(self, boundary_event):
+        # Arrange: pre-EIP-7732 the blockstamp falls back to the last non-missed slot before ref_slot.
+        bs = ReferenceBlockStampFactory.build(
+            ref_slot=63, ref_epoch=0, slot_number=60, block_number=60, block_timestamp=600
+        )
+
+        # Act
+        events = get_events_in_past(boundary_event, bs, 10, self.CHAIN_CONFIG)
+
+        # Assert
+        assert events == []
+
+    def test_get_events_in_past__event_exactly_at_cutoff__excluded(self):
+        # Arrange: the filter is strictly greater than the cutoff.
+        contract_event = self._event_at(60, 530)
+        bs = ReferenceBlockStampFactory.build(
+            ref_slot=63, ref_epoch=0, slot_number=64, block_number=63, block_timestamp=630
+        )
+
+        # Act
+        events = get_events_in_past(contract_event, bs, 10, self.CHAIN_CONFIG)
+
+        # Assert
+        assert events == []
+
+    def test_get_events_in_past__event_just_after_cutoff__included(self):
+        # Arrange
+        contract_event = self._event_at(60, 531)
+        bs = ReferenceBlockStampFactory.build(
+            ref_slot=63, ref_epoch=0, slot_number=64, block_number=63, block_timestamp=630
+        )
+
+        # Act
+        events = get_events_in_past(contract_event, bs, 10, self.CHAIN_CONFIG)
+
+        # Assert
+        assert len(events) == 1
+
+    def test_get_events_in_past__anchor_at_or_before_cutoff__returns_empty(self):
+        # Arrange: a withheld reference-slot payload leaves the anchor further back than the window.
+        contract_event = self._event_at(40, 400)
+        bs = ReferenceBlockStampFactory.build(
+            ref_slot=63, ref_epoch=0, slot_number=64, block_number=40, block_timestamp=400
+        )
+
+        # Act
+        events = get_events_in_past(contract_event, bs, 10, self.CHAIN_CONFIG)
+
+        # Assert
+        assert events == []
+        contract_event.get_logs.assert_not_called()


### PR DESCRIPTION
## Glamsterdam (Gloas / EIP-7732): the event lookback window must be anchored to the reference slot

Stacked on #963 (`feat/gloas-blockstamp-infra`), where report blockstamps start being built from the
reference slot's child. Independent of #964 and #1007.

### Problem

`get_events_in_past` never computed its cutoff directly. It stepped back from the blockstamp's
execution anchor and corrected the step by `ref_slot - slot_number`:

```python
ref_slot_shift = to_blockstamp.ref_slot - to_blockstamp.slot_number
for_slots_without_missed_blocks = for_slots - ref_slot_shift
from_timestamp = to_blockstamp.block_timestamp - for_slots_without_missed_blocks * seconds_per_slot
```

That correction worked because the anchor timestamp and the blockstamp slot moved together — a block
embedded its own payload, so `block_timestamp == genesis_time + slot_number * seconds_per_slot`.
Taking the numbers straight from the diagram in the old comment:

```
BEFORE THE FORK   for_slots = 10, ref_slot = 22, slots 19-22 missed

slot       10  11  12  13  14  15  16  17  18  19  20  21  22
block       7   8   9   -  10  11   -  12  13   -   -   -   -
           |       |                       |               |
           |       |                       |               ref_slot = 22  (missed)
           |       |                       blockstamp: slot 18 / block 13
           |       CUTOFF = t(12)
           from_block = 7  (slot 10 - left of the cutoff, on purpose)
```

The old code reached that cutoff in two steps, starting from where the blockstamp physically stands:

```
shift        = 22 - 18 = 4          the blockstamp trails ref_slot by 4 slots
steps back   = 10 - 4  = 6          so walk back 6, not 10
cutoff       = t(18) - 6 slots = t(12)
```

which is the same point this PR computes in one jump: `t(22 - 10) = t(12)`. The two agree for every
pre-fork input — the shift exists precisely to cancel the blockstamp's displacement and pin the
cutoff to reference-slot time. Note also that `from_block` deliberately lands *left* of the cutoff:
the block range is an over-fetch and the timestamp comparison is the real bound.

Under EIP-7732 the two stop moving together. `slot_number` is the child's, while the anchor is the
reference slot's own payload, so `block_timestamp` does not advance with it:

```
AFTER THE FORK    for_slots = 10, ref_slot = 22, nothing missed

slot       11  12  13  14  15  16  17  18  19  20  21  22  23
block      59  60  61  62  63  64  65  66  67  68  69  70  71
           |   |                                       |   |
           |   |                                       |   blockstamp: slot 23  (ref_slot's child)
           |   |                                       EL anchor: block 70, timestamp t(22)
           |   NEW cutoff = t(22 - 10) = t(12)      correct
           OLD cutoff = t(22) - 11 slots = t(11)  one slot too early
```

```
shift        = 22 - 23 = -1         negative: the slot ran ahead, it did not trail
steps back   = 10 - (-1) = 11       the window grows instead of shrinking
cutoff       = t(22) - 11 slots = t(11)
```

Step 1 measures the displacement in *slots*; step 3 applies it to the *anchor's timestamp*. Those
were the same quantity before the fork. Now the slot moved by +1 and the anchor timestamp did not,
so the correction subtracts a slot that was never there. The window ends up
`(slot_number - ref_slot)` slots too long, and a withheld reference-slot payload pushes the anchor
further back and adds to the same error.

Consumers: `RewardsPredictionService` (reward rate over `prediction_duration_in_slots`) and
`LidoValidatorStateService` (recent exit requests over `exit_events_lookback_window_in_slots`). Both
windows are thousands of slots, so an event has to land in the extra sliver to matter — this is a
correctness fix, not an incident.

### Fix

```python
from_timestamp = chain_config.genesis_time + (to_blockstamp.ref_slot - for_slots) * chain_config.seconds_per_slot
```

Both consumers already hold a `ChainConfig` and already read `seconds_per_slot` out of it, so this is
a parameter swap rather than new plumbing.

The units line up on the contract side, which is what makes the reference slot the right coordinate
rather than merely a convenient one — verified in `lidofinance/core`:

- `HashConsensus._computeTimestampAtSlot(slot) = GENESIS_TIME + slot * SECONDS_PER_SLOT`
- `AccountingOracle` passes `_getSlotTimestamp(data.refSlot)` into `handleOracleReport`, and it
  reaches `TokenRebased` / `ETHDistributed` as `reportTimestamp` — so those events are already stamped
  in reference-slot time;
- `ValidatorsExitBus` stamps `ValidatorExitRequest` with `block.timestamp`, which post-merge is the
  slot's own timestamp — the same grid.

The block range remains a coarse pre-filter for the node query, now sized from the timestamps rather
than from slot arithmetic. Execution blocks advance at most once per slot, so stepping back as many
blocks as there are slots in the window always reaches past the cutoff; the timestamp comparison is
what actually bounds the result. This also drops the missed-block bookkeeping and the
`for_slots_without_missed_blocks <= 0` early return, which became unreachable once the shift could go
negative.

### Testing

- New `TestGetEventsInPastCutoff` in `tests/utils/test_events.py`: immediate child, several missed
  children, and the pre-fork missed-reference-slot fallback all produce the same cutoff; an event
  exactly at the cutoff is excluded and one a second later is included; an anchor at or before the
  cutoff returns empty without querying the node.
- The existing `test_get_contract_events_in_past` assertions are unchanged — its blockstamp has
  `slot_number == ref_slot`, where old and new formulas agree.
- Call-site signatures updated in `RewardsPredictionService`, `LidoValidatorStateService` and
  `ValidatorExitIterator`, with their tests.
- Full unit suite green; `ruff` + `pyright` clean.

Base: `feat/gloas-blockstamp-infra`.
