### PR TITLE
fix: drive the signer in fork report cycles

### DIFF
--- a/.github/workflows/mainnet_fork_tests.yml
+++ b/.github/workflows/mainnet_fork_tests.yml
@@ -13,6 +13,8 @@ on:
       - develop
     paths:
       - "src/**"
+      - "tests/fork/**"
+      - ".github/workflows/mainnet_fork_tests.yml"
 
 permissions:
   contents: read

--- a/src/modules/oracles/common/oracle_module.py
+++ b/src/modules/oracles/common/oracle_module.py
@@ -95,7 +95,8 @@ class OracleModule[W3: Web3Base](DaemonModule, ConsensusModule[W3], ABC):
         except KeysOutdatedException as error:
             logger.error({'msg': 'Keys API service returns outdated data.', 'error': str(error)})
         except Web3Exception as error:
-            logger.error({'msg': 'Web3py exception.', 'error': str(error)})
+            # A bare revert selector says nothing about which call produced it.
+            logger.error({'msg': 'Web3py exception.', 'error': ''.join(traceback.format_exception(error))})
         except IPFSError as error:
             logger.error({'msg': 'IPFS provider error.', 'error': str(error)})
         except ValueError as error:

--- a/tests/fork/conftest.py
+++ b/tests/fork/conftest.py
@@ -45,6 +45,7 @@ from src.web3py.extensions import (
     LidoValidatorsProvider,
     TransactionUtils,
 )
+from src.web3py.extensions.signer import SignerModule
 from src.web3py.extensions.staking_module import StakingModuleContracts
 
 
@@ -153,7 +154,25 @@ def account_from(monkeypatch):
                 Account.from_key(private_key=pk),
             )
             logger.info(f"TESTRUN Switched to ACCOUNT {variables.ACCOUNT.address}")
-            yield
+            yield variables.ACCOUNT
+
+    return _use
+
+
+@pytest.fixture
+def signer_from(web3):
+    """Rebuild the signer for the given accounts.
+
+    Production resolves the signer once at startup from variables.ACCOUNT/ACCOUNT_2, so
+    patching those mid-test changes nothing. Fork tests drive several members from one
+    process, hence a fresh signer per cycle.
+    """
+
+    @contextmanager
+    def _use(account=None, account_2=None, delegation_contract_address=None):
+        accounts = [candidate for candidate in (account, account_2) if candidate is not None]
+        web3.signer = SignerModule(web3, accounts, delegation_contract_address)
+        yield
 
     return _use
 
@@ -304,6 +323,9 @@ def web3(forked_el_client, patched_cl_client, mocked_ipfs_client):
             'cc': lambda: patched_cl_client,  # type: ignore[dict-item]
             'kac': lambda: kac,  # type: ignore[dict-item]
             'ipfs': lambda: mocked_ipfs_client,
+            # Telemetry is covered by test_telemetry_data_bus; a stub keeps the report path
+            # from logging a failed DataBus send on every cycle.
+            'telemetry_data_bus': lambda: Mock(),
         }
     )
     yield forked_el_client

--- a/tests/fork/test_delegation_report_cycle.py
+++ b/tests/fork/test_delegation_report_cycle.py
@@ -1,5 +1,4 @@
 import logging
-from contextlib import contextmanager
 
 import pytest
 from eth_account import Account
@@ -8,7 +7,6 @@ from web3 import Web3
 from src.modules.common.types import FrameConfig
 from src.modules.oracles.ejector.ejector import Ejector
 from src.utils.range import sequence
-from src.web3py.extensions.signer import SignerModule
 from tests.fork.conftest import first_slot_of_epoch
 
 
@@ -121,17 +119,6 @@ def granted_submit_role(report_contract, six_members_with_delegation, fresh_dele
     report_contract.functions.grantRole(submit_role, fresh_delegation_contract).transact({'from': oracle_admin})
 
 
-@pytest.fixture()
-def signer_from(web3):
-    @contextmanager
-    def _use(account, account_2, delegation_contract_address):
-        accounts = [candidate for candidate in (account, account_2) if candidate is not None]
-        web3.signer = SignerModule(web3, accounts, delegation_contract_address)
-        yield
-
-    return _use
-
-
 @pytest.mark.testnet
 @pytest.mark.fork
 @pytest.mark.integration
@@ -172,7 +159,7 @@ class TestDelegatedMemberReportCycle:
         report_frame = frame
         while switch_finalized():
             for _, private_key in driven_plain_members:
-                with signer_from(Account.from_key(private_key), None, None):
+                with signer_from(Account.from_key(private_key)):
                     module.cycle_handler()
             with signer_from(None, delegate_account_obj, fresh_delegation_contract):
                 module.cycle_handler()

--- a/tests/fork/test_lido_oracle_cycle.py
+++ b/tests/fork/test_lido_oracle_cycle.py
@@ -56,7 +56,7 @@ def missed_initial_frame(frame_config: FrameConfig):
     [start_before_initial_epoch, start_after_initial_epoch, missed_initial_frame],
     indirect=True,
 )
-def test_lido_module_report(module, set_oracle_members, running_finalized_slots, account_from):
+def test_lido_module_report(module, set_oracle_members, running_finalized_slots, account_from, signer_from):
     # Skip if consensus version is different
     current_consensus_version = module.report_contract.get_consensus_version('latest')
     if current_consensus_version != module.COMPATIBLE_CONSENSUS_VERSION:
@@ -73,7 +73,7 @@ def test_lido_module_report(module, set_oracle_members, running_finalized_slots,
     switch_finalized, _ = running_finalized_slots
     while switch_finalized():
         for _, private_key in members:
-            with account_from(private_key):
+            with account_from(private_key) as account, signer_from(account):
                 module.cycle_handler()
         report_frame = module.get_initial_or_current_frame(
             module._receive_last_finalized_slot()  # pylint: disable=protected-access

--- a/tests/fork/test_staking_module_oracle_cycle.py
+++ b/tests/fork/test_staking_module_oracle_cycle.py
@@ -167,6 +167,7 @@ def test_staking_module_module_report(
     running_finalized_slots,
     frame_index_as_processed,
     account_from,
+    signer_from,
 ):
     current_contract_version = module.report_contract.get_contract_version('latest')
     if current_contract_version != module.COMPATIBLE_CONTRACT_VERSION:
@@ -196,7 +197,7 @@ def test_staking_module_module_report(
         performance_collector.cycle_handler()
         for _, private_key in members:
             # NOTE: reporters using the same cache
-            with account_from(private_key):
+            with account_from(private_key) as account, signer_from(account):
                 module.cycle_handler()
         report_frame = module.get_initial_or_current_frame(
             module._receive_last_finalized_slot()  # pylint: disable=protected-access


### PR DESCRIPTION
## Description

The **Mainnet Fork Tests** workflow has been failing on every branch (28 failures, all identical):

```
AttributeError: 'Web3' object has no attribute 'signer'
  src/modules/oracles/common/consensus.py:429  ->  self.w3.signer.process_members(members)
```

`tests/fork/test_lido_oracle_cycle.py` and `tests/fork/test_staking_module_oracle_cycle.py` act as each committee member with

```python
with account_from(private_key):
    module.cycle_handler()
```

`account_from` patches `variables.ACCOUNT`, but nothing in the report path reads that variable any more — since `SignerModule` landed, the active member is resolved through `w3.signer`, built once at startup in `_build_web3_base` (`runtime.py:69-78`). The fork `web3` fixture never attached it, so the cycle died before submitting anything, and patching the account had no effect either way.

`tests/fork/test_delegation_report_cycle.py` already had a local `signer_from` helper doing the right thing, which is why it stayed green.

Changes:
- `account_from` yields the account it switched to.
- `signer_from` moves out of the delegation test into `tests/fork/conftest.py`, with defaults so a plain EOA member reads as `signer_from(account)`.
- Both cycle tests rebuild the signer per member: `with account_from(pk) as account, signer_from(account):`.
- The fork `web3` fixture gets a `telemetry_data_bus` stub. Its absence never failed a test (`_try_send_telemetry` swallows everything) but it logged a failed DataBus send with a full traceback on every cycle, which buries the real failure in the CI log.

Not attaching a default signer to the `web3` fixture on purpose: an empty `SignerModule` would turn "test forgot to drive the signer" into a silent dry-run whose assertions fail confusingly, instead of an immediate `AttributeError`.

## Related Issue/Task
- Unblocks CI on #1019 and every other open PR

## How Has This Been Tested?
- [x] Local tests (`pytest -m unit`; `pytest tests/fork --collect-only` and `--setup-plan` to check the fixture graph)
- [ ] Manual testing — a mainnet-fork run needs an archive EL, a beacon node with history and KAPI, so the real verification is this PR's **Mainnet Fork Tests** run

## Checklist
- [x] Documentation updated (if required) — n/a, test-only
- [x] New tests added (if applicable) — existing fork tests restored